### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifeq ($(USE_SINGLE_BUILD_DIR),)
   TOP_DIR   := ../../../..
 else
   BUILD_DIR := build
-  TOP_DIR   := ../..
+  TOP_DIR   := ../
 endif
 
 ifeq ($(GEN),)


### PR DESCRIPTION
Topdir was one too high
`CMake Error: The source directory "/home/beaudan/workspace" does not appear to contain CMakeLists.txt.`