### PR TITLE
basic error recording in snode communication

### DIFF
--- a/httpserver/common.h
+++ b/httpserver/common.h
@@ -5,6 +5,22 @@ struct sn_record_t {
     std::string address; // Snode address
 };
 
+namespace std {
+
+    template<>
+    struct hash<sn_record_t>
+    {
+        std::size_t operator()(const sn_record_t& k) const {
+#ifdef INTEGRATION_TEST
+            return hash<uint16_t>{}(k.port);
+#else
+            return hash<std::string>{}(k.address);
+#endif
+        }
+    };
+
+}
+
 static std::ostream& operator<<(std::ostream& os, const sn_record_t& sn) {
 #ifdef INTEGRATION_TEST
     return os << sn.port;

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -68,6 +68,7 @@ void make_http_request(boost::asio::io_context& ioc, std::string sn_address,
                            "Could not connect to %1%:%2%, message: %3% (%4%)") %
                            sn_address % port % ec.message() % ec.value();
                 /// TODO: handle error better here
+                cb({SNodeError::NO_REACH, nullptr});
                 return;
             }
 
@@ -822,7 +823,9 @@ void HttpClientSession::init_callback(std::shared_ptr<std::string>&& body) {
 HttpClientSession::~HttpClientSession() {
 
     if (!used_callback_) {
-        sn_response_t res = {SNodeError::NO_ERROR, nullptr};
+        // If we destroy the session before posting the callback,
+        // it must be due to some error
+        sn_response_t res = {SNodeError::ERROR_OTHER, nullptr};
         ioc_.post(std::bind(callback_, std::move(res)));
     }
 }

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -39,11 +39,11 @@ struct sn_response_t {
 using http_callback_t = std::function<void(sn_response_t)>;
 
 void make_http_request(boost::asio::io_context& ioc, std::string ip,
-                       uint16_t port, const request_t& req, http_callback_t cb);
+                       uint16_t port, const request_t& req, http_callback_t&& cb);
 
 void make_http_request(boost::asio::io_context& ioc, std::string ip,
                        uint16_t port, std::string target, std::string body,
-                       http_callback_t cb);
+                       http_callback_t&& cb);
 
 void request_swarm_update(boost::asio::io_context& ioc, const swarm_callback_t&& cb);
 

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -21,10 +21,21 @@ namespace http = boost::beast::http; // from <boost/beast/http.hpp>
 using request_t = http::request<http::string_body>;
 using response_t = http::response<http::string_body>;
 
