### PR TITLE
Use safer acceptor::async_accept overload

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -179,11 +179,10 @@ namespace http_server {
 
 // "Loop" forever accepting new connections.
 static void
-accept_connection(boost::asio::io_context& ioc, tcp::acceptor& acceptor,
-                  tcp::socket& socket, ServiceNode& sn,
+accept_connection(boost::asio::io_context& ioc, tcp::acceptor& acceptor, ServiceNode& sn,
                   ChannelEncryption<std::string>& channel_encryption) {
 
-    acceptor.async_accept(socket, [&](const error_code& ec) {
+    acceptor.async_accept([&](const error_code& ec, tcp::socket socket) {
         BOOST_LOG_TRIVIAL(trace) << "connection accepted";
         if (!ec)
             std::make_shared<connection_t>(ioc, std::move(socket), sn,
@@ -193,7 +192,7 @@ accept_connection(boost::asio::io_context& ioc, tcp::acceptor& acceptor,
         if (ec)
             log_error(ec);
 
-        accept_connection(ioc, acceptor, socket, sn, channel_encryption);
+        accept_connection(ioc, acceptor, sn, channel_encryption);
     });
 }
 
@@ -206,9 +205,8 @@ void run(boost::asio::io_context& ioc, std::string& ip, uint16_t port,
         boost::asio::ip::make_address(ip); /// throws if incorrect
 
     tcp::acceptor acceptor{ioc, {address, port}};
-    tcp::socket socket{ioc};
 
-    accept_connection(ioc, acceptor, socket, sn, channel_encryption);
+    accept_connection(ioc, acceptor, sn, channel_encryption);
 
     ioc.run();
 }


### PR DESCRIPTION
This PR uses the `acceptor::async_accept` overload that provides the socket as argument of the lambda. The acceptor can already generate the socket for us, per connection. This is safer than moving the socket into the `connection_t` constructor then passing it (in an undefined/reset state?) to `accept_connection` to close the loop.