### PR TITLE
Simplify build flow with a top-level makefile and cmakelist

### DIFF
--- a/CmakeLists.txt
+++ b/CmakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.1)
+
+function(LOKI_ADD_SUBDIRECTORY SRC)
+    get_filename_component(target ${SRC} NAME)
+    if (TARGET ${target})
+        return()
+    endif ()
+    add_subdirectory(${SRC} ${ARGN})
+endfunction()
+
+project(storage_server)
+
+loki_add_subdirectory(utils)
+loki_add_subdirectory(crypto)
+loki_add_subdirectory(pow)
+loki_add_subdirectory(storage)
+loki_add_subdirectory(httpserver)
+
+if (BUILD_TESTS)
+    loki_add_subdirectory(unit_test)
+endif ()

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+
+subbuilddir:=$(shell echo  `uname | sed -e 's|[:/\\ \(\)]|_|g'`/`git branch | grep '\* ' | cut -f2- -d' '| sed -e 's|[:/\\ \(\)]|_|g'`)
+ifeq ($(USE_SINGLE_BUILDDIR),)
+  builddir := build/"$(subbuilddir)"
+  topdir   := ../../../..
+else
+  builddir := build
+  topdir   := ../..
+endif
+
+all: release-httpserver
+
+clean:
+	rm -rf build
+
+release-all:
+	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake $(topdir) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON && cmake --build .
+
+release-httpserver:
+	mkdir -p $(builddir)/release && cd $(builddir)/release && cmake $(topdir) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=OFF && cmake --build .
+
+.PHONY: all clean release-all release-httpserver

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ Requirements:
 * sodium (for ed25119 to curve25519 conversion)
 
 ```
-mkdir build
-cd build
-cmake ../httpserver -DBOOST_ROOT="path to boost" -DOPENSSL_ROOT_DIR="path to openssl"
-cmake --build .
+make
 ./httpserver 127.0.0.1 8080
 ```
-(The paths for Boost and OpenSSL need only to be provided if not installed on the system)
+
+The paths for Boost and OpenSSL can be specified by exporting the variables in the terminal before running `make`:
+```
+export OPENSSL_ROOT_DIR = ...
+export BOOST_ROOT= ...
+```
 
 Then using something like Postman (https://www.getpostman.com/) you can hit the API:
 

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -10,10 +10,10 @@ set(SRC_FILES main.cpp http_connection.cpp swarm.cpp service_node.cpp serializat
 
 add_executable(httpserver ${HEADER_FILES} ${SRC_FILES})
 
-add_subdirectory(../storage storage)
-add_subdirectory(../utils utils)
-add_subdirectory(../pow pow)
-add_subdirectory(../crypto crypto)
+loki_add_subdirectory(../storage storage)
+loki_add_subdirectory(../utils utils)
+loki_add_subdirectory(../pow pow)
+loki_add_subdirectory(../crypto crypto)
 find_package(OpenSSL REQUIRED)
 
 find_package(Boost
@@ -25,7 +25,7 @@ find_package(Boost
 )
 
 target_link_libraries(httpserver PRIVATE OpenSSL::SSL)
-target_link_libraries(httpserver PRIVATE sn_storage)
+target_link_libraries(httpserver PRIVATE storage)
 target_link_libraries(httpserver PRIVATE utils)
 target_link_libraries(httpserver PRIVATE pow)
 target_link_libraries(httpserver PRIVATE crypto)

--- a/pow/CMakeLists.txt
+++ b/pow/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SOURCES
 
 add_library(pow STATIC ${SOURCES})
 
-add_subdirectory(../utils utils)
+loki_add_subdirectory(../utils utils)
 
 set_property(TARGET pow PROPERTY CXX_STANDARD 11)
 

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(sn_storage)
-
 set(SOURCES
     include/Database.hpp
     include/Item.hpp
@@ -9,11 +7,11 @@ set(SOURCES
     src/Timer.hpp
 )
 
-add_library(sn_storage STATIC ${SOURCES})
+add_library(storage STATIC ${SOURCES})
 
-set_property(TARGET sn_storage PROPERTY CXX_STANDARD 11)
+set_property(TARGET storage PROPERTY CXX_STANDARD 11)
 
-target_include_directories(sn_storage
+target_include_directories(storage
     PUBLIC
     ${CMAKE_CURRENT_LIST_DIR}/include
     PRIVATE
@@ -21,7 +19,7 @@ target_include_directories(sn_storage
 )
 
 add_subdirectory(vendor/sqlite)
-target_link_libraries(sn_storage PRIVATE sqlite)
+target_link_libraries(storage PRIVATE sqlite)
 
 if(NOT Boost_FOUND)
     find_package(Boost
@@ -31,5 +29,5 @@ if(NOT Boost_FOUND)
     )
 endif()
 
-target_include_directories(sn_storage PRIVATE ${Boost_INCLUDE_DIRS})
-target_link_libraries(sn_storage PRIVATE ${Boost_LIBRARIES})
+target_include_directories(storage PRIVATE ${Boost_INCLUDE_DIRS})
+target_link_libraries(storage PRIVATE ${Boost_LIBRARIES})

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -5,9 +5,10 @@ add_executable (Test main.cpp storage.cpp pow.cpp)
 set_property(TARGET Test PROPERTY CXX_STANDARD 11)
 
 # library under test
-add_subdirectory(../storage storage)
-add_subdirectory(../pow pow)
-target_link_libraries(Test PRIVATE sn_storage pow)
+
+loki_add_subdirectory(../storage storage)
+loki_add_subdirectory(../pow pow)
+target_link_libraries(Test PRIVATE storage pow)
 
 # boost
 find_package(Boost


### PR DESCRIPTION
This allows running `make` from the repo root.
Also, the subdirectory are now "shared", e.g. the unit tests will link against the same libraries as the httpserver, instead of rebuilding them in a new subdirectory.

This PR will eventually simplify CD/CI commands.