### PR TITLE
Verify proof of work for relayed messages

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -247,6 +247,7 @@ void connection_t::read_request() {
             self->process_request();
         } catch (const std::exception& e) {
             BOOST_LOG_TRIVIAL(error) << "Exception caught: " << e.what();
+            self->body_stream_ << e.what();
         }
 
         if (!self->delay_response_) {

--- a/utils/include/utils.hpp
+++ b/utils/include/utils.hpp
@@ -8,9 +8,11 @@
 
 namespace util {
 
+bool validateTTL(uint64_t ttlInt);
 // Convert ttl string into uint64_t, return bool for success/fail
 bool parseTTL(const std::string& ttlString, uint64_t& ttl);
 
+bool validateTimestamp(uint64_t timestamp, uint64_t ttl);
 // Convert timestamp string into uint64_t, return bool for success/fail
 bool parseTimestamp(const std::string& timestampString, const uint64_t ttl,
                     uint64_t& timestamp);

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -77,6 +77,7 @@ bool parseTimestamp(const std::string& timestampString, const uint64_t ttl,
 }
 
 bool validateTTL(uint64_t ttlInt) {
+    // Minimum time to live of 10 seconds, maximum of 4 days
     return (ttlInt >= 10 * 1000 && ttlInt <= 96 * 60 * 60 * 1000);
 }
 
@@ -88,7 +89,6 @@ bool parseTTL(const std::string& ttlString, uint64_t& ttl) {
         return false;
     }
 
-    // Minimum time to live of 10 seconds, maximum of 4 days
     if (!validateTTL(ttlInt))
         return false;
 

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -49,14 +49,7 @@ std::string hex64_to_base32z(const std::string& src) {
     return result;
 }
 
-bool parseTimestamp(const std::string& timestampString, const uint64_t ttl,
-                    uint64_t& timestamp) {
-    try {
-        timestamp = std::stoull(timestampString);
-    } catch (...) {
-        return false;
-    }
-
+bool validateTimestamp(uint64_t timestamp, uint64_t ttl) {
     const uint64_t cur_time = get_time_ms();
     // Timestamp must not be in the future (with some tolerance)
     if (timestamp > cur_time + 10000)
@@ -72,6 +65,21 @@ bool parseTimestamp(const std::string& timestampString, const uint64_t ttl,
     return true;
 }
 
+bool parseTimestamp(const std::string& timestampString, const uint64_t ttl,
+                    uint64_t& timestamp) {
+    try {
+        timestamp = std::stoull(timestampString);
+    } catch (...) {
+        return false;
+    }
+
+    return validateTimestamp(timestamp, ttl);
+}
+
+bool validateTTL(uint64_t ttlInt) {
+    return (ttlInt >= 10 * 1000 && ttlInt <= 96 * 60 * 60 * 1000);
+}
+
 bool parseTTL(const std::string& ttlString, uint64_t& ttl) {
     int ttlInt;
     try {
@@ -81,7 +89,7 @@ bool parseTTL(const std::string& ttlString, uint64_t& ttl) {
     }
 
     // Minimum time to live of 10 seconds, maximum of 4 days
-    if (ttlInt < 10 * 1000 || ttlInt > 96 * 60 * 60 * 1000)
+    if (!validateTTL(ttlInt))
         return false;
 
     ttl = static_cast<uint64_t>(ttlInt);


### PR DESCRIPTION
Add `verify_message`, which checks ttl, timestamp, PoW and hash, in `process_push` and `process_push_batch`.
For batch, we remove the messages that are invalid but keep the ones valid.