### PR TITLE
Clear database before performance testing

### DIFF
--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -281,8 +281,6 @@ BOOST_AUTO_TEST_CASE(it_stores_data_in_bulk_even_when_overlaps) {
 }
 
 BOOST_AUTO_TEST_CASE(bulk_performance_check) {
-    StorageRAIIFixture fixture;
-
     const auto pubkey = "mypubkey";
     const auto bytes = "bytesasstring";
     const auto nonce = "nonce";
@@ -299,6 +297,7 @@ BOOST_AUTO_TEST_CASE(bulk_performance_check) {
 
     // bulk store
     {
+        StorageRAIIFixture fixture;
         boost::asio::io_context ioc;
         Database storage(ioc, ".");
         const auto start = boost::chrono::steady_clock::now();
@@ -312,6 +311,7 @@ BOOST_AUTO_TEST_CASE(bulk_performance_check) {
 
     // single stores
     {
+        StorageRAIIFixture fixture;
         boost::asio::io_context ioc;
         Database storage(ioc, ".");
         const auto start = boost::chrono::steady_clock::now();


### PR DESCRIPTION
Performance test (bulk vs single insert) is printing lots and lots of
`[error]   sqlite reset error: 19`
due to the second case (single insert) pushing the same messages to the database created by the first case (bulk).
This PR simply ensures the databases are deleted before each case.

Surprisingly, the single push performance got a lot worse (~7 seconds compare to 25ms for bulk!!) probably due to repeated disk memory allocation? It probably used to be an order of magnitude lower when the constraint failed, thanks to not having to actually allocate memory.