### PR TITLE
Add a cmake install target

### DIFF
--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SRC_FILES
     )
 
 add_executable(httpserver ${HEADER_FILES} ${SRC_FILES})
+install(TARGETS httpserver DESTINATION bin)
 
 loki_add_subdirectory(../storage storage)
 loki_add_subdirectory(../utils utils)


### PR DESCRIPTION
This allows `make install` to work to install the httpserver binary from
a cmake build dir (and won't affect anything if you don't do such a
`make install`).