### PR TITLE
Add the number of active connections of each type in get_stats

### DIFF
--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -16,6 +16,7 @@ set(HEADER_FILES
     stats.h
     security.h
     command_line.h
+    net_stats.h
     )
 
 set(SRC_FILES

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -1,6 +1,7 @@
 #include "https_client.h"
 #include "loki_logger.h"
 #include "signature.h"
+#include "net_stats.h"
 
 #include <openssl/x509.h>
 
@@ -73,7 +74,10 @@ HttpsClientSession::HttpsClientSession(
     const std::string& sn_pubkey_b32z)
     : ioc_(ioc), ssl_ctx_(ssl_ctx), resolve_results_(resolve_results),
       callback_(cb), deadline_timer_(ioc), stream_(ioc, ssl_ctx_), req_(req),
-      server_pub_key_b32z(sn_pubkey_b32z) {}
+      server_pub_key_b32z(sn_pubkey_b32z) {
+
+          get_net_stats().https_connections_out++;
+      }
 
 void HttpsClientSession::start() {
     // Set SNI Hostname (many hosts need this to handshake successfully)
@@ -263,5 +267,7 @@ HttpsClientSession::~HttpsClientSession() {
         ioc_.post(std::bind(callback_,
                             sn_response_t{SNodeError::ERROR_OTHER, nullptr}));
     }
+
+    get_net_stats().https_connections_out--;
 }
 } // namespace loki

--- a/httpserver/net_stats.h
+++ b/httpserver/net_stats.h
@@ -1,0 +1,13 @@
+#pragma once
+
+struct net_stats_t {
+
+    uint32_t connections_in = 0;
+    uint32_t http_connections_out = 0;
+    uint32_t https_connections_out = 0;
+};
+
+inline net_stats_t& get_net_stats() {
+    static net_stats_t stats;
+    return stats;
+}

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -10,6 +10,7 @@
 #include "signature.h"
 #include "utils.hpp"
 #include "version.h"
+#include "net_stats.h"
 
 #include <algorithm>
 #include <chrono>
@@ -1332,6 +1333,15 @@ std::string ServiceNode::get_stats() const {
     val["version"] = STORAGE_SERVER_VERSION_STRING;
     val["height"] = block_height_;
     val["target_height"] = target_height_;
+
+    uint64_t total_stored;
+    if (db_->get_message_count(total_stored)) {
+        val["total_stored"] = total_stored;
+    }
+
+    val["connections_in"] = get_net_stats().connections_in;
+    val["http_connections_out"] = get_net_stats().http_connections_out;
+    val["https_connections_out"] = get_net_stats().https_connections_out;
 
     /// we want pretty (indented) json, but might change that in the future
     constexpr bool PRETTY = true;


### PR DESCRIPTION
- return the number of open connections of each type (assuming connections are closed by the time the constructor is called)
- return the number of currently stored messages