### PR TITLE
Difficulty history

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -2,7 +2,6 @@
 #include "Database.hpp"
 #include "Item.hpp"
 #include "channel_encryption.hpp"
-#include "pow.hpp"
 #include "rate_limiter.h"
 #include "serialization.h"
 #include "server_certificates.h"
@@ -748,10 +747,12 @@ void connection_t::process_store(const json& params) {
 
     // Do not store message if the PoW provided is invalid
     std::string messageHash;
+    const std::vector<pow_difficulty_t> history;
 
     const bool validPoW =
         checkPoW(nonce, timestamp, ttl, pubKey, data, messageHash,
-                 service_node_.get_pow_difficulty());
+                history);
+                //  service_node_.get_pow_difficulty());
 #ifndef DISABLE_POW
     if (!validPoW) {
         response_.result(432);

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -747,19 +747,18 @@ void connection_t::process_store(const json& params) {
 
     // Do not store message if the PoW provided is invalid
     std::string messageHash;
-    const std::vector<pow_difficulty_t> history;
+    const pow_difficulty_t curr_difficulty = service_node_.get_pow_difficulty();
 
-    const bool validPoW =
+    const bool valid_pow =
         checkPoW(nonce, timestamp, ttl, pubKey, data, messageHash,
-                history);
-                //  service_node_.get_pow_difficulty());
+                  std::vector<pow_difficulty_t>{curr_difficulty});
 #ifndef DISABLE_POW
-    if (!validPoW) {
+    if (!valid_pow) {
         response_.result(432);
         response_.set(http::field::content_type, "application/json");
 
         json res_body;
-        res_body["difficulty"] = service_node_.get_pow_difficulty();
+        res_body["difficulty"] = curr_difficulty.difficulty;
         BOOST_LOG_TRIVIAL(error) << "Forbidden. Invalid PoW nonce " << nonce;
 
         /// This might throw if not utf-8 endoded
@@ -795,7 +794,7 @@ void connection_t::process_store(const json& params) {
     response_.result(http::status::ok);
     response_.set(http::field::content_type, "application/json");
     json res_body;
-    res_body["difficulty"] = service_node_.get_pow_difficulty();
+    res_body["difficulty"] = curr_difficulty.difficulty;
     body_stream_ << res_body.dump();
     BOOST_LOG_TRIVIAL(trace)
         << "Successfully stored message for " << obfuscate_pubkey(pubKey);

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -747,18 +747,17 @@ void connection_t::process_store(const json& params) {
 
     // Do not store message if the PoW provided is invalid
     std::string messageHash;
-    const pow_difficulty_t curr_difficulty = service_node_.get_pow_difficulty();
 
     const bool valid_pow =
         checkPoW(nonce, timestamp, ttl, pubKey, data, messageHash,
-                  std::vector<pow_difficulty_t>{curr_difficulty});
+                  service_node_.get_curr_pow_difficulty());
 #ifndef DISABLE_POW
     if (!valid_pow) {
         response_.result(432);
         response_.set(http::field::content_type, "application/json");
 
         json res_body;
-        res_body["difficulty"] = curr_difficulty.difficulty;
+        res_body["difficulty"] = service_node_.get_curr_pow_difficulty();
         BOOST_LOG_TRIVIAL(error) << "Forbidden. Invalid PoW nonce " << nonce;
 
         /// This might throw if not utf-8 endoded
@@ -794,7 +793,7 @@ void connection_t::process_store(const json& params) {
     response_.result(http::status::ok);
     response_.set(http::field::content_type, "application/json");
     json res_body;
-    res_body["difficulty"] = curr_difficulty.difficulty;
+    res_body["difficulty"] = service_node_.get_curr_pow_difficulty();
     body_stream_ << res_body.dump();
     BOOST_LOG_TRIVIAL(trace)
         << "Successfully stored message for " << obfuscate_pubkey(pubKey);

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -5,7 +5,6 @@
 #include "http_connection.h"
 #include "https_client.h"
 #include "lokid_key.h"
-#include "pow.hpp"
 #include "serialization.h"
 #include "signature.h"
 #include "utils.hpp"
@@ -161,10 +160,12 @@ static bool verify_message(const message_t& msg, int pow_difficulty,
         return false;
     }
     std::string hash;
+    const std::vector<pow_difficulty_t> history;
 #ifndef DISABLE_POW
     if (!checkPoW(msg.nonce, std::to_string(msg.timestamp),
                   std::to_string(msg.ttl), msg.pub_key, msg.data, hash,
-                  pow_difficulty)) {
+                  history)) {
+                //   pow_difficulty)) {
         if (error_message)
             *error_message = "Provided PoW nonce is not valid";
         return false;

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -166,9 +166,10 @@ static bool verify_message(const message_t& msg,
     }
     std::string hash;
 #ifndef DISABLE_POW
+    const int difficulty = get_valid_difficulty(std::to_string(msg.timestamp), history);
     if (!checkPoW(msg.nonce, std::to_string(msg.timestamp),
                   std::to_string(msg.ttl), msg.pub_key, msg.data, hash,
-                  history)) {
+                  difficulty)) {
         if (error_message)
             *error_message = "Provided PoW nonce is not valid";
         return false;
@@ -1009,8 +1010,8 @@ bool ServiceNode::retrieve(const std::string& pubKey,
                          CLIENT_RETRIEVE_MESSAGE_LIMIT);
 }
 
-pow_difficulty_t ServiceNode::get_pow_difficulty() const {
-    return curr_pow_difficulty_;
+int ServiceNode::get_curr_pow_difficulty() const {
+    return curr_pow_difficulty_.difficulty;
 }
 
 bool ServiceNode::get_all_messages(std::vector<Item>& all_entries) const {

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -98,7 +98,7 @@ class ServiceNode {
     boost::thread worker_thread_;
 
     pow_difficulty_t curr_pow_difficulty_{std::chrono::milliseconds(0), 100};
-    std::vector<pow_difficulty_t> pow_history_;
+    std::vector<pow_difficulty_t> pow_history_{curr_pow_difficulty_};
 
     uint64_t block_height_ = 0;
     const uint16_t lokid_rpc_port_;
@@ -245,10 +245,8 @@ class ServiceNode {
 
     void
     set_difficulty_history(const std::vector<pow_difficulty_t>& new_history) {
-        curr_pow_difficulty_ =
-            pow_difficulty_t{std::chrono::milliseconds{0}, 1};
         pow_history_ = new_history;
-        for (auto& difficulty : pow_history_) {
+        for (const auto& difficulty : pow_history_) {
             if (curr_pow_difficulty_.timestamp < difficulty.timestamp) {
                 curr_pow_difficulty_ = difficulty;
             }

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -15,6 +15,7 @@
 #include "common.h"
 #include "lokid_key.h"
 #include "swarm.h"
+#include "pow.hpp"
 
 static constexpr size_t BLOCK_HASH_CACHE_SIZE = 10;
 static constexpr char POW_DIFFICULTY_URL[] = "sentinel.messenger.loki.network";

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -238,7 +238,7 @@ class ServiceNode {
         std::vector<service_node::storage::Item>& all_entries) const;
 
     // Return the current PoW difficulty
-    pow_difficulty_t get_pow_difficulty() const;
+    int get_curr_pow_difficulty() const;
 
     bool retrieve(const std::string& pubKey, const std::string& last_hash,
                   std::vector<service_node::storage::Item>& items);

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -59,8 +59,7 @@ struct snode_stats_t {
 using pow_dns_callback_t =
     std::function<void(const std::vector<pow_difficulty_t>&)>;
 
-void query_pow_difficulty(std::vector<pow_difficulty_t>& new_history,
-                          std::error_code& ec);
+std::vector<pow_difficulty_t> query_pow_difficulty(std::error_code& ec);
 
 /// Represents failed attempt at communicating with a SNode
 /// (currently only for single messages)

--- a/pow/CMakeLists.txt
+++ b/pow/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(pow STATIC ${SOURCES})
 
 loki_add_subdirectory(../utils utils)
 
-set_property(TARGET pow PROPERTY CXX_STANDARD 11)
+set_property(TARGET pow PROPERTY CXX_STANDARD 14)
 
 find_package(OpenSSL REQUIRED)
 target_link_libraries(pow PRIVATE OpenSSL::SSL)

--- a/pow/include/pow.hpp
+++ b/pow/include/pow.hpp
@@ -1,7 +1,13 @@
 #include <iostream>
 #include <vector>
+#include <chrono>
+
+struct pow_difficulty_t {
+  std::chrono::milliseconds timestamp;
+  int difficulty;
+};
 
 bool checkPoW(const std::string& nonce, const std::string& timestamp,
               const std::string& ttl, const std::string& recipient,
               const std::string& data, std::string& messageHash,
-              int difficulty);
+              const std::vector<pow_difficulty_t>& difficulty_history);

--- a/pow/include/pow.hpp
+++ b/pow/include/pow.hpp
@@ -1,13 +1,16 @@
+#include <chrono>
 #include <iostream>
 #include <vector>
-#include <chrono>
 
 struct pow_difficulty_t {
-  std::chrono::milliseconds timestamp;
-  int difficulty;
+    std::chrono::milliseconds timestamp;
+    int difficulty;
 };
+
+int get_valid_difficulty(const std::string& timestamp,
+                   const std::vector<pow_difficulty_t>& history);
 
 bool checkPoW(const std::string& nonce, const std::string& timestamp,
               const std::string& ttl, const std::string& recipient,
               const std::string& data, std::string& messageHash,
-              const std::vector<pow_difficulty_t>& difficulty_history);
+              const int difficulty);

--- a/pow/src/pow.cpp
+++ b/pow/src/pow.cpp
@@ -64,7 +64,8 @@ bool calcTarget(const std::string& payload, const uint64_t ttlInt,
     return true;
 }
 
-int get_valid_difficulty(const std::string& timestamp, const std::vector<pow_difficulty_t>& history) {
+int get_valid_difficulty(const std::string& timestamp,
+                         const std::vector<pow_difficulty_t>& history) {
     uint64_t timestamp_long;
     try {
         timestamp_long = std::stoull(timestamp);
@@ -98,7 +99,14 @@ bool checkPoW(const std::string& nonce, const std::string& timestamp,
               const std::string& ttl, const std::string& recipient,
               const std::string& data, std::string& messageHash,
               const int difficulty) {
-    const std::string payload = timestamp + ttl + recipient + data;
+    std::string payload;
+    payload.reserve(timestamp.size() + ttl.size() + recipient.size() +
+                    data.size());
+    payload += timestamp;
+    payload += ttl;
+    payload += recipient;
+    payload += data;
+
     uint64_t ttlInt;
     if (!util::parseTTL(ttl, ttlInt))
         return false;

--- a/pow/src/pow.cpp
+++ b/pow/src/pow.cpp
@@ -39,7 +39,8 @@ bool multWillOverflow(uint64_t left, uint64_t right) {
            (std::numeric_limits<std::uint64_t>::max() / left < right);
 }
 
-bool calcTarget(const std::string& payload, const uint64_t ttlInt, const int difficulty, uint64Bytes& target) {
+bool calcTarget(const std::string& payload, const uint64_t ttlInt,
+                const int difficulty, uint64Bytes& target) {
     bool overflow = addWillOverflow(payload.size(), BYTE_LEN);
     if (overflow)
         return false;
@@ -75,22 +76,20 @@ bool checkPoW(const std::string& nonce, const std::string& timestamp,
         // Should never happen, checked previously
         return false;
     }
-    const auto timestampMilli = std::chrono::milliseconds(timestampLong);
+    const auto msg_timestamp = std::chrono::milliseconds(timestampLong);
 
     int difficulty = std::numeric_limits<int>::max();
     int mostRecentDifficulty = std::numeric_limits<int>::max();
     std::chrono::milliseconds mostRecent(0);
+    const std::chrono::milliseconds lower = msg_timestamp - TIMESTAMP_VARIANCE;
+    const std::chrono::milliseconds upper = msg_timestamp + TIMESTAMP_VARIANCE;
 
     for (auto& thisDifficulty : difficultyHistory) {
         const std::chrono::milliseconds t = thisDifficulty.timestamp;
-        if (t < timestampMilli && t >= mostRecent) {
+        if (t < msg_timestamp && t >= mostRecent) {
             mostRecent = t;
             mostRecentDifficulty = thisDifficulty.difficulty;
         }
-        const std::chrono::milliseconds lower =
-            timestampMilli - TIMESTAMP_VARIANCE;
-        const std::chrono::milliseconds upper =
-            timestampMilli + TIMESTAMP_VARIANCE;
 
         if (t >= lower && t <= upper) {
             difficulty = std::min(thisDifficulty.difficulty, difficulty);

--- a/pow/src/pow.cpp
+++ b/pow/src/pow.cpp
@@ -13,7 +13,11 @@
 #include <sstream>
 #include <string.h>
 
-const int BYTE_LEN = 8;
+using namespace std::chrono_literals;
+
+constexpr int BYTE_LEN = 8;
+constexpr std::chrono::milliseconds TIMESTAMP_VARIANCE = 10min;
+
 using uint64Bytes = std::array<uint8_t, BYTE_LEN>;
 
 // This enforces that the result array has the most significant byte at index 0
@@ -35,20 +39,10 @@ bool multWillOverflow(uint64_t left, uint64_t right) {
            (std::numeric_limits<std::uint64_t>::max() / left < right);
 }
 
-bool checkPoW(const std::string& nonce, const std::string& timestamp,
-              const std::string& ttl, const std::string& recipient,
-              const std::string& data, std::string& messageHash,
-              int difficulty) {
-    const std::string payload = timestamp + ttl + recipient + data;
-
+bool calcTarget(const std::string& payload, const uint64_t ttlInt, const int difficulty, uint64Bytes& target) {
     bool overflow = addWillOverflow(payload.size(), BYTE_LEN);
     if (overflow)
         return false;
-    uint64_t ttlInt;
-    if (!util::parseTTL(ttl, ttlInt))
-        return false;
-    // ttl is in milliseconds, but target calculation wants seconds
-    ttlInt = ttlInt / 1000;
     uint64_t totalLen = payload.size() + BYTE_LEN;
     overflow = multWillOverflow(ttlInt, totalLen);
     if (overflow)
@@ -65,28 +59,69 @@ bool checkPoW(const std::string& nonce, const std::string& timestamp,
     uint64_t denominator = difficulty * lenPlusInnerFrac;
     uint64_t targetNum = std::numeric_limits<uint64_t>::max() / denominator;
 
-    uint64Bytes target;
     u64ToU8Array(targetNum, target);
+    return true;
+}
 
-    uint8_t hashResult[SHA512_DIGEST_LENGTH];
-    // Initial hash
-    SHA512((const unsigned char*)payload.data(), payload.size(), hashResult);
-    // Convert nonce to binary
-    std::string decodedNonce = boost::beast::detail::base64_decode(nonce);
-    // Convert decoded nonce string into uint8_t vector. Will have length 8
-    std::vector<uint8_t> innerPayload;
-    innerPayload.reserve(decodedNonce.size() + SHA512_DIGEST_LENGTH);
-    innerPayload.insert(std::end(innerPayload), std::begin(decodedNonce),
-                        std::end(decodedNonce));
-    innerPayload.insert(std::end(innerPayload), hashResult,
-                        hashResult + SHA512_DIGEST_LENGTH);
-    // Final hash
-    SHA512(innerPayload.data(), innerPayload.size(), hashResult);
-    std::stringstream ss;
-    ss << std::hex << std::setfill('0');
-    for (int i = 0; i < SHA512_DIGEST_LENGTH; i++)
-        ss << std::setw(2) << static_cast<unsigned>(hashResult[i]);
-    messageHash = ss.str();
+bool checkPoW(const std::string& nonce, const std::string& timestamp,
+              const std::string& ttl, const std::string& recipient,
+              const std::string& data, std::string& messageHash,
+              const std::vector<pow_difficulty_t>& difficulty_history) {
 
-    return memcmp(hashResult, target.data(), BYTE_LEN) < 0;
+    uint64_t timestampLong;
+    try {
+        timestampLong = std::stoull(timestamp);
+    } catch (...) {
+        // Should never happen, checked previously
+        return false;
+    }
+    const auto timestampMilli = std::chrono::milliseconds(timestampLong);
+
+    int difficulty = 1;
+
+    std::vector<int> valid_difficulties;
+    for (auto& this_difficulty : difficulty_history) {
+        const std::chrono::milliseconds acceptable_timestamp =
+            this_difficulty.timestamp + TIMESTAMP_VARIANCE;
+        if (timestampMilli < acceptable_timestamp) {
+            valid_difficulties.push_back(this_difficulty.difficulty);
+        }
+    }
+    const std::string payload = timestamp + ttl + recipient + data;
+    uint64_t ttlInt;
+    if (!util::parseTTL(ttl, ttlInt))
+        return false;
+    // ttl is in milliseconds, but target calculation wants seconds
+    ttlInt = ttlInt / 1000;
+    uint64Bytes target;
+
+    for (auto& difficulty : valid_difficulties) {
+        calcTarget(payload, ttlInt, difficulty, target);
+
+        uint8_t hashResult[SHA512_DIGEST_LENGTH];
+        // Initial hash
+        SHA512((const unsigned char*)payload.data(), payload.size(), hashResult);
+        // Convert nonce to binary
+        std::string decodedNonce = boost::beast::detail::base64_decode(nonce);
+        // Convert decoded nonce string into uint8_t vector. Will have length 8
+        std::vector<uint8_t> innerPayload;
+        innerPayload.reserve(decodedNonce.size() + SHA512_DIGEST_LENGTH);
+        innerPayload.insert(std::end(innerPayload), std::begin(decodedNonce),
+                            std::end(decodedNonce));
+        innerPayload.insert(std::end(innerPayload), hashResult,
+                            hashResult + SHA512_DIGEST_LENGTH);
+        // Final hash
+        SHA512(innerPayload.data(), innerPayload.size(), hashResult);
+        std::stringstream ss;
+        ss << std::hex << std::setfill('0');
+        for (int i = 0; i < SHA512_DIGEST_LENGTH; i++)
+            ss << std::setw(2) << static_cast<unsigned>(hashResult[i]);
+        messageHash = ss.str();
+
+        const bool success = memcmp(hashResult, target.data(), BYTE_LEN) < 0;
+        if (success) {
+            return true;
+        }
+    }
+    return false;
 }

--- a/unit_test/pow.cpp
+++ b/unit_test/pow.cpp
@@ -53,43 +53,41 @@ BOOST_AUTO_TEST_CASE(it_checks_a_valid_pow) {
     using namespace valid_pow;
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW(nonce, timestamp, ttl, pubkey, data, messageHash, history),
-        true);
+        checkPoW(nonce, timestamp, ttl, pubkey, data, messageHash, 10), true);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_nonce) {
     using namespace valid_pow;
     std::string messageHash;
-    BOOST_CHECK_EQUAL(checkPoW("AAAAAAABBCF=", timestamp, ttl, pubkey, data,
-                                messageHash, history),
-                      false);
+    BOOST_CHECK_EQUAL(
+        checkPoW("AAAAAAABBCF=", timestamp, ttl, pubkey, data, messageHash, 10),
+        false);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_timestamp) {
     using namespace valid_pow;
     std::string messageHash;
     BOOST_CHECK_EQUAL(
-        checkPoW(nonce, "1549252653", ttl, pubkey, data, messageHash, history),
+        checkPoW(nonce, "1549252653", ttl, pubkey, data, messageHash, 10),
         false);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_ttl) {
     using namespace valid_pow;
     std::string messageHash;
-    BOOST_CHECK_EQUAL(checkPoW(nonce, timestamp, "345601", pubkey, data,
-                                messageHash, history),
-                      false);
+    BOOST_CHECK_EQUAL(
+        checkPoW(nonce, timestamp, "345601", pubkey, data, messageHash, 10),
+        false);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_pubkey) {
     using namespace valid_pow;
     std::string messageHash;
-    BOOST_CHECK_EQUAL(
-        checkPoW(nonce, timestamp, ttl,
-                  "05d5970e75efb8e8daccd4d07f5f59e744c3aea25cec8bf"
-                  "a3e43674c4a55875f4c",
-                  data, messageHash, history),
-        false);
+    BOOST_CHECK_EQUAL(checkPoW(nonce, timestamp, ttl,
+                               "05d5970e75efb8e8daccd4d07f5f59e744c3aea25cec8bf"
+                               "a3e43674c4a55875f4c",
+                               data, messageHash, 10),
+                      false);
 }
 
 BOOST_AUTO_TEST_CASE(it_checks_an_invalid_data) {
@@ -107,51 +105,34 @@ BOOST_AUTO_TEST_CASE(it_checks_an_invalid_data) {
         "gJApKpfGatKZAwdnUeZy+EUTuZnRzvSLOwOL6HsOFvuq4k3gQ5v5+"
         "ZPfNxSO9T6JvrGzRxofo7edadxn/hqi6dkHU7koHNAjSD2AP==";
     std::string messageHash;
-    BOOST_CHECK_EQUAL(checkPoW(nonce, timestamp, ttl, pubkey, wrong_data,
-                                messageHash, history),
-                      false);
+    BOOST_CHECK_EQUAL(
+        checkPoW(nonce, timestamp, ttl, pubkey, wrong_data, messageHash, 10),
+        false);
 }
 
-BOOST_AUTO_TEST_CASE(it_checks_most_recent_difficulty) {
+BOOST_AUTO_TEST_CASE(it_checks_correct_difficulty) {
     using namespace valid_pow;
     std::string messageHash;
     const auto t = std::chrono::milliseconds(1554859211);
     const auto t1 = t - 30min;
     const auto t2 = t - 20min;
 
-    const std::vector<pow_difficulty_t> valid_history{
-        pow_difficulty_t{t1, 1000}, pow_difficulty_t{t2, 10}};
-    BOOST_CHECK_EQUAL(checkPoW(nonce, timestamp, ttl, pubkey, data,
-                                messageHash, valid_history),
-                      true);
-
-    const std::vector<pow_difficulty_t> invalid_history{
-        pow_difficulty_t{t2, 100000}, pow_difficulty_t{t1, 10}};
-    BOOST_CHECK_EQUAL(checkPoW(nonce, timestamp, ttl, pubkey, data,
-                                messageHash, invalid_history),
-                      false);
-}
-
-BOOST_AUTO_TEST_CASE(it_checks_difficulty_in_valid_range) {
-    using namespace valid_pow;
-    std::string messageHash;
-    const auto t = std::chrono::milliseconds(1554859211);
-    const auto t1 = t - 30min;
-    const auto t2 = t + 5min;
-
     const std::vector<pow_difficulty_t> history1{pow_difficulty_t{t1, 1000},
                                                  pow_difficulty_t{t2, 10}};
-    BOOST_CHECK_EQUAL(
-        checkPoW(nonce, timestamp, ttl, pubkey, data, messageHash, history1),
-        true);
+    BOOST_CHECK_EQUAL(get_valid_difficulty(timestamp, history1), 10);
 
-    const auto t3 = t - 5min;
-    const auto t4 = t - 8min;
-    const std::vector<pow_difficulty_t> history2{pow_difficulty_t{t3, 1000},
+    const auto t3 = t - 30min;
+    const auto t4 = t + 5min;
+
+    const std::vector<pow_difficulty_t> history2{pow_difficulty_t{t1, 1000},
+                                                 pow_difficulty_t{t2, 10}};
+    BOOST_CHECK_EQUAL(get_valid_difficulty(timestamp, history2), 10);
+
+    const auto t5 = t - 5min;
+    const auto t6 = t - 8min;
+    const std::vector<pow_difficulty_t> history3{pow_difficulty_t{t3, 1000},
                                                  pow_difficulty_t{t4, 10}};
-    BOOST_CHECK_EQUAL(
-        checkPoW(nonce, timestamp, ttl, pubkey, data, messageHash, history2),
-        true);
+    BOOST_CHECK_EQUAL(get_valid_difficulty(timestamp, history3), 10);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Bit of a chaotic PR
PoW difficulty is now loaded from the DNS record in the format `{"timestamp":difficulty,"timestamp":difficulty}`
This should represent at least the last 4 days of difficulties
When verifying a client message, we always use the most recent difficulty
When verifying messages pushed by other snodes we use the smallest of either: the most recent difficulty in the past OR any difficulty 15 minutes before or after the message timestamp
This is to allow for messages that were accepted by snodes that hadn't updated their difficulty yet
The difficulty timer is handled by the worker thread and then posts the result to the main thread to update the ServiceNode value

Don't know how I feel about passing in length 1 vector for the client verification, just wanted to get it working for now