### PR TITLE
Bootstrap ips

### DIFF
--- a/common/include/loki_common.h
+++ b/common/include/loki_common.h
@@ -26,6 +26,7 @@ struct sn_record_t {
 
     sn_record_t() = default;
 
+    void set_ip(const std::string& ip) { ip_ = ip; }
     void set_port(uint16_t port) { port_ = port; }
 
     /// Set service node's public key in base32z (without .snode part)

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -103,7 +103,8 @@ void LokidClient::make_lokid_request(boost::string_view method,
                                      const nlohmann::json& params,
                                      http_callback_t&& cb) const {
 
-    make_lokid_request(local_ip_, lokid_rpc_port_, method, params, std::move(cb));
+    make_lokid_request(local_ip_, lokid_rpc_port_, method, params,
+                       std::move(cb));
 }
 
 void LokidClient::make_lokid_request(const std::string& daemon_ip,
@@ -205,7 +206,8 @@ connection_t::~connection_t() {
 
     // Safety net
     if (stream_.lowest_layer().is_open()) {
-        LOKI_LOG(warn, "Client socket should be closed by this point, but wasn't. Closing now.");
+        LOKI_LOG(warn, "Client socket should be closed by this point, but "
+                       "wasn't. Closing now.");
         stream_.lowest_layer().close();
     }
 
@@ -990,13 +992,12 @@ void connection_t::register_deadline() {
 
     auto self = shared_from_this();
 
-
     deadline_.async_wait([self](error_code ec) {
-
         bool cancelled = (ec && ec == boost::asio::error::operation_aborted);
 
         if (ec && !cancelled) {
-            LOKI_LOG(error, "Deadline timer error [{}]: {}", ec.value(), ec.message());
+            LOKI_LOG(error, "Deadline timer error [{}]: {}", ec.value(),
+                     ec.message());
         } else {
             LOKI_LOG(error, "[connection_t] socket timed out");
         }
@@ -1098,19 +1099,21 @@ void HttpClientSession::on_read(error_code ec, size_t bytes_transferred) {
 }
 
 void HttpClientSession::start() {
-    socket_.async_connect(
-        endpoint_, [this, self = shared_from_this()](const error_code& ec) {
-            /// TODO: I think I should just call again if ec == EINTR
-            if (ec) {
-                LOKI_LOG(error, "[http client]: could not connect to {}:{}, message: {} ({})",
-                         endpoint_.address().to_string(), endpoint_.port(),
-                         ec.message(), ec.value());
-                trigger_callback(SNodeError::NO_REACH, nullptr);
-                return;
-            }
+    socket_.async_connect(endpoint_, [this, self = shared_from_this()](
+                                         const error_code& ec) {
+        /// TODO: I think I should just call again if ec == EINTR
+        if (ec) {
+            LOKI_LOG(
+                error,
+                "[http client]: could not connect to {}:{}, message: {} ({})",
+                endpoint_.address().to_string(), endpoint_.port(), ec.message(),
+                ec.value());
+            trigger_callback(SNodeError::NO_REACH, nullptr);
+            return;
+        }
 
-            self->on_connect();
-        });
+        self->on_connect();
+    });
 
     deadline_timer_.expires_after(SESSION_TIME_LIMIT);
     deadline_timer_.async_wait(

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -103,6 +103,15 @@ void LokidClient::make_lokid_request(boost::string_view method,
                                      const nlohmann::json& params,
                                      http_callback_t&& cb) const {
 
+    make_lokid_request(local_ip_, lokid_rpc_port_, method, params, std::move(cb));
+}
+
+void LokidClient::make_lokid_request(const std::string& daemon_ip,
+                                     const uint16_t daemon_port,
+                                     boost::string_view method,
+                                     const nlohmann::json& params,
+                                     http_callback_t&& cb) const {
+
     auto req = std::make_shared<request_t>();
 
     const std::string target = "/json_rpc";
@@ -120,7 +129,7 @@ void LokidClient::make_lokid_request(boost::string_view method,
 
     LOKI_LOG(trace, "Making lokid request, method: {}", method.to_string());
 
-    make_http_request(ioc_, local_ip_, lokid_rpc_port_, req, std::move(cb));
+    make_http_request(ioc_, daemon_ip, daemon_port, req, std::move(cb));
 }
 // =============================================================
 

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -70,6 +70,11 @@ class LokidClient {
     void make_lokid_request(boost::string_view method,
                             const nlohmann::json& params,
                             http_callback_t&& cb) const;
+    void make_lokid_request(const std::string& daemon_ip,
+                            const uint16_t daemon_port,
+                            boost::string_view method,
+                            const nlohmann::json& params,
+                            http_callback_t&& cb) const;
 };
 
 constexpr auto SESSION_TIME_LIMIT = std::chrono::seconds(30);

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -296,9 +296,9 @@ void ServiceNode::bootstrap_data() {
     params["fields"] = fields;
 
     std::vector<std::pair<std::string, uint16_t>> seed_nodes{
-        std::pair<std::string, uint16_t>{"3.104.19.14", 22023},
-        std::pair<std::string, uint16_t>{"13.238.53.205", 38157},
-        std::pair<std::string, uint16_t>{"149.56.148.124", 38157}};
+        {{"3.104.19.14", 22023},
+         {"13.238.53.205", 38157},
+         {"149.56.148.124", 38157}}};
 
     for (auto seed_node : seed_nodes) {
         lokid_client_.make_lokid_request(
@@ -314,6 +314,9 @@ void ServiceNode::bootstrap_data() {
                             "Exception caught while bootstrapping from {}: {}",
                             seed_node.first, e.what());
                     }
+                } else {
+                    LOKI_LOG(error, "Failed to contact bootstrap node {}",
+                             seed_node.first);
                 }
             });
     }
@@ -488,10 +491,7 @@ void ServiceNode::save_bulk(const std::vector<Item>& items) {
     reset_listeners();
 }
 
-void ServiceNode::on_sync_complete() {
-
-    bootstrap_data();
-}
+void ServiceNode::on_sync_complete() { bootstrap_data(); }
 
 void ServiceNode::on_bootstrap_update(const block_update_t& bu) {
 

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -140,6 +140,8 @@ class ServiceNode {
 
     void on_swarm_update(const block_update_t& bu);
 
+    void bootstrap_ips();
+
     void bootstrap_peers(const std::vector<sn_record_t>& peers) const;
 
     void bootstrap_swarms(const std::vector<swarm_id_t>& swarms) const;

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -138,9 +138,13 @@ class ServiceNode {
     /// request swarm info from the blockchain
     void update_swarms();
 
+    void on_sync_complete();
+
+    void on_bootstrap_update(const block_update_t& bu);
+
     void on_swarm_update(const block_update_t& bu);
 
-    void bootstrap_ips();
+    void bootstrap_data();
 
     void bootstrap_peers(const std::vector<sn_record_t>& peers) const;
 

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -112,7 +112,7 @@ void Swarm::set_swarm_id(swarm_id_t sid) {
 static std::unordered_map<std::string, sn_record_t>
 get_snode_map_from_swarms(const all_swarms_t& swarms) {
 
-    std::unordered_map<std::string, sn_record_t> snode_map{};
+    std::unordered_map<std::string, sn_record_t> snode_map;
     for (const auto& swarm : swarms) {
         for (const auto& snode : swarm.snodes) {
             snode_map.insert({snode.sn_address(), snode});
@@ -122,7 +122,7 @@ get_snode_map_from_swarms(const all_swarms_t& swarms) {
 }
 
 static all_swarms_t apply_ips(const all_swarms_t& swarms_to_keep,
-                       const all_swarms_t& other_swarms) {
+                              const all_swarms_t& other_swarms) {
 
     all_swarms_t result_swarms = swarms_to_keep;
     const auto other_snode_map = get_snode_map_from_swarms(other_swarms);
@@ -131,8 +131,8 @@ static all_swarms_t apply_ips(const all_swarms_t& swarms_to_keep,
             const auto other_snode_it =
                 other_snode_map.find(snode.sn_address());
             if (other_snode_it != other_snode_map.end()) {
-                const auto other_snode = other_snode_it->second;
-                // Keep all swarms_to_keep except don't overwrite with default IPs
+                const auto& other_snode = other_snode_it->second;
+                // Keep swarms_to_keep but don't overwrite with default IPs
                 if (snode.ip() == "0.0.0.0") {
                     snode.set_ip(other_snode.ip());
                 }

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -67,6 +67,10 @@ class Swarm {
     /// Update swarm state according to `events`
     void update_state(const all_swarms_t& swarms, const SwarmEvents& events);
 
+    void bootstrap_state(const all_swarms_t& bootstrap_swarms);
+
+    void apply_swarm_changes(const all_swarms_t& new_swarms);
+
     bool is_pubkey_for_us(const std::string& pk) const;
 
     const std::vector<sn_record_t>& other_nodes() const;


### PR DESCRIPTION
Diff smaller than it looks, had to move parse_swarm_update higher but didn't touch it
We are waiting for lokid to be finished syncing, then we (only once) make 3 requests to the 3 seed nodes and replace any default ips we have with valid ips from these nodes
Since lokid now stores the ips in the database this is more useful for new nodes, but our current check for if we have finished syncing is bugged so we can use the bootstrap nodes to improve this in a future PR

Haven't been able to test this as thoroughly as I would have liked since lokid now stores IPs in the database so might try and write some tests