### PR TITLE
Refactor relaying code and fix signature for integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,14 +11,15 @@ endfunction()
 project(storage_server)
 
 option(INTEGRATION_TEST "build for integration test" OFF)
+option(DISABLE_SNODE_SIGNATURE "Generate and verify signatures for inter-snode communication"
+    ON)
 
 if (INTEGRATION_TEST)
     add_definitions(-DDISABLE_POW)
     add_definitions(-DINTEGRATION_TEST)
+    set(DISABLE_SNODE_SIGNATURE OFF)
 endif()
 
-option(DISABLE_SNODE_SIGNATURE "Generate and verify signatures for inter-snode communication"
-    ON)
 
 if (DISABLE_SNODE_SIGNATURE)
     add_definitions(-DDISABLE_SNODE_SIGNATURE)

--- a/crypto/include/signature.h
+++ b/crypto/include/signature.h
@@ -18,7 +18,7 @@ struct signature {
 
 hash hash_data(const std::string& data);
 
-void generate_signature(const hash& prefix_hash, const lokid_key_pair_t& key_pair, signature& sig);
+signature generate_signature(const hash& prefix_hash, const lokid_key_pair_t& key_pair);
 
 bool check_signature(const std::string& signature, const hash& hash,
                      const std::string& public_key_t_b32z);

--- a/crypto/src/signature.cpp
+++ b/crypto/src/signature.cpp
@@ -54,11 +54,12 @@ hash hash_data(const std::string& data) {
     return hash;
 }
 
-void generate_signature(const hash& prefix_hash,
-                        const lokid_key_pair_t& key_pair, signature& sig) {
+signature generate_signature(const hash& prefix_hash,
+                             const lokid_key_pair_t& key_pair) {
     ge_p3 tmp3;
     ec_scalar k;
     s_comm buf;
+    signature sig;
 #if !defined(NDEBUG)
     {
         ge_p3 t;
@@ -85,6 +86,7 @@ try_again:
               k.data());
     if (!sc_isnonzero((const unsigned char*)sig.r.data()))
         goto try_again;
+    return sig;
 }
 
 bool check_signature(const signature& sig, const hash& prefix_hash,

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -273,12 +273,15 @@ bool connection_t::verify_signature() {
     const auto& public_key_b32z = header_[LOKI_SENDER_SNODE_PUBKEY_HEADER];
 
     /// Known service node
+#ifndef INTEGRATION_TEST
     const std::string snode_address = public_key_b32z + ".snode";
     if (!service_node_.is_snode_address_known(snode_address)) {
         body_stream_ << "Unknown service node\n";
+        BOOST_LOG_TRIVIAL(error) << "Discarding signature from unknown service node " << public_key_b32z;
         response_.result(http::status::unauthorized);
         return false;
     }
+#endif
 
     const auto batch_hash = hash_data(request_.body());
     bool ok = check_signature(signature, batch_hash, public_key_b32z);

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -104,7 +104,6 @@ ServiceNode::ServiceNode(boost::asio::io_context& ioc, uint16_t port,
     : ioc_(ioc), db_(std::make_unique<Database>(db_location)),
       update_timer_(ioc), lokid_key_pair_(lokid_key_pair) {
 
-#ifndef INTEGRATION_TEST
     char buf[64] = {0};
     std::string our_address;
     if (char const* dest =
@@ -115,7 +114,6 @@ ServiceNode::ServiceNode(boost::asio::io_context& ioc, uint16_t port,
     }
     // TODO: fail hard if we can't encode our public key
     BOOST_LOG_TRIVIAL(info) << "Read snode address " << our_address;
-#endif
     our_address_.port = port;
 
     swarm_timer_tick();
@@ -206,7 +204,17 @@ void ServiceNode::push_message(const message_t& msg) {
 
     std::string body;
     serialize_message(body, msg);
+
+#ifndef DISABLE_SNODE_SIGNATURE
+    const auto hash = hash_data(body);
+    const auto signature = generate_signature(hash, lokid_key_pair_);
+#endif
+
     auto req = make_push_request(std::move(body));
+
+#ifndef DISABLE_SNODE_SIGNATURE
+    attach_signature(req, signature);
+#endif
 
     for (const auto& address : others) {
         /// send a request asynchronously
@@ -331,23 +339,18 @@ to_requests(std::vector<std::string>&& data) {
     return result;
 }
 
-void ServiceNode::attach_signature(
-    const std::vector<std::string>& data,
-    std::vector<std::shared_ptr<request_t>>& batches) const {
-    assert(data.size() == batches.size());
-    for (size_t i = 0; i < data.size(); ++i) {
-        const auto hash = hash_data(data[i]);
-        signature sig;
-        generate_signature(hash, lokid_key_pair_, sig);
-        std::string raw_sig;
-        raw_sig.reserve(sig.c.size() + sig.r.size());
-        raw_sig.insert(raw_sig.begin(), sig.c.begin(), sig.c.end());
-        raw_sig.insert(raw_sig.end(), sig.r.begin(), sig.r.end());
-        const std::string sig_b64 =
-            boost::beast::detail::base64_encode(raw_sig);
-        batches[i]->set(LOKI_SNODE_SIGNATURE_HEADER, sig_b64);
-        batches[i]->set(LOKI_SENDER_SNODE_PUBKEY_HEADER, our_address_.address);
-    }
+void ServiceNode::attach_signature(std::shared_ptr<request_t>& request,
+                                   const signature& sig) const {
+
+    std::string raw_sig;
+    raw_sig.reserve(sig.c.size() + sig.r.size());
+    raw_sig.insert(raw_sig.begin(), sig.c.begin(), sig.c.end());
+    raw_sig.insert(raw_sig.end(), sig.r.begin(), sig.r.end());
+
+    const std::string sig_b64 = boost::beast::detail::base64_encode(raw_sig);
+
+    request->set(LOKI_SNODE_SIGNATURE_HEADER, sig_b64);
+    request->set(LOKI_SENDER_SNODE_PUBKEY_HEADER, our_address_.address);
 }
 
 void ServiceNode::perform_peer_test() {
@@ -402,18 +405,8 @@ void ServiceNode::bootstrap_peers(const std::vector<sn_record_t>& peers) const {
     db_->retrieve("", all_entries, "");
 
     std::vector<std::string> data = serialize_messages(all_entries);
-    std::vector<std::shared_ptr<request_t>> batches =
-        to_requests(std::move(data));
 
-#ifndef DISABLE_SNODE_SIGNATURE
-    attach_signature(data, batches);
-#endif
-
-    for (const sn_record_t& sn : peers) {
-        for (const std::shared_ptr<request_t>& batch : batches) {
-            relay_data(batch, sn);
-        }
-    }
+    relay_messages(all_entries, peers);
 }
 
 template <typename T>
@@ -501,20 +494,40 @@ void ServiceNode::bootstrap_swarms(
         /// what if not found?
         const size_t idx = swarm_id_to_idx[swarm_id];
 
-        std::vector<std::string> data = serialize_messages(kv.second);
-        std::vector<std::shared_ptr<request_t>> batches =
-            to_requests(std::move(data));
+        const std::vector<std::string> data = serialize_messages(kv.second);
+
+        relay_messages(kv.second, all_swarms[idx].snodes);
+    }
+}
+
+void ServiceNode::relay_messages(
+    const std::vector<service_node::storage::Item>& messages,
+    const std::vector<sn_record_t>& snodes) const {
+    std::vector<std::string> data = serialize_messages(messages);
 
 #ifndef DISABLE_SNODE_SIGNATURE
-        attach_signature(data, batches);
+    std::vector<signature> signatures;
+    signatures.reserve(data.size());
+    for (const auto& d : data) {
+        const auto hash = hash_data(d);
+        signatures.push_back(generate_signature(hash, lokid_key_pair_));
+    }
 #endif
 
-        BOOST_LOG_TRIVIAL(info) << "serialized batches: " << data.size();
+    std::vector<std::shared_ptr<request_t>> batches =
+        to_requests(std::move(data));
 
-        for (const sn_record_t& sn : all_swarms[idx].snodes) {
-            for (const std::shared_ptr<request_t>& batch : batches) {
-                relay_data(batch, sn);
-            }
+#ifndef DISABLE_SNODE_SIGNATURE
+    assert(batches.size() == signatures.size());
+    for (size_t i = 0; i < batches.size(); ++i) {
+        attach_signature(batches[i], signatures[i]);
+    }
+#endif
+
+    BOOST_LOG_TRIVIAL(info) << "serialized batches: " << data.size();
+    for (const sn_record_t& sn : snodes) {
+        for (const std::shared_ptr<request_t>& batch : batches) {
+            relay_data(batch, sn);
         }
     }
 }

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -118,7 +118,7 @@ class ServiceNode {
                           const signature& sig) const;
 
     /// used on push and on swarm bootstrapping
-    void relay_data(const std::shared_ptr<request_t>& req,
+    void send_sn_request(const std::shared_ptr<request_t>& req,
                     const sn_record_t& address) const;
     void
     relay_messages(const std::vector<service_node::storage::Item>& messages,

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -39,6 +39,8 @@ using connection_ptr = std::shared_ptr<http_server::connection_t>;
 
 class Swarm;
 
+struct signature;
+
 struct snode_stats_t {
 
     // how many times a single push failed
@@ -112,13 +114,15 @@ class ServiceNode {
     /// (called when our old node got dissolved)
     void salvage_data() const;
 
-    void
-    attach_signature(const std::vector<std::string>& data,
-                     std::vector<std::shared_ptr<request_t>>& batches) const;
+    void attach_signature(std::shared_ptr<request_t>& request,
+                          const signature& sig) const;
 
     /// used on push and on swarm bootstrapping
     void relay_data(const std::shared_ptr<request_t>& req,
                     const sn_record_t& address) const;
+    void
+    relay_messages(const std::vector<service_node::storage::Item>& messages,
+                   const std::vector<sn_record_t>& snodes) const;
 
     /// Request swarm structure from the deamon and reset the timer
     void swarm_timer_tick();

--- a/unit_test/signature.cpp
+++ b/unit_test/signature.cpp
@@ -42,8 +42,7 @@ BOOST_AUTO_TEST_CASE(it_signs_and_verifies) {
                                    50,  238, 207, 178, 176, 54, 126, 170,
                                    111, 112, 50,  121, 227, 78, 193, 2};
     lokid_key_pair_t key_pair{secret_key, public_key};
-    signature sig;
-    generate_signature(hash, key_pair, sig);
+    const auto sig = generate_signature(hash, key_pair);
     const bool verified = check_signature(sig, hash, public_key);
     BOOST_CHECK(verified);
 }
@@ -61,8 +60,7 @@ BOOST_AUTO_TEST_CASE(it_signs_and_verifies_encoded_inputs) {
                                    50,  238, 207, 178, 176, 54, 126, 170,
                                    111, 112, 50,  121, 227, 78, 193, 2};
     lokid_key_pair_t key_pair{secret_key, public_key};
-    signature sig;
-    generate_signature(hash, key_pair, sig);
+    const auto sig = generate_signature(hash, key_pair);
 
     // convert signature to base64 and public key to base32z
     std::string raw_sig;
@@ -91,8 +89,7 @@ BOOST_AUTO_TEST_CASE(it_rejects_wrong_signature) {
                                    50,  238, 207, 178, 176, 54, 126, 170,
                                    111, 112, 50,  121, 227, 78, 193, 2};
     lokid_key_pair_t key_pair{secret_key, public_key};
-    signature sig;
-    generate_signature(hash, key_pair, sig);
+    auto sig = generate_signature(hash, key_pair);
 
     // amend signature
     sig.c[4]++;


### PR DESCRIPTION
Integration tests were failing with signature due to the list of peers being empty, hence the signature was rejected. The solution for now is just to skip that check for integration test build.

Also, refactor the data relaying code since it was mostly redundant between `boostrap_peers` and `boostrap_swarms`