### PR TITLE
Use the new target_height field to determine if lokid is still syncing

### DIFF
--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -398,7 +398,7 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
 
     hardfork_ = bu.hardfork;
 
-    if (syncing_) {
+    if (syncing_ && bu.target_height != 0) {
         syncing_ = bu.height < bu.target_height - 1;
     }
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -225,6 +225,7 @@ bool ServiceNode::snode_ready() {
     bool ready = true;
     ready = ready && hardfork_ >= STORAGE_SERVER_HARDFORK;
     ready = ready && swarm_;
+    ready = ready && !syncing_;
     return ready || force_start_;
 }
 
@@ -397,6 +398,10 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
 
     hardfork_ = bu.hardfork;
 
+    if (syncing_) {
+        syncing_ = bu.height < bu.target_height - 1;
+    }
+
     if (bu.block_hash != block_hash_) {
 
         LOKI_LOG(debug, "new block, height: {}, hash: {}", bu.height,
@@ -494,6 +499,7 @@ parse_swarm_update(const std::shared_ptr<std::string>& response_body,
         }
 
         bu.height = body.at("result").at("height").get<uint64_t>();
+        bu.target_height = body.at("result").at("target_height").get<uint64_t>();
         bu.block_hash = body.at("result").at("block_hash").get<std::string>();
         bu.hardfork = body.at("result").at("hardfork").get<int>();
 
@@ -528,6 +534,7 @@ void ServiceNode::swarm_timer_tick() {
     fields["storage_port"] = true;
     fields["public_ip"] = true;
     fields["height"] = true;
+    fields["target_height"] = true;
     fields["block_hash"] = true;
     fields["hardfork"] = true;
 

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -101,6 +101,7 @@ class ServiceNode {
     std::vector<pow_difficulty_t> pow_history_{curr_pow_difficulty_};
 
     bool force_start_ = false;
+    bool syncing_ = true;
     int hardfork_ = 0;
     uint64_t block_height_ = 0;
     const LokidClient& lokid_client_;

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -26,6 +26,7 @@ using all_swarms_t = std::vector<SwarmInfo>;
 struct block_update_t {
     all_swarms_t swarms;
     uint64_t height;
+    uint64_t target_height;
     std::string block_hash;
     int hardfork;
 };


### PR DESCRIPTION
We don't want to process blocks (testing, pushing messages etc) that we receive while lokid is still syncing