### PR TITLE
Millisecond ttl

### DIFF
--- a/pow/src/pow.cpp
+++ b/pow/src/pow.cpp
@@ -51,6 +51,8 @@ bool checkPoW(const std::string& nonce, const std::string& timestamp,
     uint64_t ttlInt;
     if (!util::parseTTL(ttl, ttlInt))
         return false;
+    // ttl is in milliseconds, but target calculation wants seconds
+    ttlInt = ttlInt / 1000;
     uint64_t totalLen = payload.size() + BYTE_LEN;
     overflow = multWillOverflow(ttlInt, totalLen);
     if (overflow)

--- a/storage/src/Database.cpp
+++ b/storage/src/Database.cpp
@@ -129,7 +129,7 @@ bool Database::store(const std::string& hash, const std::string& pubKey,
                      const std::string& bytes, uint64_t ttl, uint64_t timestamp,
                      const std::string& nonce) {
 
-    const auto exp_time = timestamp + (ttl * 1000);
+    const auto exp_time = timestamp + ttl;
 
     sqlite3_bind_text(save_stmt, 1, hash.c_str(), -1, SQLITE_STATIC);
     sqlite3_bind_text(save_stmt, 2, pubKey.c_str(), -1, SQLITE_STATIC);

--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -57,8 +57,7 @@ BOOST_AUTO_TEST_CASE(it_stores_data_persistently) {
         BOOST_CHECK_EQUAL(items.size(), 1);
         BOOST_CHECK_EQUAL(items[0].pub_key, pubkey);
         BOOST_CHECK_EQUAL(items[0].hash, hash);
-        BOOST_CHECK_EQUAL((items[0].expiration_timestamp - items[0].timestamp),
-                          (ttl * 1000));
+        BOOST_CHECK_EQUAL((items[0].expiration_timestamp - items[0].timestamp), ttl);
         BOOST_CHECK_EQUAL(items[0].data, bytes);
     }
 }

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -63,7 +63,7 @@ bool parseTimestamp(const std::string& timestampString, const uint64_t ttl,
         return false;
 
     // Don't need to worry about overflow for several hundred million years
-    const uint64_t exp_time = timestamp + (ttl * 1000);
+    const uint64_t exp_time = timestamp + ttl;
 
     // Don't accept timestamp that has already expired
     if (exp_time < cur_time)
@@ -80,8 +80,8 @@ bool parseTTL(const std::string& ttlString, uint64_t& ttl) {
         return false;
     }
 
-    // Maximum time to live of 4 days
-    if (ttlInt < 0 || ttlInt > 96 * 60 * 60)
+    // Minimum time to live of 10 seconds, maximum of 4 days
+    if (ttlInt < 10 * 1000 || ttlInt > 96 * 60 * 60 * 1000)
         return false;
 
     ttl = static_cast<uint64_t>(ttlInt);


### PR DESCRIPTION
Update calculations to expect ttl to be in milliseconds instead of seconds, require non-zero ttl because might make PoW target nonsense