### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,11 @@ sudo: true
 before_install:
   - ./install-deps-linux.sh
 script:
-  - ls $PWD/deps/openssl
   - >
     PKG_CONFIG_PATH="$PWD/deps/sodium/lib/pkgconfig:$PWD/deps/openssl/lib/pkgconfig"
     OPENSSL_ROOT_DIR="$PWD/deps/openssl"
     BOOST_ROOT="$PWD/deps/boost"
-    make USE_SINGLE_BUILD_DIR=1 VERBOSE=1 OPENSSL_ROOT_DIR="$PWD/deps/openssl"
+    make USE_SINGLE_BUILD_DIR=1 VERBOSE=1
   - ./build/unit_test/Test --log_level=unit_scope
 addons:
   apt:

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,12 @@ MKDIR := mkdir -p $(BUILD_DIR) && cd $(BUILD_DIR)
 
 all:
 	$(MKDIR) && \
-	$(CMAKE) $(TOP_DIR) \
+	$(CMAKE) \
 		-DBoost_USE_STATIC_LIBS=$(BUILD_STATIC) \
 		-DOPENSSL_USE_STATIC_LIBS=$(BUILD_STATIC) \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DBUILD_TESTS=$(BUILD_TESTS) \
-		-DOPENSSL_ROOT_DIR=$(OPENSSL_ROOT_DIR) \
+		$(TOP_DIR) \
 		&& cmake --build .
 
 integration-test:

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.1)
 
 add_definitions(-DDISABLE_ENCRYPTION)
 add_definitions(-DSPDLOG_COMPILED_LIB)

--- a/install-deps-linux.sh
+++ b/install-deps-linux.sh
@@ -3,7 +3,7 @@ set -ex
 mkdir -p deps && cd deps
 # openssl
 openssl_install=$PWD/openssl
-if [ ! -d $openssl_install ]; then
+if [ ! -f $openssl_install/include/openssl/ssl.h ]; then
     wget https://www.openssl.org/source/openssl-1.1.1a.tar.gz
     tar -xf openssl-1.1.1a.tar.gz
     mkdir -p $openssl_install

--- a/vendors/sqlite/CMakeLists.txt
+++ b/vendors/sqlite/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.1)
 
 # Clear polluted flags. For example, -Ofast would not work with sqlite
 unset(CMAKE_C_FLAGS)


### PR DESCRIPTION
EDIT: Finally fixed it!
The real issue was that travis had cached an empty install of openssl (maybe the first time it ran the install script failed). So instead of checking for the `deps/openssl` folder we should check for an actual file e.g. `deps/openssl/include/ssl.h` to determine if openssl is there.