### PR TITLE
Change ssl context to TLS

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -208,7 +208,7 @@ void run(boost::asio::io_context& ioc, std::string& ip, uint16_t port,
 
     tcp::acceptor acceptor{ioc, {address, port}};
 
-    ssl::context ssl_ctx{ssl::context::sslv23};
+    ssl::context ssl_ctx{ssl::context::tlsv12};
 
     load_server_certificate(ssl_ctx);
 

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -27,7 +27,7 @@ void make_https_request(boost::asio::io_context& ioc,
         return;
     }
 
-    static ssl::context ctx{ssl::context::sslv23_client};
+    static ssl::context ctx{ssl::context::tlsv12_client};
 
     auto session = std::make_shared<HttpsClientSession>(
         ioc, ctx, std::move(resolve_results), req, std::move(cb));


### PR DESCRIPTION
tls 1.3 is only available in a newer version of boost, so I sticked to the newest protocol that boost 1.66 supports...