### PR TITLE
Token Bucket rate limiting for snode-to-snode requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ integration-test:
 		-DINTEGRATION_TEST=ON \
 		&& cmake --build .
 
+tests: all
+	./$(BUILD_DIR)/unit_test/Test --log_level=all
+
 clean:
 	rm -rf build/$(SUB_DIR)
 

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -4,8 +4,22 @@ add_definitions(-DDISABLE_ENCRYPTION)
 
 project(httpserver)
 
-set(HEADER_FILES http_connection.h swarm.h service_node.h serialization.h ../external/json.hpp)
-set(SRC_FILES main.cpp http_connection.cpp swarm.cpp service_node.cpp serialization.cpp)
+set(HEADER_FILES
+    http_connection.h
+    swarm.h
+    service_node.h
+    serialization.h
+    rate_limiter.h
+    ../external/json.hpp)
+
+set(SRC_FILES
+    main.cpp
+    http_connection.cpp
+    swarm.cpp
+    service_node.cpp
+    serialization.cpp
+    rate_limiter.cpp
+    )
 
 add_executable(httpserver ${HEADER_FILES} ${SRC_FILES})
 

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -1,6 +1,7 @@
 #include "channel_encryption.hpp"
 #include "http_connection.h"
 #include "lokid_key.h"
+#include "rate_limiter.h"
 #include "service_node.h"
 #include "swarm.h"
 #include "version.h"
@@ -172,9 +173,11 @@ int main(int argc, char* argv[]) {
         loki::lokid_key_pair_t lokid_key_pair{private_key, public_key};
         loki::ServiceNode service_node(ioc, port, lokid_key_pair, db_location,
                                        lokid_rpc_port);
+        RateLimiter rate_limiter;
 
         /// Should run http server
-        loki::http_server::run(ioc, ip, port, service_node, channel_encryption);
+        loki::http_server::run(ioc, ip, port, service_node, channel_encryption,
+                               rate_limiter);
 
     } catch (const std::exception& e) {
         // It seems possible for logging to throw its own exception,

--- a/httpserver/rate_limiter.cpp
+++ b/httpserver/rate_limiter.cpp
@@ -1,0 +1,51 @@
+#include "rate_limiter.h"
+
+#include <algorithm>
+
+using namespace std::chrono_literals;
+
+constexpr static std::chrono::microseconds TOKEN_PERIOD_US =
+    std::chrono::duration_cast<std::chrono::microseconds>(1s) /
+    RateLimiter::TOKEN_RATE;
+constexpr static std::chrono::microseconds FILL_EMPTY_BUCKET_US =
+    TOKEN_PERIOD_US * RateLimiter::BUCKET_SIZE;
+
+void RateLimiter::fill_bucket(TokenBucket& bucket,
+                              std::chrono::steady_clock::time_point now) {
+    auto elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+        now - bucket.last_time_point);
+    // clamp elapsed time to how long it takes to fill up the whole bucket
+    // (simplifies overlow checking)
+    elapsed_us = std::min(elapsed_us, FILL_EMPTY_BUCKET_US);
+    const uint32_t token_added = elapsed_us.count() / TOKEN_PERIOD_US.count();
+    // clamp tokens to bucket size
+    bucket.num_tokens = std::min(BUCKET_SIZE, bucket.num_tokens + token_added);
+}
+
+bool RateLimiter::should_rate_limit(const std::string& identifier) {
+    return should_rate_limit(identifier, std::chrono::steady_clock::now());
+}
+
+bool RateLimiter::should_rate_limit(const std::string& identifier,
+                                    std::chrono::steady_clock::time_point now) {
+    const auto it = std::find_if(
+        buckets_.begin(), buckets_.end(),
+        [&](const buffer_pair_t& pair) { return pair.first == identifier; });
+    if (it != buckets_.end()) {
+        auto& bucket = it->second;
+
+        fill_bucket(bucket, now);
+
+        if (bucket.num_tokens == 0) {
+            return true;
+        }
+
+        bucket.num_tokens--;
+        bucket.last_time_point = now;
+    } else {
+        const TokenBucket bucket{BUCKET_SIZE - 1, now};
+        buckets_.push_back(std::make_pair(identifier, bucket));
+    }
+
+    return false;
+}

