### PR TITLE
Unit test for command line parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,20 +8,6 @@ function(LOKI_ADD_SUBDIRECTORY SRC)
     add_subdirectory(${SRC} ${ARGN})
 endfunction()
 
-# Build Info
-execute_process(
-    COMMAND
-        git rev-parse --short HEAD
-    OUTPUT_VARIABLE
-        SHORT_HASH
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-string(TIMESTAMP BUILD_TIME UTC)
-message(STATUS "using git commit hash ${SHORT_HASH}")
-message(STATUS "using UTC build time ${BUILD_TIME}")
-add_definitions(-DSTORAGE_SERVER_GIT_HASH_STRING="${SHORT_HASH}")
-add_definitions(-DSTORAGE_SERVER_BUILD_TIME="${BUILD_TIME}")
-#
-
 project(storage_server)
 
 option(INTEGRATION_TEST "build for integration test" OFF)

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -31,8 +31,7 @@ set(SRC_FILES
     command_line.cpp
     )
 
-add_executable(httpserver ${HEADER_FILES} ${SRC_FILES})
-install(TARGETS httpserver DESTINATION bin)
+add_library(httpserver_lib STATIC ${HEADER_FILES} ${SRC_FILES})
 
 loki_add_subdirectory(../common common)
 loki_add_subdirectory(../storage storage)
@@ -49,15 +48,35 @@ find_package(Boost
     program_options
 )
 
-target_link_libraries(httpserver PRIVATE common)
-target_link_libraries(httpserver PRIVATE OpenSSL::SSL OpenSSL::Crypto)
-target_link_libraries(httpserver PRIVATE storage)
-target_link_libraries(httpserver PRIVATE utils)
-target_link_libraries(httpserver PRIVATE pow)
-target_link_libraries(httpserver PRIVATE resolv)
-target_link_libraries(httpserver PRIVATE crypto)
+target_link_libraries(httpserver_lib PUBLIC common)
+target_link_libraries(httpserver_lib PUBLIC OpenSSL::SSL OpenSSL::Crypto)
+target_link_libraries(httpserver_lib PUBLIC storage)
+target_link_libraries(httpserver_lib PUBLIC utils)
+target_link_libraries(httpserver_lib PUBLIC pow)
+target_link_libraries(httpserver_lib PUBLIC resolv)
+target_link_libraries(httpserver_lib PUBLIC crypto)
 
+set_property(TARGET httpserver_lib PROPERTY CXX_STANDARD 14)
+
+target_include_directories(httpserver_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS})
+target_link_libraries(httpserver_lib PUBLIC ${Boost_LIBRARIES})
+
+
+
+add_executable(httpserver main.cpp)
 set_property(TARGET httpserver PROPERTY CXX_STANDARD 14)
