### PR TITLE
Store both pubkey and snode address per snode

### DIFF
--- a/httpserver/common.h
+++ b/httpserver/common.h
@@ -5,9 +5,39 @@
 #include <vector>
 
 struct sn_record_t {
-    uint16_t port;
-    std::string address; // Snode address
-    std::string ip;      // Snode ip
+
+// our 32 byte pub keys should always be 52 bytes long in base32z
+static constexpr size_t BASE_LEN = 52;
+
+private:
+    uint16_t port_;
+    std::string sn_address_; // Snode address
+    std::string pub_key_;
+    std::string ip_;      // Snode ip
+public:
+    sn_record_t(uint16_t port, const std::string& address, const std::string& ip) : port_(port), ip_(ip) {
+        set_address(address);
+    }
+
+    sn_record_t() = default;
+
+    void set_port(uint16_t port) { port_ = port; }
+
+    /// Set service node's public key in base32z (without .snode part)
+    void set_address(const std::string& addr) {
+
+        if (addr.size() != BASE_LEN)
+            throw std::runtime_error("snode public key has incorrect size");
+
+        sn_address_ = addr;
+        sn_address_.append(".snode");
+        pub_key_ = addr;
+    }
+
+    uint16_t port() const { return port_; }
+    const std::string& sn_address() const { return sn_address_; }
+    const std::string& pub_key() const { return pub_key_; }
+    const std::string& ip() const { return ip_; }
 };
 
 namespace loki {
@@ -37,9 +67,9 @@ template <>
 struct hash<sn_record_t> {
     std::size_t operator()(const sn_record_t& k) const {
 #ifdef INTEGRATION_TEST
-        return hash<uint16_t>{}(k.port);
+        return hash<uint16_t>{}(k.port());
 #else
-        return hash<std::string>{}(k.address);
+        return hash<std::string>{}(k.address());
 #endif
     }
 };
@@ -48,25 +78,25 @@ struct hash<sn_record_t> {
 
 inline bool operator<(const sn_record_t& lhs, const sn_record_t& rhs) {
 #ifdef INTEGRATION_TEST
-    return lhs.port < rhs.port;
+    return lhs.port() < rhs.port();
 #else
-    return lhs.address < rhs.address;
+    return lhs.address() < rhs.address();
 #endif
 }
 
 static std::ostream& operator<<(std::ostream& os, const sn_record_t& sn) {
 #ifdef INTEGRATION_TEST
-    return os << sn.port;
+    return os << sn.port();
 #else
-    return os << sn.address;
+    return os << sn.address();
 #endif
 }
 
 static bool operator==(const sn_record_t& lhs, const sn_record_t& rhs) {
 #ifdef INTEGRATION_TEST
-    return lhs.port == rhs.port;
+    return lhs.port() == rhs.port();
 #else
-    return lhs.address == rhs.address;
+    return lhs.address() == rhs.address();
 #endif
 }
 

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -108,11 +108,11 @@ parse_swarm_update(const std::shared_ptr<std::string>& response_body,
             const swarm_id_t swarm_id =
                 sn_json.at("swarm_id").get<swarm_id_t>();
             std::string snode_address = util::hex64_to_base32z(pubkey);
-            snode_address.append(".snode");
+
             const uint16_t port = sn_json.at("storage_port").get<uint16_t>();
             const std::string snode_ip =
                 sn_json.at("public_ip").get<std::string>();
-            const sn_record_t sn{port, snode_address, snode_ip};
+            const sn_record_t sn{port, std::move(snode_address), std::move(snode_ip)};
 
             swarm_map[swarm_id].push_back(sn);
         }
@@ -680,9 +680,9 @@ json snodes_to_json(const std::vector<sn_record_t>& snodes) {
 
     for (const auto& sn : snodes) {
         json snode;
-        snode["address"] = sn.address;
-        snode["port"] = std::to_string(sn.port);
-        snode["ip"] = sn.ip;
+        snode["address"] = sn.sn_address();
+        snode["port"] = std::to_string(sn.port());
+        snode["ip"] = sn.ip();
         snodes_json.push_back(snode);
     }
 


### PR DESCRIPTION
- eliminates the need to strip the `.snode` part from the address on every request for signing
- makes the API a bit more clear