### PR TITLE
Remove BOOST_LOG_DYN_LINK flag

### DIFF
--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 2.8.0)
 
-add_definitions(-DBOOST_LOG_DYN_LINK)
 add_definitions(-DDISABLE_ENCRYPTION)
 
 project(httpserver)


### PR DESCRIPTION
for people still needing it, I think they can use this form:
`BOOST_LOG_DYN_LINK=ON make`