-
-target_include_directories(httpserver PRIVATE ${Boost_INCLUDE_DIRS})
-target_link_libraries(httpserver PRIVATE ${Boost_LIBRARIES})
+target_link_libraries(httpserver PRIVATE httpserver_lib)
+install(TARGETS httpserver DESTINATION bin)
+# Build Info
+execute_process(
+    COMMAND
+        git rev-parse --short HEAD
+    OUTPUT_VARIABLE
+        SHORT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+string(TIMESTAMP BUILD_TIME UTC)
+message(STATUS "using git commit hash ${SHORT_HASH}")
+message(STATUS "using UTC build time ${BUILD_TIME}")
+target_compile_definitions(httpserver PRIVATE -DSTORAGE_SERVER_GIT_HASH_STRING="${SHORT_HASH}")
+target_compile_definitions(httpserver PRIVATE -DSTORAGE_SERVER_BUILD_TIME="${BUILD_TIME}")
+#

--- a/httpserver/command_line.cpp
+++ b/httpserver/command_line.cpp
@@ -11,20 +11,6 @@ namespace loki {
 namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
-static boost::optional<fs::path> get_home_dir() {
-
-    /// TODO: support default dir for Windows
-#ifdef WIN32
-    return boost::none;
-#endif
-
-    char* pszHome = getenv("HOME");
-    if (pszHome == NULL || strlen(pszHome) == 0)
-        return boost::none;
-
-    return fs::path(pszHome);
-}
-
 const command_line_options& command_line_parser::get_options() const {
     return options_;
 }
@@ -74,12 +60,9 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
     if (fs::exists(config_file)) {
         po::store(po::parse_config_file<char>(config_file.c_str(), all), vm);
         po::notify(vm);
-    }
-
-    if (!vm.count("data-dir")) {
-        if (auto home_dir = get_home_dir()) {
-            options_.data_dir = (home_dir.get() / ".loki" / "storage").string();
-        }
+    } else if (vm.count("config-file")) {
+        throw std::runtime_error(
+            "path provided in --config-file does not exist");
     }
 
     if (options_.print_version || options_.print_help) {

--- a/httpserver/command_line.h
+++ b/httpserver/command_line.h
@@ -14,7 +14,7 @@ struct command_line_options {
     std::string ip;
     std::string log_level = "info";
     std::string lokid_key_path;
-    std::string data_dir = ".";
+    std::string data_dir;
 };
 
 class command_line_parser {

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -7,9 +7,7 @@ add_executable (Test
     serialization.cpp
     signature.cpp
     rate_limiter.cpp
-    # TODO: remove once httpserver provides a static lib to link against
-    ../httpserver/serialization.cpp
-    ../httpserver/rate_limiter.cpp
+    command_line.cpp
 )
 
 # library under test
@@ -19,12 +17,9 @@ loki_add_subdirectory(../storage storage)
 loki_add_subdirectory(../pow pow)
 loki_add_subdirectory(../utils utils)
 loki_add_subdirectory(../crypto crypto)
+loki_add_subdirectory(../httpserver httpserver)
 
-target_link_libraries(Test PRIVATE common storage pow utils crypto)
-target_include_directories(Test
-    PRIVATE
-    ../httpserver
-)
+target_link_libraries(Test PRIVATE common storage pow utils crypto httpserver_lib)
 
 # boost
 find_package(Boost REQUIRED

--- a/unit_test/command_line.cpp
+++ b/unit_test/command_line.cpp
@@ -1,0 +1,145 @@
+#include "command_line.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <array>
+
+BOOST_AUTO_TEST_SUITE(server_command_line)
+
+BOOST_AUTO_TEST_CASE(it_throws_when_no_args) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver"};
+    BOOST_CHECK_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                        const_cast<char**>(argv)),
+                      std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(it_throws_when_no_port) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0"};
+    BOOST_CHECK_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                        const_cast<char**>(argv)),
+                      std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(it_throws_when_no_port_with_flag) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "--force-start", "0.0.0.0"};
+    BOOST_CHECK_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                        const_cast<char**>(argv)),
+                      std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(it_throws_unknown_arg) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80", "--covfefe"};
+    BOOST_CHECK_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                        const_cast<char**>(argv)),
+                      std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_help) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "--help"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.print_help, true);
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_version) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "--version"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.print_version, true);
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_force_start) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80", "--force-start"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.force_start, true);
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_ip_and_port) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.ip, "0.0.0.0");
+    BOOST_CHECK_EQUAL(options.port, 80);
+}
+
+BOOST_AUTO_TEST_CASE(it_throw_with_invalid_port) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0",
+                          "8O"}; // notice the O instead of 0
+    BOOST_CHECK_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                        const_cast<char**>(argv)),
+                      std::exception);
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_lokid_rpc_port) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80", "--lokid-rpc-port",
+                          "12345"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.lokid_rpc_port, 12345);
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_lokid_key) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80", "--lokid-key",
+                          "foobar"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.lokid_key_path, "foobar");
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_data_dir) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80", "--data-dir",
+                          "foobar"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.data_dir, "foobar");
+}
+
+BOOST_AUTO_TEST_CASE(it_returns_default_data_dir) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.data_dir, "");
+}
+
+BOOST_AUTO_TEST_CASE(it_parses_log_levels) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80", "--log-level",
+                          "foobar"};
+    BOOST_CHECK_NO_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                           const_cast<char**>(argv)));
+    const auto options = parser.get_options();
+    BOOST_CHECK_EQUAL(options.log_level, "foobar");
+}
+
+BOOST_AUTO_TEST_CASE(it_throws_with_config_file_not_found) {
+    loki::command_line_parser parser;
+    const char* argv[] = {"httpserver", "0.0.0.0", "80", "--config-file",
+                          "foobar"};
+    BOOST_CHECK_THROW(parser.parse_args(sizeof(argv) / sizeof(char*),
+                                        const_cast<char**>(argv)),
+                      std::exception);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Moved the git hash/timestamp execution form top-level CmakeLists to httpserver CmakeLists to prevent full recompile when running `make`
- Build static lib with httpserver logic and link it against main and unit test
- Moved logic (`get_home_dir`) out of `command_line_parser` (keep it dumb)
- Add unit tests for command line parser