### PR TITLE
Fix std::string::reserve using the size instead of capacity

### DIFF
--- a/httpserver/serialization.cpp
+++ b/httpserver/serialization.cpp
@@ -77,7 +77,7 @@ static void serialize_uint64(std::string& buf, uint64_t a) {
 
 static void serialize(std::string& buf, const std::string& str) {
 
-    buf.reserve(buf.size() + str.size() + 4);
+    buf.reserve(buf.capacity() + str.size() + sizeof(uint32_t));
     serialize_uint32(buf, str.size());
     buf += str;
 }


### PR DESCRIPTION
std::string::reserve
> Requests that the string capacity be adapted to a planned change in size to a length of up to n characters.
If n is greater than the current string capacity, the function causes the container to increase its capacity to n characters (or greater).

Also change a literal `4` to `sizeof(uint32_t)` for more context.