### PR TITLE
Wrong swarm response

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -203,7 +203,7 @@ void connection_t::process_request() {
                 process_client_req();
             } catch (std::exception& e) {
                 response_.result(http::status::internal_server_error);
-                BOOST_LOG_TRIVIAL(trace)
+                BOOST_LOG_TRIVIAL(error)
                     << "exception caught while processing client request: "
                     << e.what();
             }
@@ -323,8 +323,7 @@ bool connection_t::parse_header(T key_list) {
 
 void connection_t::process_store(const json& params) {
 
-    constexpr const char* fields[] = {"pubKey", "ttl", "nonce", "timestamp",
-                                      "data"};
+    constexpr const char* fields[] = {"pubKey", "ttl", "nonce", "timestamp", "data"};
 
     for (const auto& field : fields) {
         if (!params.contains(field)) {
@@ -347,6 +346,31 @@ void connection_t::process_store(const json& params) {
         response_.result(http::status::bad_request);
         bodyStream_ << "Pubkey must be 66 characters long";
         BOOST_LOG_TRIVIAL(error) << "Pubkey must be 66 characters long ";
+        return;
+    }
+
+    if (!service_node_.is_pubkey_for_us(pubKey)) {
+        std::vector<sn_record_t> nodes = service_node_.get_snodes_by_pk(pubKey);
+
+        json res_body;
+        json snodes = json::array();
+
+        for (const auto& sn : nodes) {
+#ifdef INTEGRATION_TEST
+            snodes.push_back(std::to_string(sn.port));
+#else
+            snodes.push_back(sn.address);
+#endif
+        }
+
+        res_body["snodes"] = snodes;
+
+        response_.result(http::status::misdirected_request);
+        response_.set(http::field::content_type, "application/json");
+
+        /// This might throw if not utf-8 endoded
+        bodyStream_ << res_body.dump();
+        BOOST_LOG_TRIVIAL(info) << "Client request for different swarm received";
         return;
     }
 
@@ -497,6 +521,31 @@ void connection_t::process_retrieve(const json& params) {
 
     const auto pubKey = params["pubKey"].get<std::string>();
     const auto last_hash = params["lastHash"].get<std::string>();
+
+    if (!service_node_.is_pubkey_for_us(pubKey)) {
+        std::vector<sn_record_t> nodes = service_node_.get_snodes_by_pk(pubKey);
+
+        json res_body;
+        json snodes = json::array();
+
+        for (const auto& sn : nodes) {
+#ifdef INTEGRATION_TEST
+            snodes.push_back(std::to_string(sn.port));
+#else
+            snodes.push_back(sn.address);
+#endif
+        }
+
+        res_body["snodes"] = snodes;
+
+        response_.result(http::status::misdirected_request);
+        response_.set(http::field::content_type, "application/json");
+
+        /// This might throw if not utf-8 endoded
+        bodyStream_ << res_body.dump();
+        BOOST_LOG_TRIVIAL(info) << "Client request for different swarm received";
+        return;
+    }
 
     std::vector<Item> items;
 

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -135,6 +135,8 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     /// TODO: should move somewhere else
     template <typename T>
     bool parse_header(T key_list);
+
+    bool check_correct_swarm(std::string pub_key);
 };
 
 void run(boost::asio::io_context& ioc, std::string& ip, uint16_t port,

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -136,7 +136,7 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     template <typename T>
     bool parse_header(T key_list);
 
-    bool check_correct_swarm(std::string pub_key);
+    void handle_wrong_swarm(const std::string& pubKey);
 };
 
 void run(boost::asio::io_context& ioc, std::string& ip, uint16_t port,

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -6,6 +6,7 @@
 #include <boost/log/core.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/trivial.hpp>
+#include <boost/log/utility/setup/file.hpp>
 #include <boost/program_options.hpp>
 
 #include <cstdlib>
@@ -68,6 +69,7 @@ int main(int argc, char* argv[]) {
 
         std::string lokinetIdentityPath;
         std::string dbLocation(".");
+        std::string logLocation;
         std::string logLevelString("info");
 
         const auto port = static_cast<uint16_t>(std::atoi(argv[2]));
@@ -76,11 +78,18 @@ int main(int argc, char* argv[]) {
         po::options_description desc;
         desc.add_options()("lokinet-identity", po::value(&lokinetIdentityPath),
                            "")("db-location", po::value(&dbLocation),
-                               "")("log-level", po::value(&logLevelString), "");
+                               "")("output-log", po::value(&logLocation), "")(
+            "log-level", po::value(&logLevelString), "");
 
         po::variables_map vm;
         po::store(po::parse_command_line(argc, argv, desc), vm);
         po::notify(vm);
+        if (vm.count("output-log")) {
+            auto sink = logging::add_file_log(logLocation + ".out");
+            sink->locked_backend()->auto_flush(true);
+            BOOST_LOG_TRIVIAL(info)
+                << "Outputting logs to " << logLocation << ".out";
+        }
 
         logging::trivial::severity_level logLevel;
         if (!parseLogLevel(logLevelString, logLevel)) {

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -466,7 +466,7 @@ void ServiceNode::process_push_all(std::shared_ptr<std::string> blob) {
     }
 }
 
-bool ServiceNode::is_pubkey_for_us(const std::string& pk) {
+bool ServiceNode::is_pubkey_for_us(const std::string& pk) const {
     const auto& all_swarms = swarm_->all_swarms();
     return swarm_->is_pubkey_for_us(all_swarms, pk);
 }

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -73,7 +73,7 @@ ServiceNode::ServiceNode(boost::asio::io_context& ioc, uint16_t port,
     : ioc_(ioc), db_(std::make_unique<Database>(dbLocation)), our_port_(port),
       update_timer_(ioc, std::chrono::milliseconds(100)) {
 
-#ifndef DISABLE_ENCRYPTION
+#ifndef INTEGRATION_TEST
     const std::vector<uint8_t> publicKey =
         parseLokinetIdentityPublic(identityPath);
     char buf[64] = {0};
@@ -464,6 +464,11 @@ void ServiceNode::process_push_all(std::shared_ptr<std::string> blob) {
         // TODO: Actually use the message values here
         save_if_new(std::make_shared<message_t>(msg));
     }
+}
+
+bool ServiceNode::is_pubkey_for_us(const std::string& pk) {
+    const auto& all_swarms = swarm_->all_swarms();
+    return swarm_->is_pubkey_for_us(all_swarms, pk);
 }
 
 std::vector<sn_record_t> ServiceNode::get_snodes_by_pk(const std::string& pk) {

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -105,6 +105,8 @@ class ServiceNode {
     /// Process incoming blob of messages: add to DB if new
     void process_push_all(std::shared_ptr<std::string> blob);
 
+    bool is_pubkey_for_us(const std::string& pk);
+
     std::vector<sn_record_t> get_snodes_by_pk(const std::string& pk);
 
     /// remove all data that doesn't belong to this swarm

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -105,7 +105,7 @@ class ServiceNode {
     /// Process incoming blob of messages: add to DB if new
     void process_push_all(std::shared_ptr<std::string> blob);
 
-    bool is_pubkey_for_us(const std::string& pk);
+    bool is_pubkey_for_us(const std::string& pk) const;
 
     std::vector<sn_record_t> get_snodes_by_pk(const std::string& pk);
 

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -146,7 +146,7 @@ static uint64_t hex_to_u64(const std::string& pk) {
 }
 
 bool Swarm::is_pubkey_for_us(const std::vector<SwarmInfo>& all_swarms,
-                             const std::string& pk) {
+                             const std::string& pk) const {
     return cur_swarm_id_ == get_swarm_by_pk(all_swarms, pk);
 }
 

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -145,6 +145,11 @@ static uint64_t hex_to_u64(const std::string& pk) {
     return res;
 }
 
+bool Swarm::is_pubkey_for_us(const std::vector<SwarmInfo>& all_swarms,
+                             const std::string& pk) {
+    return cur_swarm_id_ == get_swarm_by_pk(all_swarms, pk);
+}
+
 swarm_id_t get_swarm_by_pk(const std::vector<SwarmInfo>& all_swarms,
                            const std::string& pk) {
 

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -53,7 +53,7 @@ class Swarm {
     SwarmEvents update_swarms(const all_swarms_t& swarms);
 
     bool is_pubkey_for_us(const std::vector<SwarmInfo>& all_swarms,
-                          const std::string& pk);
+                          const std::string& pk) const;
 
     std::vector<sn_record_t> other_nodes() const;
 

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -52,6 +52,9 @@ class Swarm {
     /// Update swarms and work out the changes
     SwarmEvents update_swarms(const all_swarms_t& swarms);
 
+    bool is_pubkey_for_us(const std::vector<SwarmInfo>& all_swarms,
+                          const std::string& pk);
+
     std::vector<sn_record_t> other_nodes() const;
 
     const std::vector<SwarmInfo>& all_swarms() const { return all_cur_swarms_; }


### PR DESCRIPTION
Added 421 response for client requests to wrong swarm along with the correct swarm information
Added command line arg to output boost logs to file for easier log management with the messenger testnet (this may be made redundant by the launcher)
Fixed an ifdef mistake I put in before