### PR TITLE
perform blockchain testing alongside storage testing

### DIFF
--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -36,14 +36,26 @@ using service_node::storage::Item;
 
 namespace loki {
 using swarm_callback_t = std::function<void(const block_update_t&)>;
+using str_body_callback_t = std::function<void(const std::string&)>;
 
 struct message_t;
+struct lokid_key_pair_t;
 
 enum class SNodeError { NO_ERROR, ERROR_OTHER, NO_REACH };
 
 struct sn_response_t {
     SNodeError error_code;
     std::shared_ptr<std::string> body;
+};
+
+struct blockchain_test_answer_t {
+    uint64_t res_height;
+};
+
+/// Blockchain test parameters
+struct bc_test_params_t {
+    uint64_t max_height;
+    uint64_t seed;
 };
 
 using http_callback_t = std::function<void(sn_response_t)>;
@@ -53,6 +65,11 @@ using http_callback_t = std::function<void(sn_response_t)>;
 void make_http_request(boost::asio::io_context& ioc, const std::string& ip,
                        uint16_t port, const std::shared_ptr<request_t>& req,
                        http_callback_t&& cb);
+
+void request_blockchain_test(boost::asio::io_context& ioc,
+                             uint16_t lokid_rpc_port,
+                             const loki::lokid_key_pair_t& keypair,
+                             bc_test_params_t params, str_body_callback_t&& cb);
 
 void request_swarm_update(boost::asio::io_context& ioc,
                           const swarm_callback_t&& cb, uint16_t lokid_rpc_port);
@@ -201,8 +218,8 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     // Check whether we have spent enough time on this connection.
     void register_deadline();
 
-    /// Process message test request and repeat if necessary
-    void process_message_test_req(uint64_t height,
+    /// Process storage test request and repeat if necessary
+    void process_storage_test_req(uint64_t height,
                                   const std::string& tester_addr,
                                   const std::string& msg_hash);
 

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -11,6 +11,7 @@
 #include <boost/log/trivial.hpp>
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/program_options.hpp>
+#include <sodium.h>
 
 #include <cstdlib>
 #include <iomanip>
@@ -161,6 +162,11 @@ int main(int argc, char* argv[]) {
             << "Listening at address " << ip << " port " << port << std::endl;
 
         boost::asio::io_context ioc{1};
+
+        if (sodium_init() != 0) {
+            BOOST_LOG_TRIVIAL(fatal) << "Could not initialize libsodium";
+            return EXIT_FAILURE;
+        }
 
         // ed25519 key
         const auto private_key = loki::parseLokidKey(lokid_key_path);

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -387,6 +387,35 @@ make_batch_requests(std::vector<std::string>&& data) {
     return result;
 }
 
+void ServiceNode::perform_blockchain_test(
+    bc_test_params_t params,
+    std::function<void(blockchain_test_answer_t)>&& cb) const {
+
+    BOOST_LOG_TRIVIAL(debug) << "Delegating blockchain test to lokid";
+    request_blockchain_test(
+        ioc_, lokid_rpc_port_, lokid_key_pair_, params,
+        [cb = std::move(cb)](const std::string& body_str) {
+            using nlohmann::json;
+
+            const json body = json::parse(body_str, nullptr, false);
+
+            if (body == nlohmann::detail::value_t::discarded) {
+                BOOST_LOG_TRIVIAL(error)
+                    << "Bad lokid rpc response: invalid json";
+                return;
+            }
+
+            try {
+                auto result = body.at("result");
+                uint64_t height = result.at("res_height").get<uint64_t>();
+
+                cb(blockchain_test_answer_t{height});
+
+            } catch (...) {
+            }
+        });
+}
+
 void ServiceNode::attach_signature(std::shared_ptr<request_t>& request,
                                    const signature& sig) const {
 
@@ -415,7 +444,7 @@ void abort_if_integration_test() {
 #endif
 }
 
-void ServiceNode::send_message_test_req(const sn_record_t& testee,
+void ServiceNode::send_storage_test_req(const sn_record_t& testee,
                                         const Item& item) {
 
     auto callback = [testee, item,
@@ -423,7 +452,7 @@ void ServiceNode::send_message_test_req(const sn_record_t& testee,
         if (res.error_code == SNodeError::NO_ERROR && res.body) {
             if (*res.body == item.data) {
                 BOOST_LOG_TRIVIAL(debug)
-                    << "Message test is successful for: " << testee
+                    << "Storage test is successful for: " << testee
                     << " at height: " << height;
             } else {
                 BOOST_LOG_TRIVIAL(warning)
@@ -438,7 +467,7 @@ void ServiceNode::send_message_test_req(const sn_record_t& testee,
             }
         } else {
             BOOST_LOG_TRIVIAL(error)
-                << "Failed to send a message test request to snode: " << testee;
+                << "Failed to send a storage test request to snode: " << testee;
 
             /// TODO: retry here, otherwise tests sometimes fail (when SN not
             /// running yet)
@@ -451,7 +480,7 @@ void ServiceNode::send_message_test_req(const sn_record_t& testee,
     json_body["height"] = block_height_;
     json_body["hash"] = item.hash;
 
-    auto req = make_post_request("/msg_test", json_body.dump());
+    auto req = make_post_request("v1/swarms/storage_test", json_body.dump());
 
 #ifndef DISABLE_SNODE_SIGNATURE
     const auto hash = hash_data(req->body());
@@ -460,6 +489,61 @@ void ServiceNode::send_message_test_req(const sn_record_t& testee,
 #endif
 
     make_http_request(ioc_, testee.address, testee.port, req, callback);
+}
+
+void ServiceNode::send_blockchain_test_req(const sn_record_t& testee,
+                                           bc_test_params_t params,
+                                           blockchain_test_answer_t answer) {
+
+    nlohmann::json json_body;
+
+    json_body["max_height"] = params.max_height;
+    json_body["seed"] = params.seed;
+
+    auto req =
+        make_post_request("/v1/swarms/blockchain_test", json_body.dump());
+
+#ifndef DISABLE_SNODE_SIGNATURE
+    const auto hash = hash_data(req->body());
+    const auto signature = generate_signature(hash, lokid_key_pair_);
+    attach_signature(req, signature);
+#endif
+
+    make_http_request(ioc_, testee.address, testee.port, req,
+                      std::bind(&ServiceNode::process_blockchain_test_response,
+                                this, std::placeholders::_1, answer, testee,
+                                this->block_height_));
+}
+
+void ServiceNode::process_blockchain_test_response(
+    sn_response_t&& res, blockchain_test_answer_t our_answer,
+    sn_record_t testee, uint64_t bc_height) {
+
+    BOOST_LOG_TRIVIAL(debug)
+        << "Processing blockchain test response from: " << testee
+        << " at height: " << bc_height;
+
+    if (!res.body) {
+        BOOST_LOG_TRIVIAL(debug) << "Failed: empty response.";
+        return;
+    }
+
+    using nlohmann::json;
+
+    try {
+
+        const json body = json::parse(*res.body, nullptr, true);
+        uint64_t their_height = body.at("res_height").get<uint64_t>();
+
+        if (our_answer.res_height == their_height) {
+            BOOST_LOG_TRIVIAL(debug) << "Success.";
+        } else {
+            BOOST_LOG_TRIVIAL(debug) << "Failed: incorrect answer.";
+        }
+
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(debug) << "Failed: could not find answer in json.";
+    }
 }
 
 // Deterministically selects two random swarm members; returns true on success
@@ -483,7 +567,7 @@ bool ServiceNode::derive_tester_testee(uint64_t blk_height, sn_record_t& tester,
     } else if (blk_height < block_height_) {
 
         BOOST_LOG_TRIVIAL(debug)
-            << "got message test request for an older block";
+            << "got storage test request for an older block";
 
         const auto it =
             std::find_if(block_hashes_cache_.begin(), block_hashes_cache_.end(),
@@ -529,7 +613,7 @@ bool ServiceNode::derive_tester_testee(uint64_t blk_height, sn_record_t& tester,
     return true;
 }
 
-MessageTestStatus ServiceNode::process_msg_test_req(
+MessageTestStatus ServiceNode::process_storage_test_req(
     uint64_t blk_height, const std::string& tester_addr,
     const std::string& msg_hash, std::string& answer) {
 
@@ -558,6 +642,7 @@ MessageTestStatus ServiceNode::process_msg_test_req(
         if (tester.address != tester_addr) {
             BOOST_LOG_TRIVIAL(warning) << "Wrong tester: " << tester_addr
                                        << ", expected: " << tester.address;
+            abort_if_integration_test();
             return MessageTestStatus::ERROR;
         } else {
             BOOST_LOG_TRIVIAL(debug) << "Tester is valid: " << tester_addr;
@@ -624,18 +709,57 @@ void ServiceNode::initiate_peer_test() {
         return;
     }
 
-    // 2. Select a message
-    Item item;
-    if (!this->select_random_message(item)) {
-        BOOST_LOG_TRIVIAL(error) << "Could not select a message for testing";
-        return;
+    /// 2. Storage Testing
+    {
+        // 2.1. Select a message
+        Item item;
+        if (!this->select_random_message(item)) {
+            BOOST_LOG_TRIVIAL(error)
+                << "Could not select a message for testing";
+        } else {
+            BOOST_LOG_TRIVIAL(trace)
+                << "selected random message : " << item.hash << ", "
+                << item.data;
+
+            // 2.2. Initiate testing request
+            send_storage_test_req(testee, item);
+        }
     }
 
-    BOOST_LOG_TRIVIAL(trace)
-        << "selected random message : " << item.hash << ", " << item.data;
+    // Note: might consider choosing a different tester/testee pair for
+    // different types of tests as to spread out the computations
 
-    // 3. Initiate testing request
-    send_message_test_req(testee, item);
+    /// 3. Blockchain Testing
+    {
+
+        // Distance between two consecutive checkpoints,
+        // should be in sync with lokid
+        constexpr uint64_t CHECKPOINT_DISTANCE = 4;
+        // We can be confident that blockchain data won't
+        // change if we go this many blocks back
+        constexpr uint64_t SAFETY_BUFFER_BLOCKS = CHECKPOINT_DISTANCE * 2;
+
+        if (block_height_ <= SAFETY_BUFFER_BLOCKS) {
+            BOOST_LOG_TRIVIAL(debug)
+                << "Blockchain too short, skipping blockchain testing.";
+            return;
+        }
+
+        bc_test_params_t params;
+        params.max_height = block_height_ - SAFETY_BUFFER_BLOCKS;
+
+        const uint64_t rng_seed = std::chrono::high_resolution_clock::now()
+                                      .time_since_epoch()
+                                      .count();
+        std::mt19937_64 mt(rng_seed);
+        params.seed = mt();
+
+        auto callback = std::bind(&ServiceNode::send_blockchain_test_req, this,
+                                  testee, params, std::placeholders::_1);
+
+        /// Compute your own answer, then initiate a test request
+        perform_blockchain_test(params, callback);
+    }
 }
 
 void ServiceNode::bootstrap_peers(const std::vector<sn_record_t>& peers) const {

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -399,7 +399,7 @@ void ServiceNode::perform_blockchain_test(
 
             const json body = json::parse(body_str, nullptr, false);
 
-            if (body == nlohmann::detail::value_t::discarded) {
+            if (body.is_discarded()) {
                 BOOST_LOG_TRIVIAL(error)
                     << "Bad lokid rpc response: invalid json";
                 return;

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -31,6 +31,10 @@ using request_t = http::request<http::string_body>;
 
 namespace loki {
 
+struct sn_response_t;
+struct blockchain_test_answer_t;
+struct bc_test_params_t;
+
 namespace http_server {
 class connection_t;
 }
@@ -141,8 +145,18 @@ class ServiceNode {
                               sn_record_t& testee);
 
     /// Send a request to a SN under test
-    void send_message_test_req(const sn_record_t& testee,
+    void send_storage_test_req(const sn_record_t& testee,
                                const service_node::storage::Item& item);
+
+    void send_blockchain_test_req(const sn_record_t& testee,
+                                  bc_test_params_t params,
+                                  blockchain_test_answer_t answer);
+
+    /// From a peer
+    void process_blockchain_test_response(sn_response_t&& res,
+                                          blockchain_test_answer_t our_answer,
+                                          sn_record_t testee,
+                                          uint64_t bc_height);
 
     /// Check if it is our turn to test and initiate peer test if so
     void initiate_peer_test();
@@ -177,11 +191,16 @@ class ServiceNode {
     /// Process incoming blob of messages: add to DB if new
     void process_push_batch(const std::string& blob);
 
-    // Attempt to find an answer (message body) to the message test
-    MessageTestStatus process_msg_test_req(uint64_t blk_height,
-                                           const std::string& tester_addr,
-                                           const std::string& msg_hash,
-                                           std::string& answer);
+    /// request blockchain test from a peer
+    void perform_blockchain_test(
+        bc_test_params_t params,
+        std::function<void(blockchain_test_answer_t)>&& cb) const;
+
+    // Attempt to find an answer (message body) to the storage test
+    MessageTestStatus process_storage_test_req(uint64_t blk_height,
+                                               const std::string& tester_addr,
+                                               const std::string& msg_hash,
+                                               std::string& answer);
 
     bool is_pubkey_for_us(const std::string& pk) const;
 

--- a/utils/include/utils.hpp
+++ b/utils/include/utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <random>
 #include <stdint.h>
 #include <string>

--- a/utils/include/utils.hpp
+++ b/utils/include/utils.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <random>
 #include <stdint.h>
 #include <string>

--- a/vendors/loki/crypto-ops/hash-ops.c
+++ b/vendors/loki/crypto-ops/hash-ops.c
@@ -4,7 +4,7 @@ void hash_process(union hash_state *state, const uint8_t *buf, size_t count) {
   keccak1600(buf, count, (uint8_t*)state);
 }
 
-void cn_fast_hash(const void*data, size_t length, char *hash) {
+void cn_fast_hash(const void *data, size_t length, char *hash) {
   union hash_state state;
   hash_process(&state, (const uint8_t *)data, length);
   memcpy(hash, &state, HASH_SIZE);


### PR DESCRIPTION
- uses the same tester/testee pair as in storage testing
- the main difference with storage testing is that the tester has to perform blockchain testing routine asynchronously to compute the answer before sending a test request to testee (storage testing uses a fast synchronous computation in its place).