### PR TITLE
Move swarm update tick to happen after the request completes

### DIFF
--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -346,8 +346,7 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
 
     } else {
         BOOST_LOG_TRIVIAL(trace) << "already seen this block";
-        update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
-        update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));
+        reset_swarm_timer();
         return;
     }
 
@@ -367,6 +366,10 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
     }
 
     initiate_peer_test();
+    reset_swarm_timer();
+}
+
+void ServiceNode::reset_swarm_timer() {
     update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
     update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));
 }

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -346,6 +346,8 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
 
     } else {
         BOOST_LOG_TRIVIAL(trace) << "already seen this block";
+        update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
+        update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));
         return;
     }
 
@@ -365,14 +367,14 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
     }
 
     initiate_peer_test();
+    update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
+    update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));
 }
 
 void ServiceNode::swarm_timer_tick() {
     const swarm_callback_t cb =
         std::bind(&ServiceNode::on_swarm_update, this, std::placeholders::_1);
     request_swarm_update(ioc_, std::move(cb), lokid_rpc_port_);
-    update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
-    update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));
 }
 
 static std::vector<std::shared_ptr<request_t>>

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -133,6 +133,9 @@ class ServiceNode {
     relay_messages(const std::vector<service_node::storage::Item>& messages,
                    const std::vector<sn_record_t>& snodes) const;
 
+    /// Reset the swarm timer
+    void reset_swarm_timer();
+
     /// Request swarm structure from the deamon and reset the timer
     void swarm_timer_tick();
 


### PR DESCRIPTION
If for whatever reason a request to lokid for the swarm mapping would fail, new requests would pile up every 200ms
This changes only creates a new request after the previous one has completed