### PR TITLE
Clear CMake flags from upstream scope

### DIFF
--- a/storage/vendor/sqlite/CMakeLists.txt
+++ b/storage/vendor/sqlite/CMakeLists.txt
@@ -1,5 +1,18 @@
 cmake_minimum_required(VERSION 2.8.0)
 
+# Clear polluted flags. For example, -Ofast would not work with sqlite
+unset(CMAKE_C_FLAGS)
+unset(CMAKE_C_FLAGS_RELEASE)
+unset(CMAKE_C_FLAGS_DEBUG)
+unset(CMAKE_CXX_FLAGS)
+unset(CMAKE_CXX_FLAGS_RELEASE)
+unset(CMAKE_CXX_FLAGS_DEBUG)
+
+
+set(CMAKE_C_FLAGS "-Wformat -Wformat-security -fstack-protector -fstack-protector-strong -O2")
+set(CMAKE_CXX_FLAGS "-Wformat -Wformat-security -fstack-protector -fstack-protector-strong -O2")
+set(CMAKE_EXE_LINKER_FLAGS "-pie")
+
 project(sqlite)
 
 add_library(sqlite STATIC sqlite3.c)


### PR DESCRIPTION
When integrating the storage server into lokid, I got errors due to the optimisation flag `-Ofast`, that is set by the lokid cmakelist, not being supported by SQLite.
This PR make it only use the default hardening flags.
(Note: the cmake scope does not bubble up after outside of add_subdirectory, so this won't affect anything upstream)