### PR TITLE
Bulk store using sqlite transactions

### DIFF
--- a/storage/include/Database.hpp
+++ b/storage/include/Database.hpp
@@ -17,7 +17,7 @@ class Database {
     Database(const std::string& db_path);
     ~Database();
 
-    enum OnDuplicateInsertion {
+    enum class DuplicateHandling {
       IGNORE,
       FAIL
     };
@@ -25,7 +25,7 @@ class Database {
     /// this is low-level logic (separate?)
     bool store(const std::string& hash, const std::string& pubKey,
                const std::string& bytes, uint64_t ttl, uint64_t timestamp,
-               const std::string& nonce, OnDuplicateInsertion behaviour = FAIL);
+               const std::string& nonce, DuplicateHandling behaviour = DuplicateHandling::FAIL);
 
     bool bulk_store(const std::vector<service_node::storage::Item>& items);
 

--- a/storage/include/Database.hpp
+++ b/storage/include/Database.hpp
@@ -17,10 +17,17 @@ class Database {
     Database(const std::string& db_path);
     ~Database();
 
+    enum OnDuplicateInsertion {
+      IGNORE,
+      FAIL
+    };
+
     /// this is low-level logic (separate?)
     bool store(const std::string& hash, const std::string& pubKey,
                const std::string& bytes, uint64_t ttl, uint64_t timestamp,
-               const std::string& nonce);
+               const std::string& nonce, OnDuplicateInsertion behaviour = FAIL);
+
+    bool bulk_store(const std::vector<service_node::storage::Item>& items);
 
     bool retrieve(const std::string& key,
                   std::vector<service_node::storage::Item>& items,
@@ -34,6 +41,7 @@ class Database {
   private:
     sqlite3* db;
     sqlite3_stmt* save_stmt;
+    sqlite3_stmt* save_or_ignore_stmt;
     sqlite3_stmt* get_all_for_pk_stmt;
     sqlite3_stmt* get_all_stmt;
     sqlite3_stmt* get_stmt;

--- a/storage/src/Database.cpp
+++ b/storage/src/Database.cpp
@@ -181,12 +181,12 @@ bool Database::bulk_store(const std::vector<service_node::storage::Item>& items)
         return false;
     }
 
-    for (const auto& item : items) {
-        try {
+    try {
+        for (const auto& item : items) {
             store(item.hash, item.pub_key, item.data, item.ttl, item.timestamp, item.nonce, DuplicateHandling::IGNORE);
-        } catch(...) {
-            fprintf(stderr, "Can't store item with hash %s during bulk", item.hash.substr(7).c_str());
         }
+    } catch(...) {
+        fprintf(stderr, "Failed to store items during bulk operation");
     }
 
     if (sqlite3_exec(db, "END TRANSACTION;", NULL, NULL, &errmsg) != SQLITE_OK)

--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -76,8 +76,25 @@ BOOST_AUTO_TEST_CASE(it_returns_false_when_storing_existing_hash) {
     Database storage(".");
 
     BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce));
+    // store using the same hash, FAIL is default behaviour
+    BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce, Database::FAIL) == false);
+}
+
+BOOST_AUTO_TEST_CASE(it_returns_true_when_storing_existing_with_ignore_constraint) {
+    StorageRAIIFixture fixture;
+
+    const auto hash = "myhash";
+    const auto pubkey = "mypubkey";
+    const auto bytes = "bytesasstring";
+    const auto nonce = "nonce";
+    const uint64_t ttl = 123456;
+    const uint64_t timestamp = util::get_time_ms();
+
+    Database storage(".");
+
+    BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce));
     // store using the same hash