-using http_callback_t = std::function<void(std::shared_ptr<std::string>)>;
 
 namespace loki {
 using swarm_callback_t = std::function<void(const all_swarms_t&)>;
+
+enum class SNodeError {
+  NO_ERROR,
+  NO_REACH
+};
+
+struct sn_response_t {
+  SNodeError error_code;
+  std::shared_ptr<std::string> body;
+};
+
+using http_callback_t = std::function<void(sn_response_t)>;
 
 void make_http_request(boost::asio::io_context& ioc, std::string ip,
                        uint16_t port, const request_t& req, http_callback_t cb);
@@ -53,7 +64,7 @@ class HttpClientSession
 
     void on_read(boost::system::error_code ec, std::size_t bytes_transferred);
 
-    void init_callback(std::shared_ptr<std::string> body);
+    void init_callback(std::shared_ptr<std::string>&& body);
 
   public:
     tcp::socket socket_;

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -27,6 +27,7 @@ using swarm_callback_t = std::function<void(const all_swarms_t&)>;
 
 enum class SNodeError {
   NO_ERROR,
+  ERROR_OTHER,
   NO_REACH
 };
 

--- a/httpserver/serialization.cpp
+++ b/httpserver/serialization.cpp
@@ -137,7 +137,6 @@ std::vector<message_t> deserialize_messages(const std::string& blob) {
 
     std::vector<message_t> result;
 
-    /// TODO: better incapsulate serialization/deserialization!
     string_view slice{blob};
 
     bool success = false;
@@ -191,7 +190,6 @@ std::vector<message_t> deserialize_messages(const std::string& blob) {
         BOOST_LOG_TRIVIAL(trace)
             << boost::format("pk: %1%, msg: %2%") % *pk % *data;
 
-        // TODO: Actually use the message values here
         result.push_back({*pk, *data, *hash, *ttl, *timestamp, *nonce});
     }
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -95,7 +95,7 @@ void ServiceNode::relay_one(const message_ptr msg, sn_record_t sn) const {
 
     req.target("/v1/swarms/push");
 
-    make_http_request(ioc_, sn.address, sn.port, req, [this, sn](sn_response_t res) {
+    make_http_request(ioc_, sn.address, sn.port, req, [this, sn](sn_response_t&& res) {
         if (res.error_code != SNodeError::NO_ERROR) {
             BOOST_LOG_TRIVIAL(error) << "Could not relay one to: " << sn;
             snode_report_[sn].relay_fails += 1;
@@ -111,7 +111,7 @@ void ServiceNode::relay_batch(const std::string& data, sn_record_t sn) const {
     req.body() = data;
     req.target("/v1/swarms/push_all");
 
-    make_http_request(ioc_, sn.address, sn.port, req, [this, sn](sn_response_t res) {
+    make_http_request(ioc_, sn.address, sn.port, req, [this, sn](sn_response_t&& res) {
         if (res.error_code != SNodeError::NO_ERROR) {
             BOOST_LOG_TRIVIAL(error) << "Could not relay batch to: " << sn;
             snode_report_[sn].relay_fails += 1;

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -89,8 +89,6 @@ ServiceNode::~ServiceNode() = default;
 /// make this async
 void ServiceNode::relay_one(const message_ptr msg, sn_record_t sn) const {
 
-    /// TODO: need to encrypt messages?
-
     BOOST_LOG_TRIVIAL(debug) << "Relaying a message to " << sn;
 
     request_t req;
@@ -98,9 +96,9 @@ void ServiceNode::relay_one(const message_ptr msg, sn_record_t sn) const {
 
     req.target("/v1/swarms/push");
 
-    /// TODO: how to handle a failure here?
+    // TODO: record in case of a failure
     make_http_request(ioc_, sn.address, sn.port, req,
-                      [](std::shared_ptr<std::string>) {
+                      [](sn_response_t res) {
 
                       });
 }
@@ -113,8 +111,9 @@ void ServiceNode::relay_batch(const std::string& data, sn_record_t sn) const {
     req.body() = data;
     req.target("/v1/swarms/push_all");
 
+    // TODO: record in case of a failure
     make_http_request(ioc_, sn.address, sn.port, req,
-                      [](std::shared_ptr<std::string>) {
+                      [](sn_response_t res) {
 
                       });
 }
@@ -131,7 +130,7 @@ void ServiceNode::push_message(const message_ptr msg) {
         << "push_message to " << others.size() << " other nodes";
 
     for (const auto& address : others) {
-        /// send a request asynchronously (todo: collect confirmations)
+        /// send a request asynchronously
         relay_one(msg, address);
     }
 }

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -86,7 +86,6 @@ ServiceNode::ServiceNode(boost::asio::io_context& ioc, uint16_t port,
 
 ServiceNode::~ServiceNode() = default;
 
-/// make this async
 void ServiceNode::relay_one(const message_ptr msg, sn_record_t sn) const {
 
     BOOST_LOG_TRIVIAL(debug) << "Relaying a message to " << sn;
@@ -96,11 +95,12 @@ void ServiceNode::relay_one(const message_ptr msg, sn_record_t sn) const {
 
     req.target("/v1/swarms/push");
 
-    // TODO: record in case of a failure
-    make_http_request(ioc_, sn.address, sn.port, req,
-                      [](sn_response_t res) {
-
-                      });
+    make_http_request(ioc_, sn.address, sn.port, req, [this, sn](sn_response_t res) {
+        if (res.error_code != SNodeError::NO_ERROR) {
+            BOOST_LOG_TRIVIAL(error) << "Could not relay one to: " << sn;
+            snode_report_[sn].relay_fails += 1;
+        }
+    });
 }
 
 void ServiceNode::relay_batch(const std::string& data, sn_record_t sn) const {
@@ -111,11 +111,12 @@ void ServiceNode::relay_batch(const std::string& data, sn_record_t sn) const {
     req.body() = data;
     req.target("/v1/swarms/push_all");
 
-    // TODO: record in case of a failure
-    make_http_request(ioc_, sn.address, sn.port, req,
-                      [](sn_response_t res) {
-
-                      });
+    make_http_request(ioc_, sn.address, sn.port, req, [this, sn](sn_response_t res) {
+        if (res.error_code != SNodeError::NO_ERROR) {
+            BOOST_LOG_TRIVIAL(error) << "Could not relay batch to: " << sn;
+            snode_report_[sn].relay_fails += 1;
+        }
+    });
 }
 
 /// initiate a /swarms/push request
@@ -191,7 +192,8 @@ void ServiceNode::on_swarm_update(all_swarms_t all_swarms) {
 }
 
 void ServiceNode::swarm_timer_tick() {
-    const swarm_callback_t cb = std::bind(&ServiceNode::on_swarm_update, this, std::placeholders::_1);
+    const swarm_callback_t cb =
+        std::bind(&ServiceNode::on_swarm_update, this, std::placeholders::_1);
     request_swarm_update(ioc_, std::move(cb));
     update_timer_.expires_after(std::chrono::seconds(2));
     update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <unordered_map>
 
 #include <boost/asio.hpp>
 #include <boost/optional.hpp>
@@ -45,6 +46,13 @@ using message_ptr = std::shared_ptr<message_t>;
 
 class Swarm;
 
+struct snode_stats_t {
+
+  // how many times a single push failed
+  uint64_t relay_fails = 0;
+
+};
+
 /// All service node logic that is not network-specific
 class ServiceNode {
 
@@ -52,6 +60,8 @@ class ServiceNode {
 
     std::unique_ptr<Swarm> swarm_;
     std::unique_ptr<Database> db_;
+    // performance report for other snodes
+    mutable std::unordered_map<sn_record_t, snode_stats_t> snode_report_;
 
     sn_record_t our_address_;
 


### PR DESCRIPTION
Adds basic infrastructure for recording snode errors (starting with snode being unreachable). The recording information is unused at the moment.