--- a/httpserver/rate_limiter.h
+++ b/httpserver/rate_limiter.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <boost/circular_buffer.hpp>
+
+#include <chrono>
+#include <stdint.h>
+#include <string>
+#include <utility> // for std::pair
+
+/// https://en.wikipedia.org/wiki/Token_bucket
+
+class RateLimiter {
+  public:
+    // TODO: make those two constants command line parameters?
+    constexpr static uint32_t BUCKET_SIZE = 50;
+    constexpr static uint32_t TOKEN_RATE = 50;
+
+    bool should_rate_limit(const std::string& identifier,
+                           std::chrono::steady_clock::time_point now);
+    bool should_rate_limit(const std::string& identifier);
+
+  private:
+    struct TokenBucket {
+        uint32_t num_tokens;
+        std::chrono::steady_clock::time_point last_time_point;
+    };
+    using buffer_pair_t = std::pair<std::string, TokenBucket>;
+
+    boost::circular_buffer<buffer_pair_t> buckets_{128};
+
+    void fill_bucket(TokenBucket& bucket,
+                     std::chrono::steady_clock::time_point now);
+};

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -776,7 +776,8 @@ void ServiceNode::salvage_data() const {
 bool ServiceNode::retrieve(const std::string& pubKey,
                            const std::string& last_hash,
                            std::vector<Item>& items) {
-    return db_->retrieve(pubKey, items, last_hash, CLIENT_RETRIEVE_MESSAGE_LIMIT);
+    return db_->retrieve(pubKey, items, last_hash,
+                         CLIENT_RETRIEVE_MESSAGE_LIMIT);
 }
 
 bool ServiceNode::get_all_messages(std::vector<Item>& all_entries) const {

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -190,8 +190,8 @@ class ServiceNode {
     bool is_snode_address_known(const std::string&);
 
     /// return all messages for a particular PK (in JSON)
-    bool
-    get_all_messages(std::vector<service_node::storage::Item>& all_entries) const;
+    bool get_all_messages(
+        std::vector<service_node::storage::Item>& all_entries) const;
 
     bool retrieve(const std::string& pubKey, const std::string& last_hash,
                   std::vector<service_node::storage::Item>& items);

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -6,7 +6,10 @@ add_executable (Test
     pow.cpp
     serialization.cpp
     signature.cpp
+    rate_limiter.cpp
+    # TODO: remove once httpserver provides a static lib to link against
     ../httpserver/serialization.cpp
+    ../httpserver/rate_limiter.cpp
 )
 
 # library under test

--- a/unit_test/rate_limiter.cpp
+++ b/unit_test/rate_limiter.cpp
@@ -1,0 +1,56 @@
+#include "rate_limiter.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+
+BOOST_AUTO_TEST_SUITE(request_rate_limiter)
+
+BOOST_AUTO_TEST_CASE(it_ratelimits_only_with_empty_bucket) {
+    RateLimiter rate_limiter;
+    const std::string identifier = "mypubkey";
+    const auto now = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < RateLimiter::BUCKET_SIZE; ++i) {
+        BOOST_CHECK_EQUAL(rate_limiter.should_rate_limit(identifier, now),
+                          false);
+    }
+    BOOST_CHECK_EQUAL(rate_limiter.should_rate_limit(identifier, now), true);
+
+    // wait just enough to allow one more request
+    const auto delta =
+        std::chrono::milliseconds(1000 / RateLimiter::TOKEN_RATE);
+    BOOST_CHECK_EQUAL(rate_limiter.should_rate_limit(identifier, now + delta),
+                      false);
+}
+
+BOOST_AUTO_TEST_CASE(it_fills_up_bucket_steadily) {
+    RateLimiter rate_limiter;
+    const std::string identifier = "mypubkey";
+    const auto now = std::chrono::steady_clock::now();
+    // make requests at the same rate as the bucket is filling up
+    for (int i = 0; i < RateLimiter::BUCKET_SIZE * 10; ++i) {
+        const auto delta =
+            std::chrono::milliseconds(i * 1000 / RateLimiter::TOKEN_RATE);
+        BOOST_CHECK_EQUAL(
+            rate_limiter.should_rate_limit(identifier, now + delta), false);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(it_handle_multiple_identifiers) {
+    RateLimiter rate_limiter;
+    const std::string identifier1 = "mypubkey";
+    const auto now = std::chrono::steady_clock::now();
+
+    for (int i = 0; i < RateLimiter::BUCKET_SIZE; ++i) {
+        BOOST_CHECK_EQUAL(rate_limiter.should_rate_limit(identifier1, now),
+                          false);
+    }
+    BOOST_CHECK_EQUAL(rate_limiter.should_rate_limit(identifier1, now), true);
+
+    // other id
+    BOOST_CHECK_EQUAL(rate_limiter.should_rate_limit("otherpubkey", now),
+                      false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -1,9 +1,9 @@
 #include "Database.hpp"
 #include "utils.hpp"
 
+#include <chrono>
 #include <iostream>
 #include <string>
-#include <chrono>
 
 /// This file fails to link on linux when trying to use std:: for threading and
 /// chrono
@@ -356,7 +356,6 @@ BOOST_AUTO_TEST_CASE(it_checks_the_retrieve_limit_works) {
         BOOST_CHECK(storage.retrieve("mypubkey", items, lastHash, num_results));
         BOOST_CHECK_EQUAL(items.size(), num_results);
     }
-
 
     // should return 88 items
     {


### PR DESCRIPTION
Use  token-bucket algorithm to implement rate limiting.
Returns HTTP code `too_many_requests`.
Values for `BUCKET_SIZE` and `TOKEN_RATE` are still to be fine tuned, currently set to allow max 5 connections per seconds on average.
(PR is slightly tainted by clang format)
See #98 