### PR TITLE
Enable SSL for http server

### DIFF
--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -11,7 +11,9 @@ set(HEADER_FILES
     serialization.h
     rate_limiter.h
     ../external/json.hpp
-    https_client.h)
+    https_client.h
+    server_certificates.h
+    )
 
 set(SRC_FILES
     main.cpp

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -10,7 +10,8 @@ set(HEADER_FILES
     service_node.h
     serialization.h
     rate_limiter.h
-    ../external/json.hpp)
+    ../external/json.hpp
+    https_client.h)
 
 set(SRC_FILES
     main.cpp
@@ -19,6 +20,7 @@ set(SRC_FILES
     service_node.cpp
     serialization.cpp
     rate_limiter.cpp
+    https_client.cpp
     )
 
 add_executable(httpserver ${HEADER_FILES} ${SRC_FILES})

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -37,7 +37,7 @@ find_package(Boost
     program_options
 )
 
-target_link_libraries(httpserver PRIVATE OpenSSL::SSL)
+target_link_libraries(httpserver PRIVATE OpenSSL::SSL OpenSSL::Crypto)
 target_link_libraries(httpserver PRIVATE storage)
 target_link_libraries(httpserver PRIVATE utils)
 target_link_libraries(httpserver PRIVATE pow)

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -5,6 +5,7 @@
 #include "pow.hpp"
 #include "rate_limiter.h"
 #include "serialization.h"
+#include "server_certificates.h"
 #include "service_node.h"
 #include "signature.h"
 #include "utils.hpp"
@@ -179,7 +180,8 @@ namespace http_server {
 
 // "Loop" forever accepting new connections.
 static void
-accept_connection(boost::asio::io_context& ioc, tcp::acceptor& acceptor,
+accept_connection(boost::asio::io_context& ioc,
+                  boost::asio::ssl::context& ssl_ctx, tcp::acceptor& acceptor,
                   ServiceNode& sn,
                   ChannelEncryption<std::string>& channel_encryption,
                   RateLimiter& rate_limiter) {
@@ -187,14 +189,15 @@ accept_connection(boost::asio::io_context& ioc, tcp::acceptor& acceptor,
     acceptor.async_accept([&](const error_code& ec, tcp::socket socket) {
         BOOST_LOG_TRIVIAL(trace) << "connection accepted";
         if (!ec)
-            std::make_shared<connection_t>(ioc, std::move(socket), sn,
+            std::make_shared<connection_t>(ioc, ssl_ctx, std::move(socket), sn,
                                            channel_encryption, rate_limiter)
                 ->start();
 
         if (ec)
             log_error(ec);
 
-        accept_connection(ioc, acceptor, sn, channel_encryption, rate_limiter);
+        accept_connection(ioc, ssl_ctx, acceptor, sn, channel_encryption,
+                          rate_limiter);
     });
 }
 
@@ -209,22 +212,27 @@ void run(boost::asio::io_context& ioc, std::string& ip, uint16_t port,
 
     tcp::acceptor acceptor{ioc, {address, port}};
 
-    accept_connection(ioc, acceptor, sn, channel_encryption, rate_limiter);
+    ssl::context ssl_ctx{ssl::context::sslv23};
+
+    load_server_certificate(ssl_ctx);
+
+    accept_connection(ioc, ssl_ctx, acceptor, sn, channel_encryption,
+                      rate_limiter);
 
     ioc.run();
 }
 
 /// ============ connection_t ============
 
-connection_t::connection_t(boost::asio::io_context& ioc, tcp::socket socket,
-                           ServiceNode& sn,
+connection_t::connection_t(boost::asio::io_context& ioc, ssl::context& ssl_ctx,
+                           tcp::socket socket, ServiceNode& sn,
                            ChannelEncryption<std::string>& channel_encryption,
                            RateLimiter& rate_limiter)
-    : ioc_(ioc), socket_(std::move(socket)), service_node_(sn),
-      channel_cipher_(channel_encryption), repeat_timer_(ioc),
-      deadline_(ioc, SESSION_TIME_LIMIT),
-      notification_ctx_({boost::asio::steady_timer{ioc}, boost::none}),
-      rate_limiter_(rate_limiter) {
+    : ioc_(ioc), ssl_ctx_(ssl_ctx), socket_(std::move(socket)),
+      stream_(socket_, ssl_ctx_), service_node_(sn),
+      channel_cipher_(channel_encryption), rate_limiter_(rate_limiter),
+      repeat_timer_(ioc), deadline_(ioc, SESSION_TIME_LIMIT),
+      notification_ctx_({boost::asio::steady_timer{ioc}, boost::none}) {
 
     BOOST_LOG_TRIVIAL(trace) << "connection_t";
 }
@@ -233,6 +241,23 @@ connection_t::~connection_t() { BOOST_LOG_TRIVIAL(trace) << "~connection_t"; }
 
 void connection_t::start() {
     register_deadline();
+    do_handshake();
+}
+
+void connection_t::do_handshake() {
+    // Perform the SSL handshake
+    stream_.async_handshake(ssl::stream_base::server,
+                            std::bind(&connection_t::on_handshake,
+                                      shared_from_this(),
+                                      std::placeholders::_1));
+}
+
+void connection_t::on_handshake(boost::system::error_code ec) {
+    if (ec) {
+        BOOST_LOG_TRIVIAL(warning) << "ssl handshake failed:" << ec.message();
+        return;
+    }
+
     read_request();
 }
 
@@ -276,7 +301,7 @@ void connection_t::read_request() {
         }
     };
 
-    http::async_read(socket_, buffer_, request_, on_data);
+    http::async_read(stream_, buffer_, request_, on_data);
 }
 
 bool connection_t::validate_snode_request() {
@@ -525,8 +550,8 @@ void connection_t::write_response() {
 
     /// This attempts to write all data to a stream
     /// TODO: handle the case when we are trying to send too much
-    http::async_write(socket_, response_, [self](error_code ec, size_t) {
-        self->socket_.shutdown(tcp::socket::shutdown_send, ec);
+    http::async_write(stream_, response_, [self](error_code ec, size_t) {
+        self->do_close();
         self->deadline_.cancel();
     });
 }
@@ -942,6 +967,19 @@ void connection_t::register_deadline() {
             self->socket_.close(ec);
         }
     });
+}
+
+void connection_t::do_close() {
+    // Perform the SSL shutdown
+    stream_.async_shutdown(std::bind(
+        &connection_t::on_shutdown, shared_from_this(), std::placeholders::_1));
+}
+
+void connection_t::on_shutdown(boost::system::error_code ec) {
+    if (ec)
+        BOOST_LOG_TRIVIAL(error) << "Could not close ssl stream gracefully";
+
+    // At this point the connection is closed gracefully
 }
 
 /// ============

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -39,7 +39,6 @@ using error_code = boost::system::error_code;
 
 namespace loki {
 
-constexpr auto SESSION_TIME_LIMIT = std::chrono::seconds(30);
 constexpr auto TEST_RETRY_PERIOD = std::chrono::milliseconds(50);
 
 // Note: on the client side the limit is different

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -975,6 +975,11 @@ void connection_t::do_close() {
 }
 
 void connection_t::on_shutdown(boost::system::error_code ec) {
+    if (ec == boost::asio::error::eof) {
+        // Rationale:
+        // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
+        ec.assign(0, ec.category());
+    }
     if (ec)
         BOOST_LOG_TRIVIAL(error) << "Could not close ssl stream gracefully";
 

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -6,6 +6,7 @@
 
 #include "../external/json.hpp"
 #include <boost/asio.hpp>
+#include <boost/asio/ssl/stream.hpp>
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
@@ -22,6 +23,7 @@ class ChannelEncryption;
 class RateLimiter;
 
 namespace http = boost::beast::http; // from <boost/beast/http.hpp>
+namespace ssl = boost::asio::ssl;    // from <boost/asio/ssl.hpp>
 
 using request_t = http::request<http::string_body>;
 using response_t = http::response<http::string_body>;
@@ -106,12 +108,14 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
 
   private:
     boost::asio::io_context& ioc_;
+    ssl::context& ssl_ctx_;
 
     // The socket for the currently connected client.
     tcp::socket socket_;
 
     // The buffer for performing reads.
     boost::beast::flat_buffer buffer_{8192};
+    ssl::stream<tcp::socket&> stream_;
 
     // The request message.
     request_t request_;
@@ -155,8 +159,8 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     } notification_ctx_;
 
   public:
-    connection_t(boost::asio::io_context& ioc, tcp::socket socket,
-                 ServiceNode& sn,
+    connection_t(boost::asio::io_context& ioc, ssl::context& ssl_ctx,
+                 tcp::socket socket, ServiceNode& sn,
                  ChannelEncryption<std::string>& channel_encryption,
                  RateLimiter& rate_limiter);
 
@@ -171,8 +175,13 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     void reset();
 
   private:
+    void do_handshake();
+    void on_handshake(boost::system::error_code ec);
     /// Asynchronously receive a complete request message.
     void read_request();
+
+    void do_close();
+    void on_shutdown(boost::system::error_code ec);
 
     /// Check the database for new data, reschedule if empty
     void poll_db(const std::string& pk, const std::string& last_hash);

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -50,6 +50,8 @@ struct sn_response_t {
 
 using http_callback_t = std::function<void(sn_response_t)>;
 
+constexpr auto SESSION_TIME_LIMIT = std::chrono::seconds(30);
+
 // TODO: the name should indicate that we are actually trying to send data
 // unlike in `make_post_request`
 void make_http_request(boost::asio::io_context& ioc, const std::string& ip,

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -1,0 +1,204 @@
+#include "https_client.h"
+
+#include <boost/log/trivial.hpp>
+
+namespace loki {
+
+using error_code = boost::system::error_code;
+
+void make_https_request(boost::asio::io_context& ioc,
+                        const std::string& sn_address, uint16_t port,
+                        const std::shared_ptr<request_t>& req,
+                        http_callback_t&& cb) {
+
+    error_code ec;
+    boost::asio::ip::tcp::resolver resolver(ioc);
+#ifdef INTEGRATION_TEST
+    const auto resolve_results =
+        resolver.resolve("0.0.0.0", std::to_string(port), ec);
+#else
+    const auto resolve_results =
+        resolver.resolve(sn_address, std::to_string(port), ec);
+#endif
+    if (ec) {
+        BOOST_LOG_TRIVIAL(error)
+            << "Failed to parse the IP address. Error code = " << ec.value()
+            << ". Message: " << ec.message();
+        return;
+    }
+
+    static ssl::context ctx{ssl::context::sslv23_client};
+
+    auto session = std::make_shared<HttpsClientSession>(
+        ioc, ctx, std::move(resolve_results), req, std::move(cb));
+
+    session->start();
+}
+HttpsClientSession::HttpsClientSession(
+    boost::asio::io_context& ioc, ssl::context& ssl_ctx,
+    tcp::resolver::results_type resolve_results,
+    const std::shared_ptr<request_t>& req, http_callback_t&& cb)
+    : ioc_(ioc), ssl_ctx_(ssl_ctx), resolve_results_(resolve_results),
+      callback_(cb), deadline_timer_(ioc), stream_(ioc, ssl_ctx_), req_(req) {}
+
+void HttpsClientSession::on_connect() {
+    BOOST_LOG_TRIVIAL(trace) << "on connect";
+    stream_.async_handshake(ssl::stream_base::client,
+                            std::bind(&HttpsClientSession::on_handshake,
+                                      shared_from_this(),
+                                      std::placeholders::_1));
+}
+
+void HttpsClientSession::on_handshake(boost::system::error_code ec) {
+    if (ec) {
+        BOOST_LOG_TRIVIAL(error) << "handshake failed:" << ec.message();
+        BOOST_LOG_TRIVIAL(error)
+            << stream_.lowest_layer().remote_endpoint().address() << ":"
+            << stream_.lowest_layer().remote_endpoint().port();
+        return;
+    }
+
+    http::async_write(stream_, *req_,
+                      std::bind(&HttpsClientSession::on_write,
+                                shared_from_this(), std::placeholders::_1,
+                                std::placeholders::_2));
+}
+
+void HttpsClientSession::on_write(error_code ec, size_t bytes_transferred) {
+
+    BOOST_LOG_TRIVIAL(trace) << "on write";
+    if (ec) {
+        BOOST_LOG_TRIVIAL(error) << "Error on write, ec: " << ec.value()
+                                 << ". Message: " << ec.message();
+        trigger_callback(SNodeError::ERROR_OTHER, nullptr);
+        return;
+    }
+
+    BOOST_LOG_TRIVIAL(trace)
+        << "Successfully transferred " << bytes_transferred << " bytes";
+
+    // Receive the HTTP response
+    http::async_read(stream_, buffer_, res_,
+                     std::bind(&HttpsClientSession::on_read, shared_from_this(),
+                               std::placeholders::_1, std::placeholders::_2));
+}
+
+void HttpsClientSession::on_read(error_code ec, size_t bytes_transferred) {
+
+    BOOST_LOG_TRIVIAL(trace)
+        << "Successfully received " << bytes_transferred << " bytes";
+
+    std::shared_ptr<std::string> body = nullptr;
+
+    if (!ec || (ec == http::error::end_of_stream)) {
+
+        if (http::to_status_class(res_.result_int()) ==
+            http::status_class::successful) {
+            body = std::make_shared<std::string>(res_.body());
+        }
+
+    } else {
+
+        /// Do we need to handle `operation aborted` separately here (due to
+        /// deadline timer)?
+        BOOST_LOG_TRIVIAL(error)
+            << "Error on read: " << ec.value() << ". Message: " << ec.message();
+        trigger_callback(SNodeError::ERROR_OTHER, nullptr);
+    }
+
+    // Gracefully close the socket
+    do_close();
+
+    // not_connected happens sometimes so don't bother reporting it.
+    if (ec && ec != boost::system::errc::not_connected) {
+
+        BOOST_LOG_TRIVIAL(error)
+            << "ec: " << ec.value() << ". Message: " << ec.message();
+        return;
+    }
+
+    trigger_callback(SNodeError::NO_ERROR, std::move(body));
+
+    // If we get here then the connection is closed gracefully
+}
+
+void HttpsClientSession::start() {
+    // Set SNI Hostname (many hosts need this to handshake successfully)
+    if (!SSL_set_tlsext_host_name(stream_.native_handle(), "service node")) {
+        boost::beast::error_code ec{static_cast<int>(::ERR_get_error()),
+                                    boost::asio::error::get_ssl_category()};
+        std::cerr << ec.message() << "\n";
+        return;
+    }
+    boost::asio::async_connect(
+        stream_.next_layer(), resolve_results_,
+        [this, self = shared_from_this()](boost::system::error_code ec,
+                                          const tcp::endpoint& endpoint) {
+            /// TODO: I think I should just call again if ec ==
+            /// EINTR
+            if (ec) {
+                BOOST_LOG_TRIVIAL(error)
+                    << boost::format("Could not connect to %1%, "
+                                     "message: %2% (%3%)") %
+                           endpoint % ec.message() % ec.value();
+                trigger_callback(SNodeError::NO_REACH, nullptr);
+                return;
+            }
+
+            self->on_connect();
+        });
+
+    deadline_timer_.expires_after(SESSION_TIME_LIMIT);
+    deadline_timer_.async_wait([self =
+                                    shared_from_this()](const error_code& ec) {
+        if (ec) {
+            if (ec != boost::asio::error::operation_aborted) {
+                BOOST_LOG_TRIVIAL(error) << boost::format("Error(%1%): %2%\n") %
+                                                ec.value() % ec.message();
+            }
+        } else {
+            BOOST_LOG_TRIVIAL(error) << "client socket timed out";
+            self->do_close();
+        }
+    });
+}
+
+void HttpsClientSession::trigger_callback(SNodeError error,
+                                          std::shared_ptr<std::string>&& body) {
+    ioc_.post(std::bind(callback_, sn_response_t{error, body}));
+    used_callback_ = true;
+    deadline_timer_.cancel();
+}
+
+void HttpsClientSession::do_close() {
+    // Gracefully close the stream
+    stream_.async_shutdown(std::bind(&HttpsClientSession::on_shutdown,
+                                     shared_from_this(),
+                                     std::placeholders::_1));
+}
+
+void HttpsClientSession::on_shutdown(boost::system::error_code ec) {
+    if (ec == boost::asio::error::eof) {
+        // Rationale:
+        // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
+        ec.assign(0, ec.category());
+    }
+    if (ec) {
+        BOOST_LOG_TRIVIAL(error)
+            << "could not shutdown stream gracefully: " << ec.message();
+    }
+
+    // If we get here then the connection is closed gracefully
+}
+
+/// We execute callback (if haven't already) here to make sure it is called
+HttpsClientSession::~HttpsClientSession() {
+
+    if (!used_callback_) {
+        // If we destroy the session before posting the callback,
+        // it must be due to some error
+        ioc_.post(std::bind(callback_,
+                            sn_response_t{SNodeError::ERROR_OTHER, nullptr}));
+    }
+}
+} // namespace loki

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -95,6 +95,7 @@ void HttpsClientSession::on_read(error_code ec, size_t bytes_transferred) {
         if (http::to_status_class(res_.result_int()) ==
             http::status_class::successful) {
             body = std::make_shared<std::string>(res_.body());
+            trigger_callback(SNodeError::NO_ERROR, std::move(body));
         }
 
     } else {
@@ -116,8 +117,6 @@ void HttpsClientSession::on_read(error_code ec, size_t bytes_transferred) {
             << "ec: " << ec.value() << ". Message: " << ec.message();
         return;
     }
-
-    trigger_callback(SNodeError::NO_ERROR, std::move(body));
 
     // If we get here then the connection is closed gracefully
 }

--- a/httpserver/https_client.h
+++ b/httpserver/https_client.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "http_connection.h"
+#include <functional>
+
+namespace loki {
+using http_callback_t = std::function<void(sn_response_t)>;
+
+void make_https_request(boost::asio::io_context& ioc, const std::string& ip,
+                        uint16_t port, const std::shared_ptr<request_t>& req,
+                        http_callback_t&& cb);
+
+class HttpsClientSession
+    : public std::enable_shared_from_this<HttpsClientSession> {
+
+    using tcp = boost::asio::ip::tcp;
+
+    boost::asio::io_context& ioc_;
+    ssl::context& ssl_ctx_;
+    tcp::resolver::results_type resolve_results_;
+    http_callback_t callback_;
+    boost::asio::steady_timer deadline_timer_;
+
+    ssl::stream<tcp::socket> stream_;
+    boost::beast::flat_buffer buffer_;
+    /// NOTE: this needs to be a shared pointer since
+    /// it is very common for the same request to be
+    /// sent to multiple snodes
+    std::shared_ptr<request_t> req_;
+    response_t res_;
+
+    bool used_callback_ = false;
+
+    void on_connect();
+
+    void on_write(boost::system::error_code ec, std::size_t bytes_transferred);
+
+    void on_read(boost::system::error_code ec, std::size_t bytes_transferred);
+
+    void trigger_callback(SNodeError error,
+                          std::shared_ptr<std::string>&& body);
+
+    void on_handshake(boost::system::error_code ec);
+
+    void do_close();
+    void on_shutdown(boost::system::error_code ec);
+
+  public:
+    // Resolver and socket require an io_context
+    HttpsClientSession(boost::asio::io_context& ioc, ssl::context& ssl_ctx,
+                       tcp::resolver::results_type resolve_results,
+                       const std::shared_ptr<request_t>& req,
+                       http_callback_t&& cb);
+
+    // initiate the client connection
+    void start();
+
+    ~HttpsClientSession();
+};
+} // namespace loki

--- a/httpserver/rate_limiter.cpp
+++ b/httpserver/rate_limiter.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 
-
 constexpr uint32_t RateLimiter::BUCKET_SIZE;
 constexpr uint32_t RateLimiter::TOKEN_RATE;
 

--- a/httpserver/server_certificates.h
+++ b/httpserver/server_certificates.h
@@ -1,0 +1,254 @@
+#pragma once
+
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/ssl/context.hpp>
+#include <boost/filesystem.hpp>
+
+#include <openssl/conf.h>
+#include <openssl/crypto.h>
+#include <openssl/dh.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509v3.h>
+
+#include <cstddef>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+int callback(int p, int n, void* arg) {
+    char c = 'B';
+
+    if (p == 0)
+        c = '.';
+    if (p == 1)
+        c = '+';
+    if (p == 2)
+        c = '*';
+    if (p == 3)
+        c = '\n';
+    std::cout << c;
+
+    if ((n % 10) == 0)
+        std::cout << std::flush;
+
+    return 1;
+}
+void generate_dh_pem(const char* dh_path) {
+    const int prime_len = 2048;
+    const int generator = DH_GENERATOR_2;
+    DH* dh = DH_new();
+    if (dh == NULL) {
+        printf("Alloc for dh failed\n");
+        ERR_print_errors_fp(stderr);
+        abort();
+    }
+    std::cout << "Generating DH parameter, this might take a while..."
+              << std::endl;
+
+    const int res =
+        DH_generate_parameters_ex(dh, prime_len, generator, nullptr);
+
+    if (!res) {
+        printf("Alloc for dh failed\n");
+        ERR_print_errors_fp(stderr);
+        abort();
+    }
+
+    std::cout << "DH parameter done!" << std::endl;
+    FILE* pFile = NULL;
+    pFile = fopen(dh_path, "wt");
+    PEM_write_DHparams(pFile, dh);
+    fclose(pFile);
+}
+
+/* Add extension using V3 code: we can set the config file as NULL
+ * because we wont reference any other sections.
+ */
+
+int add_ext(X509* cert, int nid, char* value) {
+    X509_EXTENSION* ex;
+    X509V3_CTX ctx;
+    /* This sets the 'context' of the extensions. */
+    /* No configuration database */
+    X509V3_set_ctx_nodb(&ctx);
+    /* Issuer and subject certs: both the target since it is self signed,
+     * no request and no CRL
+     */
+    X509V3_set_ctx(&ctx, cert, cert, NULL, NULL, 0);
+    ex = X509V3_EXT_conf_nid(NULL, &ctx, nid, value);
+    if (!ex)
+        return 0;
+
+    X509_add_ext(cert, ex, -1);
+    X509_EXTENSION_free(ex);
+    return 1;
+}
+
+int mkcert(X509** x509p, EVP_PKEY** pkeyp, int bits, int serial, int days) {
+    X509* x;
+    EVP_PKEY* pk;
+    RSA* rsa;
+    X509_NAME* name = NULL;
+
+    if ((pkeyp == NULL) || (*pkeyp == NULL)) {
+        if ((pk = EVP_PKEY_new()) == NULL) {
+            abort();
+            return (0);
+        }
+    } else
+        pk = *pkeyp;
+
+    if ((x509p == NULL) || (*x509p == NULL)) {
+        if ((x = X509_new()) == NULL)
+            goto err;
+    } else
+        x = *x509p;
+
+    rsa = RSA_generate_key(bits, RSA_F4, NULL, NULL);
+    if (!EVP_PKEY_assign_RSA(pk, rsa)) {
+        abort();
+        goto err;
+    }
+    rsa = NULL;
+
+    X509_set_version(x, 2);
+    ASN1_INTEGER_set(X509_get_serialNumber(x), serial);
+    X509_gmtime_adj(X509_get_notBefore(x), 0);
+    X509_gmtime_adj(X509_get_notAfter(x), (long)60 * 60 * 24 * days);
+    X509_set_pubkey(x, pk);
+
+    name = X509_get_subject_name(x);
+
+    /* This function creates and adds the entry, working out the
+     * correct string type and performing checks on its length.
+     * Normally we'd check the return value for errors...
+     */
+    X509_NAME_add_entry_by_txt(name, "C", MBSTRING_ASC,
+                               (const unsigned char*)"AU", -1, -1, 0);
+    X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                               (const unsigned char*)"localhost", -1, -1, 0);
+    X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC,
+                               (const unsigned char*)"Loki", -1, -1, 0);
+
+    /* Its self signed so set the issuer name to be the same as the
+     * subject.
+     */
+    X509_set_issuer_name(x, name);
+
+    /* Add various extensions: standard extensions */
+    //    add_ext(x, NID_basic_constraints, "critical,CA:FALSE");
+    //    add_ext(x, NID_key_usage, "critical,keyCertSign,cRLSign");
+
+    add_ext(x, NID_subject_key_identifier, (char*)"hash");
+
+    /* Some Netscape specific extensions */
+    //    add_ext(x, NID_netscape_cert_type, "sslCA");
+
+    //    add_ext(x, NID_netscape_comment, "example comment extension");
+
+#ifdef CUSTOM_EXT
+    /* Maybe even add our own extension based on existing */
+    {
+        int nid;
+        nid = OBJ_create("1.2.3.4", "MyAlias", "My Test Alias Extension");
+        X509V3_EXT_add_alias(nid, NID_netscape_comment);
+        add_ext(x, nid, "example comment alias");
+    }
+#endif
+
+    if (!X509_sign(x, pk, EVP_sha256()))
+        goto err;
+
+    *x509p = x;
+    *pkeyp = pk;
+    return (1);
+err:
+    return (0);
+}
+
+void generate_cert(const char* cert_path, const char* key_path) {
+    BIO* bio_err;
+    X509* x509 = NULL;
+    EVP_PKEY* pkey = NULL;
+
+    OpenSSL_add_all_digests();
+
+    CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
+
+    bio_err = BIO_new_fp(stderr, BIO_NOCLOSE);
+
+    mkcert(&x509, &pkey, 2048, 1, 10000);
+
+    //    RSA* rsa = EVP_PKEY_get1_RSA(pkey);
+    //    RSA_print_fp(stdout,rsa,0);
+    X509_print_fp(stdout, x509);
+
+    FILE* key_f = fopen(key_path, "wt");
+    if (!PEM_write_PrivateKey(key_f, pkey, NULL, NULL, 0, NULL, NULL))
+        abort();
+    fclose(key_f);
+    FILE* cert_f = fopen(cert_path, "wt");
+    PEM_write_X509(cert_f, x509);
+    fclose(cert_f);
+
+    X509_free(x509);
+    EVP_PKEY_free(pkey);
+
+    CRYPTO_cleanup_all_ex_data();
+
+    //    CRYPTO_mem_leaks(bio_err);
+    BIO_free(bio_err);
+}
+
+inline void load_server_certificate(boost::asio::ssl::context& ctx) {
+    /*
+        The certificate was generated from CMD.EXE on Windows 10 using:
+
+        winpty openssl dhparam -out dh.pem 2048
+        winpty openssl req -newkey rsa:2048 -nodes -keyout key.pem -x509 -days
+       10000 -out cert.pem -subj "//C=US\ST=CA\L=Los
+       Angeles\O=Beast\CN=www.example.com"
+    */
+    const auto cert_path = "./cert.pem";
+    const auto key_path = "./key.pem";
+    const auto dh_path = "./dh.pem";
+    if (!boost::filesystem::exists(cert_path) ||
+        !boost::filesystem::exists(key_path)) {
+        generate_cert(cert_path, key_path);
+    }
+    if (!boost::filesystem::exists(dh_path)) {
+        generate_dh_pem(dh_path);
+    }
+
+    std::ifstream file(cert_path);
+    const std::string cert((std::istreambuf_iterator<char>(file)),
+                           std::istreambuf_iterator<char>());
+    file.close();
+
+    file.open(key_path);
+    const std::string key((std::istreambuf_iterator<char>(file)),
+                          std::istreambuf_iterator<char>());
+    file.close();
+
+    file.open(dh_path);
+    const std::string dh((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+    file.close();
+
+    ctx.set_password_callback(
+        [](std::size_t, boost::asio::ssl::context_base::password_purpose) {
+            return "test";
+        });
+
+    ctx.set_options(boost::asio::ssl::context::default_workarounds |
+                    boost::asio::ssl::context::no_sslv2 |
+                    boost::asio::ssl::context::single_dh_use);
+
+    ctx.use_certificate_chain(boost::asio::buffer(cert.data(), cert.size()));
+
+    ctx.use_private_key(boost::asio::buffer(key.data(), key.size()),
+                        boost::asio::ssl::context::file_format::pem);
+
+    ctx.use_tmp_dh(boost::asio::buffer(dh.data(), dh.size()));
+}


### PR DESCRIPTION
The ssl stuff is mostly from boost beast async_ssl example.
The certificate generation is mostly from mkcert.c (https://opensource.apple.com/source/OpenSSL/OpenSSL-22/openssl/demos/x509/mkcert.c)

`server_certificate.h` is still pretty rough but as a temporary thing it should be ok.

Note: this PR will break snode to snode requests (httpClientSession needs to use ssl as well). Another PR is coming up for that.