### PR TITLE
Provide RPC endpoint for retrieving peer test results and other stats

### DIFF
--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -13,6 +13,7 @@ set(HEADER_FILES
     ../external/json.hpp
     https_client.h
     server_certificates.h
+    stats.h
     )
 
 set(SRC_FILES
@@ -23,6 +24,7 @@ set(SRC_FILES
     serialization.cpp
     rate_limiter.cpp
     https_client.cpp
+    stats.cpp
     )
 
 add_executable(httpserver ${HEADER_FILES} ${SRC_FILES})

--- a/httpserver/common.h
+++ b/httpserver/common.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <ostream>
 
 struct sn_record_t {
     uint16_t port;

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -1,7 +1,7 @@
-#include "http_connection.h"
 #include "Database.hpp"
 #include "Item.hpp"
 #include "channel_encryption.hpp"
+#include "http_connection.h"
 #include "rate_limiter.h"
 #include "serialization.h"
 #include "server_certificates.h"
@@ -588,13 +588,18 @@ void connection_t::process_request() {
         }
 #endif
         else {
-            BOOST_LOG_TRIVIAL(error) << "unknown target: " << target;
+            BOOST_LOG_TRIVIAL(error) << "unknown target for POST: " << target;
             response_.result(http::status::not_found);
         }
         break;
     case http::verb::get:
-        BOOST_LOG_TRIVIAL(error) << "GET requests not supported";
-        response_.result(http::status::bad_request);
+
+        if (target == "/v1/swarms/get_stats") {
+            this->on_get_stats();
+        } else {
+            BOOST_LOG_TRIVIAL(error) << "unknown target for GET: " << target;
+            response_.result(http::status::not_found);
+        }
         break;
     default:
         BOOST_LOG_TRIVIAL(error) << "bad request";
@@ -750,7 +755,7 @@ void connection_t::process_store(const json& params) {
 
     const bool valid_pow =
         checkPoW(nonce, timestamp, ttl, pubKey, data, messageHash,
-                  service_node_.get_curr_pow_difficulty());
+                 service_node_.get_curr_pow_difficulty());
 #ifndef DISABLE_POW
     if (!valid_pow) {
         response_.result(432);
@@ -817,7 +822,8 @@ void connection_t::process_snodes_by_pk(const json& params) {
         return;
     }
 
-    const std::vector<sn_record_t> nodes = service_node_.get_snodes_by_pk(pubKey);
+    const std::vector<sn_record_t> nodes =
+        service_node_.get_snodes_by_pk(pubKey);
     const json res_body = snodes_to_json(nodes);
 
     response_.result(http::status::ok);
@@ -856,7 +862,8 @@ void connection_t::process_retrieve_all() {
 
 void connection_t::handle_wrong_swarm(const std::string& pubKey) {
 
-    const std::vector<sn_record_t> nodes = service_node_.get_snodes_by_pk(pubKey);
+    const std::vector<sn_record_t> nodes =
+        service_node_.get_snodes_by_pk(pubKey);
     const json res_body = snodes_to_json(nodes);
 
     response_.result(http::status::misdirected_request);
@@ -951,6 +958,8 @@ void connection_t::poll_db(const std::string& pk,
 }
 
 void connection_t::process_retrieve(const json& params) {
+
+    service_node_.all_stats_.client_retrieve_requests++;
 
     constexpr const char* fields[] = {"pubKey", "lastHash"};
 
@@ -1080,6 +1089,11 @@ void connection_t::on_shutdown(boost::system::error_code ec) {
         BOOST_LOG_TRIVIAL(error) << "Could not close ssl stream gracefully";
 
     // At this point the connection is closed gracefully
+}
+
+void connection_t::on_get_stats() {
+    this->body_stream_ << service_node_.get_stats();
+    this->response_.result(http::status::ok);
 }
 
 /// ============

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -202,6 +202,9 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     void do_close();
     void on_shutdown(boost::system::error_code ec);
 
+    /// process GET /v1/swarms/get_stats
+    void on_get_stats();
+
     /// Check the database for new data, reschedule if empty
     void poll_db(const std::string& pk, const std::string& last_hash);
 

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -34,6 +34,7 @@ void make_https_request(boost::asio::io_context& ioc,
 
     session->start();
 }
+
 HttpsClientSession::HttpsClientSession(
     boost::asio::io_context& ioc, ssl::context& ssl_ctx,
     tcp::resolver::results_type resolve_results,

--- a/httpserver/server_certificates.h
+++ b/httpserver/server_certificates.h
@@ -162,7 +162,7 @@ void generate_cert(const char* cert_path, const char* key_path) {
 
     mkcert(&x509, &pkey, 2048, 1, 10000);
 
-    X509_print_fp(stdout, x509);
+    // X509_print_fp(stdout, x509);
 
     FILE* key_f = fopen(key_path, "wt");
     if (!PEM_write_PrivateKey(key_f, pkey, NULL, NULL, 0, NULL, NULL))

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -17,6 +17,7 @@
 #include "lokid_key.h"
 #include "pow.hpp"
 #include "swarm.h"
+#include "stats.h"
 
 static constexpr size_t BLOCK_HASH_CACHE_SIZE = 10;
 static constexpr char POW_DIFFICULTY_URL[] = "sentinel.messenger.loki.network";
@@ -50,12 +51,6 @@ class Swarm;
 
 struct signature;
 
-struct snode_stats_t {
-
-    // how many times a single push failed
-    uint64_t relay_fails = 0;
-};
-
 using pow_dns_callback_t =
     std::function<void(const std::vector<pow_difficulty_t>&)>;
 
@@ -72,11 +67,16 @@ class FailedRequestHandler
 
     uint32_t attempt_count_ = 0;
 
+    /// Call this if we give up re-transmitting
+    boost::optional<std::function<void()>> give_up_callback_;
+
     void retry(std::shared_ptr<FailedRequestHandler>&& self);
 
   public:
-    FailedRequestHandler(boost::asio::io_context& ioc, const sn_record_t& sn,
-                         std::shared_ptr<request_t> req);
+    FailedRequestHandler(
+        boost::asio::io_context& ioc, const sn_record_t& sn,
+        std::shared_ptr<request_t> req,
+        boost::optional<std::function<void()>>&& give_up_cb = boost::none);
 
     ~FailedRequestHandler();
     /// Initiates the timer for retrying (which cannot be done directly in
@@ -101,11 +101,9 @@ class ServiceNode {
 
     uint64_t block_height_ = 0;
     const uint16_t lokid_rpc_port_;
-    std::string block_hash_ = "";
+    std::string block_hash_;
     std::unique_ptr<Swarm> swarm_;
     std::unique_ptr<Database> db_;
-    // performance report for other snodes
-    mutable std::unordered_map<sn_record_t, snode_stats_t> snode_report_;
 
     sn_record_t our_address_;
 
@@ -118,6 +116,8 @@ class ServiceNode {
     boost::asio::steady_timer swarm_update_timer_;
 
     boost::asio::steady_timer lokid_ping_timer_;
+
+    boost::asio::steady_timer stats_cleanup_timer_;
 
     /// map pubkeys to a list of connections to be notified
     std::unordered_map<pub_key_t, listeners_t> pk_to_listeners;
@@ -157,6 +157,8 @@ class ServiceNode {
     /// Request swarm structure from the deamon and reset the timer
     void swarm_timer_tick();
 
+    void cleanup_timer_tick();
+
     /// Update PoW difficulty from DNS text record
     void pow_difficulty_timer_tick(const pow_dns_callback_t cb);
 
@@ -194,6 +196,8 @@ class ServiceNode {
                 const std::string& db_location, uint16_t lokid_rpc_port);
 
     ~ServiceNode();
+
+    mutable all_stats_t all_stats_;
 
     // Register a connection as waiting for new data for pk
     void register_listener(const std::string& pk,
@@ -250,6 +254,10 @@ class ServiceNode {
                 curr_pow_difficulty_ = difficulty;
             }
         }
+    }
+
+    std::string get_stats() const {
+        return all_stats_.to_json(true);
     }
 };
 

--- a/httpserver/stats.cpp
+++ b/httpserver/stats.cpp
@@ -2,6 +2,7 @@
 #include "stats.h"
 #include <algorithm>
 #include <iostream>
+#include <chrono>
 
 namespace loki {
 
@@ -34,7 +35,7 @@ std::string all_stats_t::to_json(bool pretty) const {
     return json.dump(indent);
 }
 
-static void cleanup_old(std::vector<test_result_t>& tests, time_t cutoff_time) {
+static void cleanup_old(std::deque<test_result_t>& tests, time_t cutoff_time) {
 
     const auto it = std::find_if(tests.begin(), tests.end(),
                                  [cutoff_time](const test_result_t& res) {

--- a/httpserver/stats.cpp
+++ b/httpserver/stats.cpp
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <chrono>
 
+using namespace std::chrono_literals;
+
 namespace loki {
 
 void to_json(nlohmann::json& j, const test_result_t& val) {
@@ -45,15 +47,14 @@ static void cleanup_old(std::deque<test_result_t>& tests, time_t cutoff_time) {
     tests.erase(tests.begin(), it);
 }
 
-static constexpr auto ROLLING_WINDOW_SIZE = std::chrono::minutes(60);
+static constexpr std::chrono::seconds ROLLING_WINDOW_SIZE = 60min;
 
 void all_stats_t::cleanup() {
 
     using std::chrono::duration_cast;
     using std::chrono::seconds;
 
-    const auto cutoff =
-        reset_time - duration_cast<seconds>(ROLLING_WINDOW_SIZE).count();
+    const auto cutoff = time(nullptr) - ROLLING_WINDOW_SIZE.count();
 
     for (auto& kv : peer_report_) {
 

--- a/httpserver/stats.cpp
+++ b/httpserver/stats.cpp
@@ -1,0 +1,66 @@
+#include "../external/json.hpp"
+#include "stats.h"
+#include <algorithm>
+#include <iostream>
+
+namespace loki {
+
+void to_json(nlohmann::json& j, const test_result_t& val) {
+    j["timestamp"] = time(nullptr);
+    j["success"] = val.success;
+}
+
+std::string all_stats_t::to_json(bool pretty) const {
+
+    nlohmann::json json;
+
+    json["client_store_requests"] = client_store_requests;
+    json["client_retrieve_requests"] = client_retrieve_requests;
+    json["reset_time"] = reset_time;
+
+    nlohmann::json peers;
+
+    for (const auto& kv : peer_report_) {
+        const auto& pubkey = kv.first.address;
+
+        peers[pubkey]["requests_failed"] = kv.second.requests_failed;
+        peers[pubkey]["pushes_failed"] = kv.second.requests_failed;
+        peers[pubkey]["storage_tests"] = kv.second.storage_tests;
+        peers[pubkey]["blockchain_tests"] = kv.second.blockchain_tests;
+    }
+
+    json["peers"] = peers;
+    const int indent = pretty ? 4 : 0;
+    return json.dump(indent);
+}
+
+static void cleanup_old(std::vector<test_result_t>& tests, time_t cutoff_time) {
+
+    const auto it = std::find_if(tests.begin(), tests.end(),
+                                 [cutoff_time](const test_result_t& res) {
+                                     return res.timestamp > cutoff_time;
+                                 });
+
+    tests.erase(tests.begin(), it);
+}
+
+static constexpr auto ROLLING_WINDOW_SIZE = std::chrono::minutes(60);
+
+void all_stats_t::cleanup() {
+
+    using std::chrono::duration_cast;
+    using std::chrono::seconds;
+
+    const auto cutoff =
+        reset_time - duration_cast<seconds>(ROLLING_WINDOW_SIZE).count();
+
+    for (auto& kv : peer_report_) {
+
+        const sn_record_t& sn = kv.first;
+
+        cleanup_old(peer_report_[sn].storage_tests, cutoff);
+        cleanup_old(peer_report_[sn].blockchain_tests, cutoff);
+    }
+}
+
+} // namespace loki

--- a/httpserver/stats.h
+++ b/httpserver/stats.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "common.h"
+#include <unordered_map>
+
+namespace loki {
+
+struct time_entry_t {
+    time_t timestamp;
+};
+
+struct test_result_t {
+    // seconds since Epoch when entry was recorded
+    time_t timestamp;
+    bool success;
+};
+
+// Stats per peer
+struct peer_stats_t {
+
+    // how many times a single request failed
+    uint64_t requests_failed = 0;
+    // how many times a series of push requests failed
+    // causing this node to give up re-transmitting
+    uint64_t pushes_failed = 0;
+
+    std::vector<test_result_t> storage_tests;
+
+    std::vector<test_result_t> blockchain_tests;
+};
+
+class all_stats_t {
+
+    // stats per every peer in our swarm (including former peers)
+    std::unordered_map<sn_record_t, peer_stats_t> peer_report_;
+
+  public:
+    // ===== This node's stats =====
+    uint64_t client_store_requests = 0;
+    uint64_t client_retrieve_requests = 0;
+
+    time_t reset_time = time(nullptr);
+
+    // =============================
+
+    void record_request_failed(const sn_record_t& sn) {
+        peer_report_[sn].requests_failed++;
+    }
+
+    void record_push_failed(const sn_record_t& sn) {
+        peer_report_[sn].pushes_failed++;
+    }
+
+    void record_storage_test_result(const sn_record_t& sn, bool success) {
+        test_result_t res = {std::time(nullptr), success};
+        peer_report_[sn].storage_tests.push_back(res);
+    }
+
+    void record_blockchain_test_result(const sn_record_t& sn, bool success) {
+        test_result_t t = {std::time(nullptr), success};
+        peer_report_[sn].blockchain_tests.push_back(t);
+    }
+
+    // remove old test entries and reset counters, update reset time
+    void cleanup();
+
+    // Convert to a string, add indentations if pretty
+    std::string to_json(bool pretty) const;
+};
+
+} // namespace loki

--- a/httpserver/stats.h
+++ b/httpserver/stats.h
@@ -2,6 +2,8 @@
 
 #include "common.h"
 #include <unordered_map>
+#include <deque>
+#include <ctime>
 
 namespace loki {
 
@@ -24,9 +26,9 @@ struct peer_stats_t {
     // causing this node to give up re-transmitting
     uint64_t pushes_failed = 0;
 
-    std::vector<test_result_t> storage_tests;
+    std::deque<test_result_t> storage_tests;
 
-    std::vector<test_result_t> blockchain_tests;
+    std::deque<test_result_t> blockchain_tests;
 };
 
 class all_stats_t {


### PR DESCRIPTION
Exposes GET `/v1/swarms/get_stats`.

Sample response:
```
{
    "client_store_requests": 10,
    "peers": {
        "hizcwd3jhqe4wi55j1pf6ruz4eb4mesttxrwtcbim4j84qqdh5dy.snode": {
            "blockchain_tests": [],
            "pushes_failed": 0,
            "requests_failed": 0,
            "storage_tests": [
                {
                    "success": true,
                    "timestamp": 1560750454
                }
            ]
        }
    },
    "reset_time": 1560750445,
    "client_retrieve_requests": 0
}
```

`reset_time` - time since last restart (UNIX time, seconds)
`client_store_requests` - number of times got a store request directly from a client
`client_retrieve_requests` - number of times got a retrieve request directly from a client
`peers` - per peer stats:

`blockchain_tests` - a list of blockchain test results from a peer, a single entry is comprised of a boolean `success` to indicate the outcome of the test and `timestamp` in UNIX time for when the test for performed.
`storage_tests` - similar to blockchain testing above but for storage tests
`requests_failed` - number of times a single SN request failed (before trying to retransmit)
`pushes_failed` - number of times a single SN request failed after trying to retransmit a few times (it gave up).




