### PR TITLE
Use STL instead of loops for snode/swarm find operations

### DIFF
--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -41,11 +41,11 @@ class Swarm {
 
     swarm_id_t cur_swarm_id_ = UINT64_MAX;
     std::vector<SwarmInfo> all_cur_swarms_;
-    sn_record_t our_address;
+    sn_record_t our_address_;
     std::vector<sn_record_t> swarm_peers_;
 
   public:
-    Swarm(sn_record_t address) : our_address(address) {}
+    Swarm(sn_record_t address) : our_address_(address) {}
 
     ~Swarm();
 


### PR DESCRIPTION
Started with a very small fix PR about adding an early `break` in a loop that was finding an index.
Ended up changing a bunch of loops to use STL.
Also some best practice nits.

Note: could not run any tests or executable to check if this PR introduces undesired behaviour.