-    BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce) == false);
+    BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce, Database::IGNORE) == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_only_returns_entries_for_specified_pubkey) {
@@ -165,4 +182,133 @@ BOOST_AUTO_TEST_CASE(it_removes_expired_entries) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(it_stores_data_in_bulk) {
+    StorageRAIIFixture fixture;
+
+    const auto pubkey = "mypubkey";
+    const auto bytes = "bytesasstring";
+    const auto nonce = "nonce";
+    const uint64_t ttl = 123456;
+    const uint64_t timestamp = util::get_time_ms();
+
+    const size_t num_items = 10000;
+
+    Database storage(".");
+
+    // bulk store
+    {
+        std::vector<service_node::storage::Item> items;
+        for (int i = 0; i < num_items; ++i) {
+            items.push_back({
+                std::to_string(i),
+                pubkey,
+                timestamp,
+                ttl,
+                timestamp + ttl,
+                nonce,
+                bytes
+            });
+        }
+
+        BOOST_CHECK(storage.bulk_store(items));
+    }
+
+    // retrieve
+    {
+        std::vector<service_node::storage::Item> items;
+
+        BOOST_CHECK(storage.retrieve(pubkey, items, ""));
+        BOOST_CHECK_EQUAL(items.size(), num_items);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(it_stores_data_in_bulk_even_when_overlaps) {
+    StorageRAIIFixture fixture;
+
+    const auto pubkey = "mypubkey";
+    const auto bytes = "bytesasstring";
+    const auto nonce = "nonce";
+    const uint64_t ttl = 123456;
+    const uint64_t timestamp = util::get_time_ms();
+
+    const size_t num_items = 10000;
+
+    Database storage(".");
+
+    // insert existing
+    BOOST_CHECK(storage.store("0", pubkey, bytes, ttl, timestamp, nonce));
+
+    // bulk store
+    {
+        std::vector<service_node::storage::Item> items;
+        for (int i = 0; i < num_items; ++i) {
+            items.push_back({
+                std::to_string(i),
+                pubkey,
+                timestamp,
+                ttl,
+                timestamp + ttl,
+                nonce,
+                bytes
+            });
+        }
+
+        BOOST_CHECK(storage.bulk_store(items));
+    }
+
+    // retrieve
+    {
+        std::vector<service_node::storage::Item> items;
+
+        BOOST_CHECK(storage.retrieve(pubkey, items, ""));
+        BOOST_CHECK_EQUAL(items.size(), num_items);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(bulk_performance_check) {
+    StorageRAIIFixture fixture;
+
+    const auto pubkey = "mypubkey";
+    const auto bytes = "bytesasstring";
+    const auto nonce = "nonce";
+    const uint64_t ttl = 123456;
+    const uint64_t timestamp = util::get_time_ms();
+
+    const size_t num_items = 10000;
+
+    std::vector<service_node::storage::Item> items;
+    for (int i = 0; i < num_items; ++i) {
+        items.push_back({
+            std::to_string(i),
+            pubkey,
+            timestamp,
+            ttl,
+            timestamp + ttl,
+            nonce,
+            bytes
+        });
+    }
+
+    // bulk store
+    {
+        Database storage(".");
+        const auto start = std::chrono::steady_clock::now();
+        storage.bulk_store(items);
+        const auto end = std::chrono::steady_clock::now();
+        const auto diff = end - start;
+        std::cout << "bulk: " << std::chrono::duration<double, std::milli>(diff).count() << " ms" << std::endl;
+    }
+
+    // single stores
+    {
+        Database storage(".");
+        const auto start = std::chrono::steady_clock::now();
+        for (const auto& item : items) {
+            storage.store(item.hash, item.pub_key, item.data, item.ttl, item.timestamp, item.nonce);
+        }
+        const auto end = std::chrono::steady_clock::now();
+        const auto diff = end - start;
+        std::cout << "singles:" << std::chrono::duration<double, std::milli>(diff).count() << " ms" << std::endl;
+    }
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(it_returns_false_when_storing_existing_hash) {
 
     BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce));
     // store using the same hash, FAIL is default behaviour
-    BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce, Database::FAIL) == false);
+    BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce, Database::DuplicateHandling::FAIL) == false);
 }
 
 BOOST_AUTO_TEST_CASE(it_returns_true_when_storing_existing_with_ignore_constraint) {
@@ -94,7 +94,7 @@ BOOST_AUTO_TEST_CASE(it_returns_true_when_storing_existing_with_ignore_constrain
 
     BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce));
     // store using the same hash
-    BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce, Database::IGNORE) == true);
+    BOOST_CHECK(storage.store(hash, pubkey, bytes, ttl, timestamp, nonce, Database::DuplicateHandling::IGNORE) == true);
 }
 
 BOOST_AUTO_TEST_CASE(it_only_returns_entries_for_specified_pubkey) {


### PR DESCRIPTION
Added a new `bulk_store` entrypoint to the storage api.
Also added a new argument in the `store` function, to use the `INSERT OR IGNORE` sql statement when set to true. This will ensure the bulk transaction doesn't fail when the UNIQUE constraint is violated by inserting entries already present.