### PR TITLE
Exclude own snode from swarm peers

### DIFF
--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -127,12 +127,12 @@ void ServiceNode::push_message(const message_ptr msg) {
     if (!swarm_)
         return;
 
-    auto others = swarm_->other_nodes();
+    const auto& others = swarm_->other_nodes();
 
     BOOST_LOG_TRIVIAL(debug)
         << "push_message to " << others.size() << " other nodes";
 
-    for (auto& address : others) {
+    for (const auto& address : others) {
         /// send a request asynchronously (todo: collect confirmations)
         relay_one(msg, address);
     }

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -200,6 +200,8 @@ swarm_id_t get_swarm_by_pk(const std::vector<SwarmInfo>& all_swarms,
     return cur_best;
 }
 
-std::vector<sn_record_t> Swarm::other_nodes() const { return swarm_peers_; }
+const std::vector<sn_record_t>& Swarm::other_nodes() const {
+    return swarm_peers_;
+}
 
 } // namespace loki

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -106,7 +106,12 @@ SwarmEvents Swarm::update_swarms(const all_swarms_t& swarms) {
 
     cur_swarm_id_ = our_swarm_id;
     all_cur_swarms_ = swarms;
-    swarm_peers_ = our_swarm_snodes;
+
+    swarm_peers_.clear();
+    std::copy_if(
+        our_swarm_snodes.begin(), our_swarm_snodes.end(),
+        std::back_inserter(swarm_peers_),
+        [this](const sn_record_t& record) { return record != our_address_; });
 
     return events;
 }
@@ -195,15 +200,6 @@ swarm_id_t get_swarm_by_pk(const std::vector<SwarmInfo>& all_swarms,
     return cur_best;
 }
 
-std::vector<sn_record_t> Swarm::other_nodes() const {
-
-    std::vector<sn_record_t> result;
-
-    std::copy_if(
-        swarm_peers_.begin(), swarm_peers_.end(), std::back_inserter(result),
-        [this](const sn_record_t& record) { return record != our_address_; });
-
-    return result;
-}
+std::vector<sn_record_t> Swarm::other_nodes() const { return swarm_peers_; }
 
 } // namespace loki

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -55,7 +55,7 @@ class Swarm {
     bool is_pubkey_for_us(const std::vector<SwarmInfo>& all_swarms,
                           const std::string& pk) const;
 
-    std::vector<sn_record_t> other_nodes() const;
+    const std::vector<sn_record_t>& other_nodes() const;
 
     const std::vector<SwarmInfo>& all_swarms() const { return all_cur_swarms_; }
 


### PR DESCRIPTION
This way the numerous calls to `other_nodes()` are not doing anything except return the cached values :)