### PR TITLE
Limit client retrieve request to 10 messages at a time

### DIFF
--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -84,6 +84,7 @@ constexpr std::chrono::milliseconds SWARM_UPDATE_INTERVAL = 200ms;
 #else
 constexpr std::chrono::milliseconds SWARM_UPDATE_INTERVAL = 1000ms;
 #endif
+constexpr int CLIENT_RETRIEVE_MESSAGE_LIMIT = 10;
 
 static std::shared_ptr<request_t> make_post_request(const char* target,
                                                     std::string&& data) {
@@ -632,7 +633,7 @@ void ServiceNode::initiate_peer_test() {
 void ServiceNode::bootstrap_peers(const std::vector<sn_record_t>& peers) const {
 
     std::vector<Item> all_entries;
-    db_->retrieve("", all_entries, "");
+    get_all_messages(all_entries);
 
     relay_messages(all_entries, peers);
 }
@@ -670,7 +671,7 @@ void ServiceNode::bootstrap_swarms(
     const auto& all_swarms = swarm_->all_swarms();
 
     std::vector<Item> all_entries;
-    if (!db_->retrieve("", all_entries, "")) {
+    if (!get_all_messages(all_entries)) {
         BOOST_LOG_TRIVIAL(error)
             << "could not retrieve entries from the database\n";
         return;
@@ -767,10 +768,10 @@ void ServiceNode::salvage_data() const {
 bool ServiceNode::retrieve(const std::string& pubKey,
                            const std::string& last_hash,
                            std::vector<Item>& items) {
-    return db_->retrieve(pubKey, items, last_hash);
+    return db_->retrieve(pubKey, items, last_hash, CLIENT_RETRIEVE_MESSAGE_LIMIT);
 }
 
-bool ServiceNode::get_all_messages(std::vector<Item>& all_entries) {
+bool ServiceNode::get_all_messages(std::vector<Item>& all_entries) const {
 
     BOOST_LOG_TRIVIAL(trace) << "get all messages";
 

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -190,7 +190,7 @@ class ServiceNode {
 
     /// return all messages for a particular PK (in JSON)
     bool
-    get_all_messages(std::vector<service_node::storage::Item>& all_entries);
+    get_all_messages(std::vector<service_node::storage::Item>& all_entries) const;
 
     bool retrieve(const std::string& pubKey, const std::string& last_hash,
                   std::vector<service_node::storage::Item>& items);

--- a/storage/include/Database.hpp
+++ b/storage/include/Database.hpp
@@ -30,7 +30,7 @@ class Database {
 
     bool retrieve(const std::string& key,
                   std::vector<service_node::storage::Item>& items,
-                  const std::string& lastHash);
+                  const std::string& lastHash, int num_results = -1);
 
     // Return the total number of messages stored
     bool get_message_count(uint64_t& count);

--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -340,7 +340,7 @@ BOOST_AUTO_TEST_CASE(it_checks_the_retrieve_limit_works) {
                       util::get_time_ms(), "nonce");
     }
 
-    // should return every items
+    // should return all items
     {
         std::vector<service_node::storage::Item> items;
         const auto lastHash = "";


### PR DESCRIPTION
Implements #123 
Note that SQLITE states 
` If the LIMIT expression evaluates to a negative value, then there is no upper bound on the number of rows returned` so we can use `-1` to specify we don't want to limit the results.