### PR TITLE
Deactivate nodes when they get decommissioned; plus some refactoring

### DIFF
--- a/common/include/loki_common.h
+++ b/common/include/loki_common.h
@@ -119,3 +119,5 @@ static bool operator!=(const sn_record_t& lhs, const sn_record_t& rhs) {
 }
 
 using swarm_id_t = uint64_t;
+
+constexpr swarm_id_t INVALID_SWARM_ID = UINT64_MAX;

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -457,7 +457,7 @@ void connection_t::process_request() {
     switch (request_.method()) {
     case http::verb::post:
         if (!service_node_.snode_ready()) {
-            LOKI_LOG(error, "Ignoring post request: snode not ready");
+            LOKI_LOG(debug, "Ignoring post request: snode not ready");
             break;
         }
         if (target == "/storage_rpc/v1") {

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]) {
     LOKI_LOG(info, "Setting log level to {}", options.log_level);
     LOKI_LOG(info, "Setting database location to {}", options.data_dir);
     LOKI_LOG(info, "Setting Lokid key path to {}", options.lokid_key_path);
-    LOKI_LOG(info, "Setting lokid RPC port to {}", options.lokid_rpc_port);
+    LOKI_LOG(info, "Setting Lokid RPC port to {}", options.lokid_rpc_port);
     LOKI_LOG(info, "Listening at address {} port {}", options.ip, options.port);
 
     boost::asio::io_context ioc{1};

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -225,7 +225,7 @@ ServiceNode::ServiceNode(boost::asio::io_context& ioc,
 bool ServiceNode::snode_ready() {
     bool ready = true;
     ready = ready && hardfork_ >= STORAGE_SERVER_HARDFORK;
-    ready = ready && swarm_;
+    ready = ready && swarm_ && swarm_->is_valid();
     ready = ready && !syncing_;
     return ready || force_start_;
 }
@@ -392,10 +392,6 @@ void ServiceNode::save_bulk(const std::vector<Item>& items) {
 }
 
 void ServiceNode::on_swarm_update(const block_update_t& bu) {
-    if (!swarm_) {
-        LOKI_LOG(info, "Initialized our swarm");
-        swarm_ = std::make_unique<Swarm>(our_address_);
-    }
 
     hardfork_ = bu.hardfork;
 
@@ -403,12 +399,18 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
         syncing_ = bu.height < bu.target_height - 1;
     }
 
+    /// We don't have anything to do until we have synced
+    if (syncing_) {
+        LOKI_LOG(debug, "Still syncing: {}/{}", bu.height, bu.target_height);
+        return;
+    }
+
     if (bu.block_hash != block_hash_) {
 
         LOKI_LOG(debug, "new block, height: {}, hash: {}", bu.height,
                  bu.block_hash);
 
-        if (bu.height > block_height_ + 1) {
+        if (bu.height > block_height_ + 1 && block_height_ != 0) {
             LOKI_LOG(warn, "Skipped some block(s), old: {} new: {}",
                      block_height_, bu.height);
             /// TODO: if we skipped a block, should we try to run peer tests for
@@ -429,11 +431,22 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
         return;
     }
 
-    const SwarmEvents events = swarm_->update_swarms(bu.swarms);
+    if (!swarm_) {
+        LOKI_LOG(info, "Initialized our swarm");
+        swarm_ = std::make_unique<Swarm>(our_address_);
+    }
+
+    const SwarmEvents events = swarm_->derive_swarm_events(bu.swarms);
+
+    swarm_->set_swarm_id(events.our_swarm_id);
 
     if (!snode_ready()) {
+        LOKI_LOG(warn, "Service Node is still not ready");
         return;
     }
+
+    swarm_->update_state(bu.swarms, events);
+
     if (!events.new_snodes.empty()) {
         bootstrap_peers(events.new_snodes);
     }
@@ -465,13 +478,13 @@ static block_update_t
 parse_swarm_update(const std::shared_ptr<std::string>& response_body) {
 
     if (!response_body) {
-        LOKI_LOG(error, "Bad lokid rpc response: no response body");
+        LOKI_LOG(error, "Bad Lokid rpc response: no response body");
         throw std::runtime_error("Failed to parse swarm update");
     }
     const json body = json::parse(*response_body, nullptr, false);
     if (body.is_discarded()) {
         LOKI_LOG(trace, "Response body: {}", *response_body);
-        LOKI_LOG(error, "Bad lokid rpc response: invalid json");
+        LOKI_LOG(error, "Bad Lokid rpc response: invalid json");
         throw std::runtime_error("Failed to parse swarm update");
     }
     std::map<swarm_id_t, std::vector<sn_record_t>> swarm_map;
@@ -506,7 +519,7 @@ parse_swarm_update(const std::shared_ptr<std::string>& response_body) {
 
     } catch (...) {
         LOKI_LOG(trace, "swarm repsonse: {}", body.dump(2));
-        LOKI_LOG(error, "Bad lokid rpc response: invalid json fields");
+        LOKI_LOG(error, "Bad Lokid rpc response: invalid json fields");
         throw std::runtime_error("Failed to parse swarm update");
     }
 
@@ -576,16 +589,16 @@ void ServiceNode::lokid_ping_timer_tick() {
 
                 if (res_json.at("result").at("status").get<std::string>() ==
                     "OK") {
-                    LOKI_LOG(info, "Successfully pinged lokid");
+                    LOKI_LOG(info, "Successfully pinged Lokid");
                 } else {
-                    LOKI_LOG(info, "PING status is NOT OK");
+                    LOKI_LOG(error, "Could not ping Lokid: status is NOT OK");
                 }
             } catch (...) {
-                LOKI_LOG(error, "Bad json");
+                LOKI_LOG(error, "Could not ping Lokid: bad json in response");
             }
 
         } else {
-            LOKI_LOG(warn, "Could not ping lokid");
+            LOKI_LOG(warn, "Could not ping Lokid");
         }
     };
 
@@ -614,7 +627,7 @@ void ServiceNode::perform_blockchain_test(
     bc_test_params_t test_params,
     std::function<void(blockchain_test_answer_t)>&& cb) const {
 
-    LOKI_LOG(debug, "Delegating blockchain test to lokid");
+    LOKI_LOG(debug, "Delegating blockchain test to Lokid");
 
     nlohmann::json params;
 
@@ -630,7 +643,7 @@ void ServiceNode::perform_blockchain_test(
         const json body = json::parse(*resp.body, nullptr, false);
 
         if (body.is_discarded()) {
-            LOKI_LOG(error, "Bad lokid rpc response: invalid json");
+            LOKI_LOG(error, "Bad Lokid rpc response: invalid json");
             return;
         }
 
@@ -903,7 +916,7 @@ bool ServiceNode::select_random_message(Item& item) {
         return false;
     }
 
-    LOKI_LOG(info, "total messages: {}", message_count);
+    LOKI_LOG(debug, "total messages: {}", message_count);
 
     if (message_count == 0) {
         LOKI_LOG(warn, "No messages in the database to initiate a peer test");
@@ -946,7 +959,7 @@ void ServiceNode::initiate_peer_test() {
         // 2.1. Select a message
         Item item;
         if (!this->select_random_message(item)) {
-            LOKI_LOG(error, "Could not select a message for testing");
+            LOKI_LOG(warn, "Could not select a message for testing");
         } else {
             LOKI_LOG(trace, "Selected random message: {}, {}", item.hash,
                      item.data);
@@ -1108,7 +1121,7 @@ void ServiceNode::relay_messages(const std::vector<storage::Item>& messages,
     }
 #endif
 
-    LOKI_LOG(info, "Serialised batches: {}", data.size());
+    LOKI_LOG(debug, "Serialised batches: {}", data.size());
     for (const sn_record_t& sn : snodes) {
         for (const std::shared_ptr<request_t>& batch : batches) {
             send_sn_request(batch, sn);

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -19,7 +19,7 @@
 #include "stats.h"
 #include "swarm.h"
 
-static constexpr size_t BLOCK_HASH_CACHE_SIZE = 10;
+static constexpr size_t BLOCK_HASH_CACHE_SIZE = 20;
 static constexpr char POW_DIFFICULTY_URL[] = "sentinel.messenger.loki.network";
 static constexpr int STORAGE_SERVER_HARDFORK = 12;
 

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -36,6 +36,8 @@ swarm_id_t get_swarm_by_pk(const std::vector<SwarmInfo>& all_swarms,
 
 struct SwarmEvents {
 
+    /// our (potentially new) swarm id
+    swarm_id_t our_swarm_id;
     /// whether our swarm got decommissioned and we
     /// need to salvage our stale data
     bool decommissioned = false;
@@ -43,11 +45,13 @@ struct SwarmEvents {
     std::vector<swarm_id_t> new_swarms;
     /// detected new snodes in our swarm
     std::vector<sn_record_t> new_snodes;
+    /// our swarm members 
+    std::vector<sn_record_t> our_swarm_members;
 };
 
 class Swarm {
 
-    swarm_id_t cur_swarm_id_ = UINT64_MAX;
+    swarm_id_t cur_swarm_id_ = INVALID_SWARM_ID;
     std::vector<SwarmInfo> all_cur_swarms_;
     sn_record_t our_address_;
     std::vector<sn_record_t> swarm_peers_;
@@ -57,8 +61,11 @@ class Swarm {
 
     ~Swarm();
 
-    /// Update swarms and work out the changes
-    SwarmEvents update_swarms(const all_swarms_t& swarms);
+    /// Extract relevant information from incoming swarm composition
+    SwarmEvents derive_swarm_events(const all_swarms_t& swarms) const;
+
+    /// Update swarm state according to `events`
+    void update_state(const all_swarms_t& swarms, const SwarmEvents& events);
 
     bool is_pubkey_for_us(const std::string& pk) const;
 
@@ -67,6 +74,10 @@ class Swarm {
     const std::vector<SwarmInfo>& all_swarms() const { return all_cur_swarms_; }
 
     swarm_id_t our_swarm_id() const { return cur_swarm_id_; }
+
+    bool is_valid() const { return cur_swarm_id_ != INVALID_SWARM_ID; }
+
+    void set_swarm_id(swarm_id_t sid);
 };
 
 } // namespace loki


### PR DESCRIPTION
- nodes are active (i.e. they do work) only while they are in the latest swarm list
- only print messages about changes in swarms when we are active
- a bit of refactoring in how swarm updates are applied (still passes integration tests)