### PR TITLE
Use boost::endian to ensure serialised data is little endian

### DIFF
--- a/httpserver/serialization.h
+++ b/httpserver/serialization.h
@@ -13,10 +13,10 @@ namespace loki {
 
 class message_t;
 
-template<typename T>
+template <typename T>
 void serialize_message(std::string& buf, const T& msg);
 
-template<typename T>
+template <typename T>
 std::vector<std::string> serialize_messages(const std::vector<T>& msgs);
 
 std::vector<message_t> deserialize_messages(const std::string& blob);


### PR DESCRIPTION
+ clang-format