### PR TITLE
Adjustable PoW difficulty

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -15,6 +15,17 @@
             "cStandard": "c11",
             "cppStandard": "c++17",
             "intelliSenseMode": "clang-x64"
+        },
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/g++",
+            "cStandard": "c11",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "clang-x64"
         }
     ],
     "version": 4

--- a/crypto/include/lokid_key.h
+++ b/crypto/include/lokid_key.h
@@ -1,16 +1,16 @@
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <string>
-#include <array>
 
-namespace loki{
+namespace loki {
 
 constexpr size_t KEY_LENGTH = 32;
 using public_key_t = std::array<uint8_t, KEY_LENGTH>;
 using private_key_t = std::array<uint8_t, KEY_LENGTH>;
 
-struct lokid_key_pair_t{
+struct lokid_key_pair_t {
     private_key_t private_key;
     public_key_t public_key;
 };
@@ -19,4 +19,4 @@ private_key_t parseLokidKey(const std::string& path);
 
 public_key_t calcPublicKey(const private_key_t& private_key);
 
-}
+} // namespace loki

--- a/crypto/include/signature.h
+++ b/crypto/include/signature.h
@@ -18,7 +18,8 @@ struct signature {
 
 hash hash_data(const std::string& data);
 
-signature generate_signature(const hash& prefix_hash, const lokid_key_pair_t& key_pair);
+signature generate_signature(const hash& prefix_hash,
+                             const lokid_key_pair_t& key_pair);
 
 bool check_signature(const std::string& signature, const hash& hash,
                      const std::string& public_key_t_b32z);

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(httpserver PRIVATE OpenSSL::SSL)
 target_link_libraries(httpserver PRIVATE storage)
 target_link_libraries(httpserver PRIVATE utils)
 target_link_libraries(httpserver PRIVATE pow)
+target_link_libraries(httpserver PRIVATE resolv)
 target_link_libraries(httpserver PRIVATE crypto)
 
 set_property(TARGET httpserver PROPERTY CXX_STANDARD 14)

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -619,7 +619,7 @@ void connection_t::process_store(const json& params) {
 #ifndef DISABLE_POW
     if (!validPoW) {
         response_.result(http::status::payment_required);
-        response_.set(http::field::content_type, "text/plain");
+        response_.set(http::field::content_type, "application/json");
 
         json res_body;
         res_body["difficulty"] = service_node_.get_pow_difficulty();
@@ -656,6 +656,10 @@ void connection_t::process_store(const json& params) {
     }
 
     response_.result(http::status::ok);
+    response_.set(http::field::content_type, "application/json");
+    json res_body;
+    res_body["difficulty"] = service_node_.get_pow_difficulty();
+    body_stream_ << res_body.dump();
     BOOST_LOG_TRIVIAL(trace)
         << "Successfully stored message for " << obfuscate_pubkey(pubKey);
 }

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -614,7 +614,8 @@ void connection_t::process_store(const json& params) {
     std::string messageHash;
 
     const bool validPoW =
-        checkPoW(nonce, timestamp, ttl, pubKey, data, messageHash);
+        checkPoW(nonce, timestamp, ttl, pubKey, data, messageHash,
+                 service_node_.get_pow_difficulty());
 #ifndef DISABLE_POW
     if (!validPoW) {
         response_.result(http::status::forbidden);

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -618,10 +618,15 @@ void connection_t::process_store(const json& params) {
                  service_node_.get_pow_difficulty());
 #ifndef DISABLE_POW
     if (!validPoW) {
-        response_.result(http::status::forbidden);
+        response_.result(http::status::payment_required);
         response_.set(http::field::content_type, "text/plain");
-        body_stream_ << "Provided PoW nonce is not valid.\n";
+
+        json res_body;
+        res_body["difficulty"] = service_node_.get_pow_difficulty();
         BOOST_LOG_TRIVIAL(error) << "Forbidden. Invalid PoW nonce " << nonce;
+
+        /// This might throw if not utf-8 endoded
+        body_stream_ << res_body.dump();
         return;
     }
 #endif

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -618,7 +618,7 @@ void connection_t::process_store(const json& params) {
                  service_node_.get_pow_difficulty());
 #ifndef DISABLE_POW
     if (!validPoW) {
-        response_.result(http::status::payment_required);
+        response_.result(432);
         response_.set(http::field::content_type, "application/json");
 
         json res_body;

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -12,7 +12,6 @@
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/program_options.hpp>
 
-#include <resolv.h>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
@@ -21,7 +20,6 @@
 #include <utility> // for std::pair
 #include <vector>
 
-using json = nlohmann::json;
 using namespace service_node;
 namespace po = boost::program_options;
 namespace logging = boost::log;
@@ -174,25 +172,8 @@ int main(int argc, char* argv[]) {
 
         loki::lokid_key_pair_t lokid_key_pair{private_key, public_key};
 
-        int response;
-        unsigned char query_buffer[1024];
-        response = res_query(POW_DIFFICULTY_URL, C_IN, ns_t_txt, query_buffer, sizeof(query_buffer));
-        int pow_difficulty;
-        ns_msg nsMsg;
-        ns_initparse(query_buffer, response, &nsMsg);
-        ns_rr rr;
-        ns_parserr(&nsMsg, ns_s_an, 0, &rr);
-
-        try {
-            const json difficulty_json = json::parse(ns_rr_rdata(rr) + 1, nullptr, false);
-            pow_difficulty = std::stoi(difficulty_json.at("difficulty").get<std::string>());
-        } catch (...) {
-            BOOST_LOG_TRIVIAL(error) << "Failed to retrieve PoW difficulty";
-            return EXIT_FAILURE;
-        }
-
         loki::ServiceNode service_node(ioc, port, lokid_key_pair, db_location,
-                                       lokid_rpc_port, pow_difficulty);
+                                       lokid_rpc_port);
         RateLimiter rate_limiter;
 
         /// Should run http server

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -12,6 +12,7 @@
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/program_options.hpp>
 
+#include <resolv.h>
 #include <cstdlib>
 #include <iomanip>
 #include <iostream>
@@ -20,6 +21,7 @@
 #include <utility> // for std::pair
 #include <vector>
 
+using json = nlohmann::json;
 using namespace service_node;
 namespace po = boost::program_options;
 namespace logging = boost::log;
@@ -171,8 +173,26 @@ int main(int argc, char* argv[]) {
         ChannelEncryption<std::string> channel_encryption(priv);
 
         loki::lokid_key_pair_t lokid_key_pair{private_key, public_key};
+
+        int response;
+        unsigned char query_buffer[1024];
+        response = res_query(POW_DIFFICULTY_URL, C_IN, ns_t_txt, query_buffer, sizeof(query_buffer));
+        int pow_difficulty;
+        ns_msg nsMsg;
+        ns_initparse(query_buffer, response, &nsMsg);
+        ns_rr rr;
+        ns_parserr(&nsMsg, ns_s_an, 0, &rr);
+
+        try {
+            const json difficulty_json = json::parse(ns_rr_rdata(rr) + 1, nullptr, false);
+            pow_difficulty = std::stoi(difficulty_json.at("difficulty").get<std::string>());
+        } catch (...) {
+            BOOST_LOG_TRIVIAL(error) << "Failed to retrieve PoW difficulty";
+            return EXIT_FAILURE;
+        }
+
         loki::ServiceNode service_node(ioc, port, lokid_key_pair, db_location,
-                                       lokid_rpc_port);
+                                       lokid_rpc_port, pow_difficulty);
         RateLimiter rate_limiter;
 
         /// Should run http server

--- a/httpserver/rate_limiter.cpp
+++ b/httpserver/rate_limiter.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 
-
 constexpr uint32_t RateLimiter::BUCKET_SIZE;
 constexpr uint32_t RateLimiter::TOKEN_RATE;
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -38,9 +38,15 @@ int query_pow_difficulty() {
                          sizeof(query_buffer));
     int pow_difficulty;
     ns_msg nsMsg;
-    ns_initparse(query_buffer, response, &nsMsg);
+    if (ns_initparse(query_buffer, response, &nsMsg) == -1) {
+        BOOST_LOG_TRIVIAL(error) << "Failed to retrieve PoW difficulty";
+        return -1;
+    }
     ns_rr rr;
-    ns_parserr(&nsMsg, ns_s_an, 0, &rr);
+    if (ns_parserr(&nsMsg, ns_s_an, 0, &rr) == -1) {
+        BOOST_LOG_TRIVIAL(error) << "Failed to retrieve PoW difficulty";
+        return -1;
+    }
 
     try {
         const json difficulty_json =

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -133,7 +133,7 @@ static std::shared_ptr<request_t> make_push_request(std::string&& data) {
     return make_post_request("/v1/swarms/push", std::move(data));
 }
 
-static bool verify_message(const message_t& msg, const int pow_difficulty,
+static bool verify_message(const message_t& msg, int pow_difficulty,
                            const char** error_message = nullptr) {
     if (!util::validateTTL(msg.ttl)) {
         if (error_message)
@@ -398,7 +398,7 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
 }
 
 void ServiceNode::pow_difficulty_timer_tick() {
-    int new_difficulty = query_pow_difficulty();
+    const int new_difficulty = query_pow_difficulty();
     if (new_difficulty != -1) {
         pow_difficulty_ = new_difficulty;
     }

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -410,7 +410,8 @@ void ServiceNode::swarm_timer_tick() {
         std::bind(&ServiceNode::on_swarm_update, this, std::placeholders::_1);
     request_swarm_update(ioc_, std::move(cb), lokid_rpc_port_);
     swarm_update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
-    swarm_update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));
+    swarm_update_timer_.async_wait(
+        boost::bind(&ServiceNode::swarm_timer_tick, this));
 }
 
 static std::vector<std::shared_ptr<request_t>>

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -13,11 +13,13 @@
 #include <chrono>
 #include <fstream>
 #include <iomanip>
+#include <resolv.h>
 
 #include <boost/beast/core/detail/base64.hpp>
 #include <boost/bind.hpp>
 #include <boost/log/trivial.hpp>
 
+using json = nlohmann::json;
 using service_node::storage::Item;
 using namespace std::chrono_literals;
 
@@ -28,6 +30,29 @@ constexpr std::array<std::chrono::seconds, 6> RETRY_INTERVALS = {
     std::chrono::seconds(1),  std::chrono::seconds(5),
     std::chrono::seconds(10), std::chrono::seconds(20),
     std::chrono::seconds(40), std::chrono::seconds(80)};
+
+int query_pow_difficulty() {
+    int response;
+    unsigned char query_buffer[1024] = {};
+    response = res_query(POW_DIFFICULTY_URL, C_IN, ns_t_txt, query_buffer,
+                         sizeof(query_buffer));
+    int pow_difficulty;
+    ns_msg nsMsg;
+    ns_initparse(query_buffer, response, &nsMsg);
+    ns_rr rr;
+    ns_parserr(&nsMsg, ns_s_an, 0, &rr);
+
+    try {
+        const json difficulty_json =
+            json::parse(ns_rr_rdata(rr) + 1, nullptr, true);
+        pow_difficulty =
+            std::stoi(difficulty_json.at("difficulty").get<std::string>());
+        return pow_difficulty;
+    } catch (...) {
+        BOOST_LOG_TRIVIAL(error) << "Failed to retrieve PoW difficulty";
+        return -1;
+    }
+}
 
 FailedRequestHandler::FailedRequestHandler(boost::asio::io_context& ioc,
                                            const sn_record_t& sn,
@@ -84,6 +109,7 @@ constexpr std::chrono::milliseconds SWARM_UPDATE_INTERVAL = 200ms;
 #else
 constexpr std::chrono::milliseconds SWARM_UPDATE_INTERVAL = 1000ms;
 #endif
+constexpr std::chrono::minutes POW_DIFFICULTY_UPDATE_INTERVAL = 10min;
 constexpr int CLIENT_RETRIEVE_MESSAGE_LIMIT = 10;
 
 static std::shared_ptr<request_t> make_post_request(const char* target,
@@ -120,7 +146,8 @@ static bool verify_message(const message_t& msg, const int pow_difficulty,
     std::string hash;
 #ifndef DISABLE_POW
     if (!checkPoW(msg.nonce, std::to_string(msg.timestamp),
-                  std::to_string(msg.ttl), msg.pub_key, msg.data, hash, pow_difficulty)) {
+                  std::to_string(msg.ttl), msg.pub_key, msg.data, hash,
+                  pow_difficulty)) {
         if (error_message)
             *error_message = "Provided PoW nonce is not valid";
         return false;
@@ -137,10 +164,10 @@ static bool verify_message(const message_t& msg, const int pow_difficulty,
 ServiceNode::ServiceNode(boost::asio::io_context& ioc, uint16_t port,
                          const loki::lokid_key_pair_t& lokid_key_pair,
                          const std::string& db_location,
-                         uint16_t lokid_rpc_port, const int pow_difficulty)
+                         uint16_t lokid_rpc_port)
     : ioc_(ioc), db_(std::make_unique<Database>(ioc, db_location)),
-      update_timer_(ioc), lokid_key_pair_(lokid_key_pair),
-      lokid_rpc_port_(lokid_rpc_port), pow_difficulty_(pow_difficulty) {
+      swarm_update_timer_(ioc), pow_update_timer_(ioc),
+      lokid_key_pair_(lokid_key_pair), lokid_rpc_port_(lokid_rpc_port) {
 
     char buf[64] = {0};
     if (char const* dest =
@@ -156,6 +183,7 @@ ServiceNode::ServiceNode(boost::asio::io_context& ioc, uint16_t port,
 
     BOOST_LOG_TRIVIAL(info) << "Requesting initial swarm state";
     swarm_timer_tick();
+    pow_difficulty_timer_tick();
 }
 
 ServiceNode::~ServiceNode() = default;
@@ -367,12 +395,22 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
     initiate_peer_test();
 }
 
+void ServiceNode::pow_difficulty_timer_tick() {
+    int new_difficulty = query_pow_difficulty();
+    if (new_difficulty != -1) {
+        pow_difficulty_ = new_difficulty;
+    }
+    pow_update_timer_.expires_after(POW_DIFFICULTY_UPDATE_INTERVAL);
+    pow_update_timer_.async_wait(
+        boost::bind(&ServiceNode::pow_difficulty_timer_tick, this));
+}
+
 void ServiceNode::swarm_timer_tick() {
     const swarm_callback_t cb =
         std::bind(&ServiceNode::on_swarm_update, this, std::placeholders::_1);
     request_swarm_update(ioc_, std::move(cb), lokid_rpc_port_);
-    update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
-    update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));
+    swarm_update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
+    swarm_update_timer_.async_wait(boost::bind(&ServiceNode::swarm_timer_tick, this));
 }
 
 static std::vector<std::shared_ptr<request_t>>
@@ -780,9 +818,7 @@ bool ServiceNode::retrieve(const std::string& pubKey,
                          CLIENT_RETRIEVE_MESSAGE_LIMIT);
 }
 
-int ServiceNode::get_pow_difficulty() const {
-    return pow_difficulty_;
-}
+int ServiceNode::get_pow_difficulty() const { return pow_difficulty_; }
 
 bool ServiceNode::get_all_messages(std::vector<Item>& all_entries) const {
 
@@ -805,10 +841,10 @@ void ServiceNode::process_push_batch(const std::string& blob) {
                              << " messages from peers, size: " << blob.size();
 
 #ifndef DISABLE_POW
-    const auto it = std::remove_if(messages.begin(), messages.end(),
-                                   [this](const message_t& message) {
-                                       return verify_message(message, pow_difficulty_) == false;
-                                   });
+    const auto it = std::remove_if(
+        messages.begin(), messages.end(), [this](const message_t& message) {
+            return verify_message(message, pow_difficulty_) == false;
+        });
     messages.erase(it, messages.end());
     if (it != messages.end()) {
         BOOST_LOG_TRIVIAL(warning)

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -34,7 +34,7 @@ constexpr std::array<std::chrono::seconds, 6> RETRY_INTERVALS = {
 int query_pow_difficulty() {
     int response;
     unsigned char query_buffer[1024] = {};
-    response = res_query(POW_DIFFICULTY_URL, C_IN, ns_t_txt, query_buffer,
+    response = res_query(POW_DIFFICULTY_URL, ns_c_in, ns_t_txt, query_buffer,
                          sizeof(query_buffer));
     int pow_difficulty;
     ns_msg nsMsg;
@@ -47,6 +47,8 @@ int query_pow_difficulty() {
             json::parse(ns_rr_rdata(rr) + 1, nullptr, true);
         pow_difficulty =
             std::stoi(difficulty_json.at("difficulty").get<std::string>());
+        BOOST_LOG_TRIVIAL(info)
+            << "Read PoW difficulty: " << std::to_string(pow_difficulty);
         return pow_difficulty;
     } catch (...) {
         BOOST_LOG_TRIVIAL(error) << "Failed to retrieve PoW difficulty";

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -17,6 +17,7 @@
 
 static constexpr uint16_t SNODE_PORT = 8080;
 static constexpr size_t BLOCK_HASH_CACHE_SIZE = 10;
+static constexpr char POW_DIFFICULTY_URL[] = "sentinel.messenger.loki.network";
 
 class Database;
 
@@ -82,6 +83,7 @@ class ServiceNode {
 
     boost::asio::io_context& ioc_;
 
+    int pow_difficulty_ = 100;
     uint64_t block_height_ = 0;
     const uint16_t lokid_rpc_port_;
     std::string block_hash_ = "";
@@ -153,7 +155,8 @@ class ServiceNode {
   public:
     ServiceNode(boost::asio::io_context& ioc, uint16_t port,
                 const loki::lokid_key_pair_t& key_pair,
-                const std::string& db_location, uint16_t lokid_rpc_port);
+                const std::string& db_location, uint16_t lokid_rpc_port,
+                const int pow_difficulty);
 
     ~ServiceNode();
 
@@ -192,6 +195,9 @@ class ServiceNode {
     /// return all messages for a particular PK (in JSON)
     bool get_all_messages(
         std::vector<service_node::storage::Item>& all_entries) const;
+
+    // Return the current PoW difficulty
+    int get_pow_difficulty() const;
 
     bool retrieve(const std::string& pubKey, const std::string& last_hash,
                   std::vector<service_node::storage::Item>& items);

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -50,6 +50,8 @@ struct snode_stats_t {
     uint64_t relay_fails = 0;
 };
 
+int query_pow_difficulty();
+
 /// Represents failed attempt at communicating with a SNode
 /// (currently only for single messages)
 class FailedRequestHandler
@@ -98,7 +100,9 @@ class ServiceNode {
     boost::circular_buffer<std::pair<uint64_t, std::string>>
         block_hashes_cache_{BLOCK_HASH_CACHE_SIZE};
 
-    boost::asio::steady_timer update_timer_;
+    boost::asio::steady_timer pow_update_timer_;
+
+    boost::asio::steady_timer swarm_update_timer_;
 
     /// map pubkeys to a list of connections to be notified
     std::unordered_map<pub_key_t, listeners_t> pk_to_listeners;
@@ -138,6 +142,9 @@ class ServiceNode {
     /// Request swarm structure from the deamon and reset the timer
     void swarm_timer_tick();
 
+    /// Update PoW difficulty from DNS text record
+    void pow_difficulty_timer_tick();
+
     /// Return tester/testee pair based on block_height
     bool derive_tester_testee(uint64_t block_height, sn_record_t& tester,
                               sn_record_t& testee);
@@ -155,8 +162,7 @@ class ServiceNode {
   public:
     ServiceNode(boost::asio::io_context& ioc, uint16_t port,
                 const loki::lokid_key_pair_t& key_pair,
-                const std::string& db_location, uint16_t lokid_rpc_port,
-                const int pow_difficulty);
+                const std::string& db_location, uint16_t lokid_rpc_port);
 
     ~ServiceNode();
 

--- a/pow/include/pow.hpp
+++ b/pow/include/pow.hpp
@@ -3,4 +3,5 @@
 
 bool checkPoW(const std::string& nonce, const std::string& timestamp,
               const std::string& ttl, const std::string& recipient,
-              const std::string& data, std::string& messageHash);
+              const std::string& data, std::string& messageHash,
+              const int& difficulty);

--- a/pow/include/pow.hpp
+++ b/pow/include/pow.hpp
@@ -4,4 +4,4 @@
 bool checkPoW(const std::string& nonce, const std::string& timestamp,
               const std::string& ttl, const std::string& recipient,
               const std::string& data, std::string& messageHash,
-              const int& difficulty);
+              int difficulty);

--- a/pow/src/pow.cpp
+++ b/pow/src/pow.cpp
@@ -38,7 +38,7 @@ bool multWillOverflow(uint64_t left, uint64_t right) {
 bool checkPoW(const std::string& nonce, const std::string& timestamp,
               const std::string& ttl, const std::string& recipient,
               const std::string& data, std::string& messageHash,
-              const int& difficulty) {
+              int difficulty) {
     const std::string payload = timestamp + ttl + recipient + data;
 
     bool overflow = addWillOverflow(payload.size(), BYTE_LEN);

--- a/pow/src/pow.cpp
+++ b/pow/src/pow.cpp
@@ -14,11 +14,6 @@
 #include <string.h>
 
 const int BYTE_LEN = 8;
-#ifdef NDEBUG
-const int NONCE_TRIALS = 100;
-#else
-const int NONCE_TRIALS = 10;
-#endif
 using uint64Bytes = std::array<uint8_t, BYTE_LEN>;
 
 // This enforces that the result array has the most significant byte at index 0
@@ -42,7 +37,8 @@ bool multWillOverflow(uint64_t left, uint64_t right) {
 
 bool checkPoW(const std::string& nonce, const std::string& timestamp,
               const std::string& ttl, const std::string& recipient,
-              const std::string& data, std::string& messageHash) {
+              const std::string& data, std::string& messageHash,
+              const int& difficulty) {
     const std::string payload = timestamp + ttl + recipient + data;
 
     bool overflow = addWillOverflow(payload.size(), BYTE_LEN);
@@ -63,10 +59,10 @@ bool checkPoW(const std::string& nonce, const std::string& timestamp,
     if (overflow)
         return false;
     uint64_t lenPlusInnerFrac = totalLen + innerFrac;
-    overflow = multWillOverflow(NONCE_TRIALS, lenPlusInnerFrac);
+    overflow = multWillOverflow(difficulty, lenPlusInnerFrac);
     if (overflow)
         return false;
-    uint64_t denominator = NONCE_TRIALS * lenPlusInnerFrac;
+    uint64_t denominator = difficulty * lenPlusInnerFrac;
     uint64_t targetNum = std::numeric_limits<uint64_t>::max() / denominator;
 
     uint64Bytes target;

--- a/unit_test/pow.cpp
+++ b/unit_test/pow.cpp
@@ -48,14 +48,14 @@ BOOST_AUTO_TEST_CASE(it_checks_a_valid_pow) {
     using namespace valid_pow;
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW(nonce, timestamp, ttl, pubkey, data, messageHash), true);
+        checkPoW(nonce, timestamp, ttl, pubkey, data, messageHash, 10), true);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_nonce) {
     using namespace valid_pow;
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW("AAAAAAABBCF=", timestamp, ttl, pubkey, data, messageHash),
+        checkPoW("AAAAAAABBCF=", timestamp, ttl, pubkey, data, messageHash, 10),
         false);
 }
 
@@ -63,14 +63,14 @@ BOOST_AUTO_TEST_CASE(it_checks_an_invalid_timestamp) {
     using namespace valid_pow;
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW(nonce, "1549252653", ttl, pubkey, data, messageHash), false);
+        checkPoW(nonce, "1549252653", ttl, pubkey, data, messageHash, 10), false);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_ttl) {
     using namespace valid_pow;
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW(nonce, timestamp, "345601", pubkey, data, messageHash), false);
+        checkPoW(nonce, timestamp, "345601", pubkey, data, messageHash, 10), false);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_pubkey) {
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(it_checks_an_invalid_pubkey) {
     BOOST_CHECK_EQUAL(checkPoW(nonce, timestamp, ttl,
                                "05d5970e75efb8e8daccd4d07f5f59e744c3aea25cec8bf"
                                "a3e43674c4a55875f4c",
-                               data, messageHash),
+                               data, messageHash, 10),
                       false);
 }
 
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(it_checks_an_invalid_data) {
         "ZPfNxSO9T6JvrGzRxofo7edadxn/hqi6dkHU7koHNAjSD2AP==";
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW(nonce, timestamp, ttl, pubkey, wrong_data, messageHash),
+        checkPoW(nonce, timestamp, ttl, pubkey, wrong_data, messageHash, 10),
         false);
 }
 

--- a/unit_test/pow.cpp
+++ b/unit_test/pow.cpp
@@ -63,14 +63,16 @@ BOOST_AUTO_TEST_CASE(it_checks_an_invalid_timestamp) {
     using namespace valid_pow;
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW(nonce, "1549252653", ttl, pubkey, data, messageHash, 10), false);
+        checkPoW(nonce, "1549252653", ttl, pubkey, data, messageHash, 10),
+        false);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_ttl) {
     using namespace valid_pow;
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW(nonce, timestamp, "345601", pubkey, data, messageHash, 10), false);
+        checkPoW(nonce, timestamp, "345601", pubkey, data, messageHash, 10),
+        false);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_pubkey) {


### PR DESCRIPTION
Every 10 mins the snodes will query the sentinel dns text record to get their PoW difficulty (previously NONCE_TRIALS)
Snodes will now send the difficulty with every successful request to allow clients to lower their difficulty if needed
Snodes will now send the difficulty with a 402: payment_required response when the clients provide invalid PoW to allow them to raise their difficulty if needed

Also added a lil bit to vscode settings to make my vscode experience a lil nicer and I think there was a couple straggler clang format changes that weren't caused by my changes

closes #138 