### PR TITLE
small refactor: use common function for sn-sn calls

### DIFF
--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -232,6 +232,8 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     /// Syncronously (?) process client store/load requests
     void process_client_req();
 
+    void process_swarm_req(boost::string_view target);
+
     // Check whether we have spent enough time on this connection.
     void register_deadline();
 

--- a/httpserver/serialization.cpp
+++ b/httpserver/serialization.cpp
@@ -12,8 +12,6 @@ using service_node::storage::Item;
 
 namespace loki {
 
-/// TODO: use endianness aware serialisation
-// ( boost::native_to_big_inplace? )
 template <typename T>
 static T deserialize_integer(std::string::const_iterator& it) {
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -117,7 +117,6 @@ void FailedRequestHandler::retry(std::shared_ptr<FailedRequestHandler>&& self) {
                                     << "Could not relay one: " << self->sn_
                                     << " (attempt #" << self->attempt_count_
                                     << ")";
-                                /// TODO: record failure here as well?
                                 self->retry(std::move(self));
                             }
                         });
@@ -340,8 +339,6 @@ void ServiceNode::push_message(const message_t& msg) {
 
 /// do this asynchronously on a different thread? (on the same thread?)
 bool ServiceNode::process_store(const message_t& msg) {
-
-    /// TODO: accept messages if they are coming from other service nodes
 
     /// only accept a message if we are in a swarm
     if (!swarm_) {


### PR DESCRIPTION
Makes all "swarms" requests share the same code path that verifies service node signatures before being passed to request-specific handlers. This code will need much more refactoring (like parsing the "target" value into components), but this is a first step.