### PR TITLE
Check header

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -518,15 +518,15 @@ void connection_t::process_request() {
                 return;
             }
 
-            std::string tester_pk;
-#ifndef DISABLE_SNODE_SIGNATURE
-            // Note we know that the header is present because we already
-            // verified the signature (how can we enforce that in code?)
-            tester_pk = header_.at(LOKI_SENDER_SNODE_PUBKEY_HEADER);
-            tester_pk.append(".snode");
-#endif
-
-            this->process_storage_test_req(blk_height, tester_pk, msg_hash);
+            const auto it = header_.find(LOKI_SENDER_SNODE_PUBKEY_HEADER);
+            if (it != header_.end()) {
+                std::string& tester_pk = it->second;
+                tester_pk.append(".snode");
+                this->process_storage_test_req(blk_height, tester_pk, msg_hash);
+            } else {
+                BOOST_LOG_TRIVIAL(warning)
+                    << "Ignoring test request, no pubkey present";
+            }
         } else if (target == "/v1/swarms/blockchain_test") {
             BOOST_LOG_TRIVIAL(debug) << "Got blockchain test request";
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -534,9 +534,12 @@ void ServiceNode::attach_signature(std::shared_ptr<request_t>& request,
     raw_sig.insert(raw_sig.end(), sig.r.begin(), sig.r.end());
 
     const std::string sig_b64 = boost::beast::detail::base64_encode(raw_sig);
-
     request->set(LOKI_SNODE_SIGNATURE_HEADER, sig_b64);
 
+    attach_pubkey(request);
+}
+
+void ServiceNode::attach_pubkey(std::shared_ptr<request_t>& request) const {
     // TODO: store both clean and .snode versions of the address
     std::string stripped = our_address_.address;
     size_t pos = stripped.find(".snode");
@@ -595,6 +598,8 @@ void ServiceNode::send_storage_test_req(const sn_record_t& testee,
     const auto hash = hash_data(req->body());
     const auto signature = generate_signature(hash, lokid_key_pair_);
     attach_signature(req, signature);
+#else
+    attach_pubkey(req);
 #endif
 
     // TODO: Return to using snode address instead of ip
@@ -617,6 +622,8 @@ void ServiceNode::send_blockchain_test_req(const sn_record_t& testee,
     const auto hash = hash_data(req->body());
     const auto signature = generate_signature(hash, lokid_key_pair_);
     attach_signature(req, signature);
+#else
+    attach_pubkey(req);
 #endif
 
     // TODO: Return to using snode address instead of ip

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -147,6 +147,8 @@ class ServiceNode {
     void attach_signature(std::shared_ptr<request_t>& request,
                           const signature& sig) const;
 
+    void attach_pubkey(std::shared_ptr<request_t>& request) const;
+
     /// used on push and on swarm bootstrapping
     void send_sn_request(const std::shared_ptr<request_t>& req,
                          const sn_record_t& address) const;


### PR DESCRIPTION
Still attach the pubkey to test requests if signatures are disabled. Still check for header on the other side if signatures are disabled