### PR TITLE
Revert "Use std:: instead of boost:: for chrono and thread"

### DIFF
--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -3,12 +3,13 @@
 
 #include <iostream>
 #include <string>
-#include <chrono>
-#include <thread>
 
+/// This file fails to link on linux when trying to use std:: for threading and
+/// chrono
+#include <boost/chrono.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
-
+#include <boost/thread/thread.hpp>
 
 struct StorageRAIIFixture {
     StorageRAIIFixture() {
@@ -179,7 +180,7 @@ BOOST_AUTO_TEST_CASE(it_removes_expired_entries) {
     // the timer kicks in every 10 seconds
     // give 100ms to perform the cleanup
     std::cout << "waiting for cleanup timer..." << std::endl;
-    std::this_thread::sleep_for(std::chrono::milliseconds(10000 + 100));
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(10000 + 100));
 
     {
         std::vector<service_node::storage::Item> items;
@@ -279,27 +280,27 @@ BOOST_AUTO_TEST_CASE(bulk_performance_check) {
     // bulk store
     {
         Database storage(".");
-        const auto start = std::chrono::steady_clock::now();
+        const auto start = boost::chrono::steady_clock::now();
         storage.bulk_store(items);
-        const auto end = std::chrono::steady_clock::now();
+        const auto end = boost::chrono::steady_clock::now();
         const auto diff = end - start;
         std::cout << "bulk: "
-                  << std::chrono::duration<double, std::milli>(diff).count()
+                  << boost::chrono::duration<double, boost::milli>(diff).count()
                   << " ms" << std::endl;
     }
 
     // single stores
     {
         Database storage(".");
-        const auto start = std::chrono::steady_clock::now();
+        const auto start = boost::chrono::steady_clock::now();
         for (const auto& item : items) {
             storage.store(item.hash, item.pub_key, item.data, item.ttl,
                           item.timestamp, item.nonce);
         }
-        const auto end = std::chrono::steady_clock::now();
+        const auto end = boost::chrono::steady_clock::now();
         const auto diff = end - start;
         std::cout << "singles:"
-                  << std::chrono::duration<double, std::milli>(diff).count()
+                  << boost::chrono::duration<double, boost::milli>(diff).count()
                   << " ms" << std::endl;
     }
 }


### PR DESCRIPTION
Linux builds on travis doesn't like mixing std::thread/std::chrono within the boost unit test, go figure.
This reverts commit 9dc29a01b07b056347e270fac1119c42005730b3.