### PR TITLE
make shortcut for integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,20 @@ endfunction()
 
 project(storage_server)
 
+option(INTEGRATION_TEST "build for integration test" OFF)
+
+if (INTEGRATION_TEST)
+    add_definitions(-DDISABLE_POW)
+    add_definitions(-DINTEGRATION_TEST)
+endif()
+
+option(DISABLE_SNODE_SIGNATURE "Generate and verify signatures for inter-snode communication"
+    ON)
+
+if (DISABLE_SNODE_SIGNATURE)
+    add_definitions(-DDISABLE_SNODE_SIGNATURE)
+endif()
+
 loki_add_subdirectory(utils)
 loki_add_subdirectory(crypto)
 loki_add_subdirectory(pow)

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,22 @@ BUILD_STATIC ?= ON
 
 MKDIR := mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR)
 
-MAKE_CMD := $(CMAKE) $(TOP_DIR) -DBoost_USE_STATIC_LIBS=$(BUILD_STATIC) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) -DBUILD_TESTS=$(BUILD_TESTS) && cmake --build .
-
 all:
-	$(MKDIR) && $(MAKE_CMD)
+	$(MKDIR) && \
+	$(CMAKE) $(TOP_DIR) \
+		-DBoost_USE_STATIC_LIBS=$(BUILD_STATIC) \
+		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DBUILD_TESTS=$(BUILD_TESTS) \
+		&& cmake --build .
+
+integration-test:
+	$(MKDIR) && \
+	$(CMAKE) $(TOP_DIR) \
+		-DBoost_USE_STATIC_LIBS=$(BUILD_STATIC) \
+		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DBUILD_TESTS=$(BUILD_TESTS) \
+		-DINTEGRATION_TEST=ON \
+		&& cmake --build .
 
 clean:
 	rm -rf build/$(SUB_DIR)

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 2.8.0)
 
 add_definitions(-DDISABLE_ENCRYPTION)
-option(DISABLE_SNODE_SIGNATURE "Generate and verify signatures for inter-snode communication"
-       ON)
-
-if (DISABLE_SNODE_SIGNATURE)
-    add_definitions(-DDISABLE_SNODE_SIGNATURE)
-endif()
-
 
 project(httpserver)
 


### PR DESCRIPTION
`make integration-test` builds the storage server with the correct flags for integration tests.
(could not confirm with integration tests because of `Bad lokid rpc response: invalid json` but the build seems to have the correct flags)