### PR TITLE
Clean up log messages

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -2,9 +2,17 @@ cmake_minimum_required(VERSION 3.1)
 
 add_definitions(-DSPDLOG_COMPILED_LIB)
 
-add_library(common STATIC
+set(SRC_FILES
     src/loki_logger.cpp
 )
+
+set(HEADER_FILES
+    include/loki_common.h
+    include/loki_logger.h
+    include/dev_sink.h
+)
+
+add_library(common STATIC ${HEADER_FILES} ${SRC_FILES})
 
 find_package(Boost
     REQUIRED

--- a/common/include/dev_sink.h
+++ b/common/include/dev_sink.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <iostream>
+#include <spdlog/sinks/base_sink.h>
+#include <vector>
+// A sink used to store most important logs for developers
+
+namespace loki {
+
+template <typename Mutex>
+class dev_sink : public spdlog::sinks::base_sink<Mutex> {
+
+    // Potentially all entries will be returned in a
+    // single message, so we should keep the limit
+    // relatively small
+    static constexpr size_t BUFFER_SIZE = 100;
+    static constexpr size_t MAX_ENTRIES = 2 * BUFFER_SIZE;
+
+    std::vector<std::string> primary_buffer_;
+    std::vector<std::string> secondary_buffer_;
+    // size_t log_entires
+
+  protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        fmt::memory_buffer formatted;
+        spdlog::sinks::sink::formatter_->format(msg, formatted);
+
+        if (primary_buffer_.size() >= BUFFER_SIZE) {
+            secondary_buffer_ = std::move(primary_buffer_);
+            primary_buffer_.clear();
+        }
+
+        primary_buffer_.push_back(fmt::to_string(formatted));
+    }
+
+    void flush_() override {
+        // no op
+    }
+
+  public:
+    dev_sink() : spdlog::sinks::base_sink<Mutex>() {
+        primary_buffer_.reserve(BUFFER_SIZE);
+        secondary_buffer_.reserve(BUFFER_SIZE);
+    }
+
+    std::vector<std::string> peek() {
+
+        std::lock_guard<Mutex> lock{this->mutex_};
+
+        std::vector<std::string> result;
+        result.reserve(MAX_ENTRIES);
+
+        for (auto it = primary_buffer_.end() - 1;
+             it >= primary_buffer_.begin() && result.size() < MAX_ENTRIES;
+             --it) {
+            result.push_back(*it);
+        }
+
+        for (auto it = secondary_buffer_.end() - 1;
+             it >= secondary_buffer_.begin() && result.size() < MAX_ENTRIES;
+             --it) {
+            result.push_back(*it);
+        }
+
+        return result;
+    }
+};
+
+#include <mutex>
+using dev_sink_mt = dev_sink<std::mutex>;
+
+} // namespace loki

--- a/common/include/loki_logger.h
+++ b/common/include/loki_logger.h
@@ -2,11 +2,16 @@
 
 #include "spdlog/spdlog.h"
 
-#define LOKI_LOG_N(LVL, msg, ...) spdlog::get("loki_logger")->LVL("[{}] " msg, __func__, __VA_ARGS__)
-#define LOKI_LOG_2(LVL, msg) spdlog::get("loki_logger")->LVL("[{}] " msg, __func__);
+#define LOKI_LOG_N(LVL, msg, ...)                                              \
+    spdlog::get("loki_logger")->LVL("[{}] " msg, __func__, __VA_ARGS__)
+#define LOKI_LOG_2(LVL, msg)                                                   \
+    spdlog::get("loki_logger")->LVL("[{}] " msg, __func__);
 
 #define GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, NAME, ...) NAME
-#define LOKI_LOG(...) GET_MACRO(__VA_ARGS__, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_2)(__VA_ARGS__)
+#define LOKI_LOG(...)                                                          \
+    GET_MACRO(__VA_ARGS__, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_N,     \
+              LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_N, LOKI_LOG_2)                  \
+    (__VA_ARGS__)
 
 namespace loki {
 using LogLevelPair = std::pair<std::string, spdlog::level::level_enum>;
@@ -19,6 +24,7 @@ static const LogLevelMap logLevelMap{
     {"info", LogLevel::info},
     {"warning", LogLevel::warn},
     {"error", LogLevel::err},
+    {"critical", LogLevel::critical}
 };
 // clang-format on
 

--- a/common/src/loki_logger.cpp
+++ b/common/src/loki_logger.cpp
@@ -62,7 +62,7 @@ void init_logging(const std::string& data_dir,
 
     auto developer_sink = std::make_shared<loki::dev_sink_mt>();
 
-    /// IMPORTANT: get_logs endpoint makes assumes that sink #3 is a dev sink
+    /// IMPORTANT: get_logs endpoint assumes that sink #3 is a dev sink
     std::vector<spdlog::sink_ptr> sinks = {console_sink, file_sink,
                                            developer_sink};
 

--- a/common/src/loki_logger.cpp
+++ b/common/src/loki_logger.cpp
@@ -3,6 +3,7 @@
 // clang-format off
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include "spdlog/sinks/rotating_file_sink.h"
+#include "dev_sink.h"
 // clang-format on
 #include <boost/filesystem.hpp>
 
@@ -59,11 +60,18 @@ void init_logging(const std::string& data_dir,
         log_location, LOG_FILE_SIZE_LIMIT, EXTRA_FILES);
     file_sink->set_level(log_level);
 
-    std::vector<spdlog::sink_ptr> sinks = {console_sink, file_sink};
+    auto developer_sink = std::make_shared<loki::dev_sink_mt>();
+
+    /// IMPORTANT: get_logs endpoint makes assumes that sink #3 is a dev sink
+    std::vector<spdlog::sink_ptr> sinks = {console_sink, file_sink,
+                                           developer_sink};
 
     auto logger = std::make_shared<spdlog::logger>("loki_logger", sinks.begin(),
                                                    sinks.end());
     logger->set_level(log_level);
+    logger->flush_on(spdlog::level::err);
+
+    developer_sink->set_level(spdlog::level::warn);
     spdlog::register_logger(logger);
     spdlog::flush_every(std::chrono::seconds(1));
 

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -2,6 +2,7 @@
 #include "Database.hpp"
 #include "Item.hpp"
 #include "channel_encryption.hpp"
+#include "dev_sink.h"
 #include "rate_limiter.h"
 #include "security.h"
 #include "serialization.h"
@@ -562,6 +563,8 @@ void connection_t::process_request() {
 
         if (target == "/get_stats/v1") {
             this->on_get_stats();
+        } else if (target == "/get_logs/v1") {
+            this->on_get_logs();
         } else {
             LOKI_LOG(debug, "unknown target for GET: {}", target.to_string());
             response_.result(http::status::not_found);
@@ -1086,6 +1089,38 @@ void connection_t::on_shutdown(boost::system::error_code ec) {
 
 void connection_t::on_get_stats() {
     this->body_stream_ << service_node_.get_stats();
+    this->response_.result(http::status::ok);
+}
+
+void connection_t::on_get_logs() {
+
+    /// Limit this call to 1 request per second
+    static time_t last_req_time = 0;
+    const time_t now = time(nullptr);
+    constexpr time_t PERIOD = 1;
+
+    if (now - last_req_time < PERIOD) {
+        this->body_stream_ << "Too many request, try again later.";
+        this->response_.result(http::status::too_many_requests);
+        return;
+    }
+
+    last_req_time = now;
+
+    auto dev_sink = dynamic_cast<loki::dev_sink_mt*>(
+        spdlog::get("loki_logger")->sinks()[2].get());
+
+    if (dev_sink == nullptr) {
+        LOKI_LOG(critical, "Sink #3 should be dev sink");
+        assert(false);
+        this->body_stream_ << "Developer error: sink #3 is not a dev sink.";
+        this->response_.result(http::status::not_implemented);
+        return;
+    }
+
+    nlohmann::json val;
+    val["entries"] = dev_sink->peek();
+    this->body_stream_ << val.dump(4);
     this->response_.result(http::status::ok);
 }
 

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -218,6 +218,9 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     /// process GET /get_stats/v1
     void on_get_stats();
 
+    /// process GET /get_logs/v1; only returns errors atm
+    void on_get_logs();
+
     /// Check the database for new data, reschedule if empty
     void poll_db(const std::string& pk, const std::string& last_hash);
 

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -51,18 +51,18 @@ void make_https_request(boost::asio::io_context& ioc,
 static std::string x509_to_string(X509* x509) {
     BIO* bio_out = BIO_new(BIO_s_mem());
     if (!bio_out) {
-        LOKI_LOG(error, "Could not allocate openssl BIO");
+        LOKI_LOG(critical, "Could not allocate openssl BIO");
         return "";
     }
     if (!PEM_write_bio_X509(bio_out, x509)) {
-        LOKI_LOG(error, "Could not write x509 cert to openssl BIO");
+        LOKI_LOG(critical, "Could not write x509 cert to openssl BIO");
         return "";
     }
     BUF_MEM* bio_buf;
     BIO_get_mem_ptr(bio_out, &bio_buf);
     std::string pem = std::string(bio_buf->data, bio_buf->length);
     if (!BIO_free(bio_out)) {
-        LOKI_LOG(error, "Could not free openssl BIO");
+        LOKI_LOG(critical, "Could not free openssl BIO");
     }
     return pem;
 }
@@ -84,7 +84,7 @@ void HttpsClientSession::start() {
     if (!SSL_set_tlsext_host_name(stream_.native_handle(), "service node")) {
         boost::beast::error_code ec{static_cast<int>(::ERR_get_error()),
                                     boost::asio::error::get_ssl_category()};
-        LOKI_LOG(error, "{}", ec.message());
+        LOKI_LOG(critical, "{}", ec.message());
         return;
     }
     boost::asio::async_connect(
@@ -94,7 +94,9 @@ void HttpsClientSession::start() {
             /// TODO: I think I should just call again if ec ==
             /// EINTR
             if (ec) {
-                LOKI_LOG(error,
+                /// Don't forget to print the error from where we call this!
+                /// (similar to http)
+                LOKI_LOG(debug,
                          "[https client]: could not connect to {}:{}, message: "
                          "{} ({})",
                          endpoint.address().to_string(), endpoint.port(),
@@ -111,10 +113,13 @@ void HttpsClientSession::start() {
         [self = shared_from_this()](const error_code& ec) {
             if (ec) {
                 if (ec != boost::asio::error::operation_aborted) {
-                    LOKI_LOG(error, "Error({}): {}", ec.value(), ec.message());
+                    LOKI_LOG(error,
+                             "Deadline timer failed in https client session "
+                             "[{}: {}]",
+                             ec.value(), ec.message());
                 }
             } else {
-                LOKI_LOG(error, "client socket timed out");
+                LOKI_LOG(warn, "client socket timed out");
                 self->do_close();
             }
         });
@@ -195,7 +200,7 @@ void HttpsClientSession::on_read(error_code ec, size_t bytes_transferred) {
             http::status_class::successful) {
 
             if (!verify_signature()) {
-                LOKI_LOG(error, "Bad signature from {}", server_pub_key_b32z);
+                LOKI_LOG(debug, "Bad signature from {}", server_pub_key_b32z);
                 trigger_callback(SNodeError::ERROR_OTHER, nullptr);
                 return;
             }

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char* argv[]) {
     }
 
     if (options.ip == "127.0.0.1") {
-        LOKI_LOG(error, "Tried to bind loki-storage to localhost, please bind "
+        LOKI_LOG(critical, "Tried to bind loki-storage to localhost, please bind "
                         "to outward facing address");
         return EXIT_FAILURE;
     }

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -79,12 +79,14 @@ int main(int argc, char* argv[]) {
     }
 
     if (options.ip == "127.0.0.1") {
-        LOKI_LOG(error, "Tried to bind loki-storage to localhost, please bind to outward facing address");
+        LOKI_LOG(error, "Tried to bind loki-storage to localhost, please bind "
+                        "to outward facing address");
         return EXIT_FAILURE;
     }
 
     if (options.port == options.lokid_rpc_port) {
-        LOKI_LOG(error, "Storage server port must be different from that of Lokid! Terminating.");
+        LOKI_LOG(error, "Storage server port must be different from that of "
+                        "Lokid! Terminating.");
         exit(EXIT_INVALID_PORT);
     }
 

--- a/httpserver/security.cpp
+++ b/httpserver/security.cpp
@@ -7,7 +7,9 @@
 #include <boost/beast/core/detail/base64.hpp>
 
 namespace loki {
-Security::Security(const lokid_key_pair_t& key_pair, const boost::filesystem::path& base_path) : key_pair_(key_pair), base_path_(base_path) {}
+Security::Security(const lokid_key_pair_t& key_pair,
+                   const boost::filesystem::path& base_path)
+    : key_pair_(key_pair), base_path_(base_path) {}
 
 std::string Security::base64_sign(const std::string& body) {
     const auto hash = hash_data(body);

--- a/httpserver/security.h
+++ b/httpserver/security.h
@@ -10,7 +10,8 @@ struct lokid_key_pair_t;
 
 class Security {
   public:
-    Security(const lokid_key_pair_t& key_pair, const boost::filesystem::path& base_path);
+    Security(const lokid_key_pair_t& key_pair,
+             const boost::filesystem::path& base_path);
 
     std::string base64_sign(const std::string& body);
     void generate_cert_signature();

--- a/httpserver/serialization.cpp
+++ b/httpserver/serialization.cpp
@@ -143,42 +143,42 @@ std::vector<message_t> deserialize_messages(const std::string& blob) {
         /// Deserialize PK
         auto pk = deserialize_string(slice, PK_SIZE);
         if (!pk) {
-            LOKI_LOG(error, "Could not deserialize pk");
+            LOKI_LOG(debug, "Could not deserialize pk");
             return {};
         }
 
         /// Deserialize Hash
         auto hash = deserialize_string(slice);
         if (!hash) {
-            LOKI_LOG(error, "Could not deserialize hash");
+            LOKI_LOG(debug, "Could not deserialize hash");
             return {};
         }
 
         /// Deserialize Data
         auto data = deserialize_string(slice);
         if (!data) {
-            LOKI_LOG(error, "Could not deserialize data");
+            LOKI_LOG(debug, "Could not deserialize data");
             return {};
         }
 
         /// Deserialize TTL
         auto ttl = deserialize_uint64(slice);
         if (!ttl) {
-            LOKI_LOG(error, "Could not deserialize ttl");
+            LOKI_LOG(debug, "Could not deserialize ttl");
             return {};
         }
 
         /// Deserialize Timestamp
         auto timestamp = deserialize_uint64(slice);
         if (!timestamp) {
-            LOKI_LOG(error, "Could not deserialize timestamp");
+            LOKI_LOG(debug, "Could not deserialize timestamp");
             return {};
         }
 
         /// Deserialize Nonce
         auto nonce = deserialize_string(slice);
         if (!nonce) {
-            LOKI_LOG(error, "Could not deserialize nonce");
+            LOKI_LOG(debug, "Could not deserialize nonce");
             return {};
         }
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -328,7 +328,7 @@ void ServiceNode::bootstrap_data() {
                         on_bootstrap_update(bu);
                     } catch (const std::exception& e) {
                         LOKI_LOG(
-                            critical,
+                            error,
                             "Exception caught while bootstrapping from {}: {}",
                             seed_node.first, e.what());
                     }
@@ -697,7 +697,7 @@ void ServiceNode::swarm_timer_tick() {
                     const block_update_t bu = parse_swarm_update(res.body);
                     on_swarm_update(bu);
                 } catch (const std::exception& e) {
-                    LOKI_LOG(critical, "Exception caught on swarm update: {}",
+                    LOKI_LOG(error, "Exception caught on swarm update: {}",
                              e.what());
                 }
             } else {

--- a/httpserver/stats.h
+++ b/httpserver/stats.h
@@ -11,11 +11,7 @@ struct time_entry_t {
     time_t timestamp;
 };
 
-enum class ResultType {
-    OK,
-    MISMATCH,
-    OTHER
-};
+enum class ResultType { OK, MISMATCH, OTHER };
 
 struct test_result_t {
 
@@ -77,7 +73,8 @@ class all_stats_t {
         peer_report_[sn].storage_tests.push_back(res);
     }
 
-    void record_blockchain_test_result(const sn_record_t& sn, ResultType result) {
+    void record_blockchain_test_result(const sn_record_t& sn,
+                                       ResultType result) {
         test_result_t t = {std::time(nullptr), result};
         peer_report_[sn].blockchain_tests.push_back(t);
     }

--- a/httpserver/version.h
+++ b/httpserver/version.h
@@ -4,10 +4,6 @@
 
 #include <iostream>
 
-#ifndef STORAGE_SERVER_VERSION
-#define STORAGE_SERVER_VERSION 0010
-#endif
-
 #ifndef STORAGE_SERVER_VERSION_STRING
 #define STORAGE_SERVER_VERSION_STRING "1.0.4"
 #endif

--- a/storage/src/Database.cpp
+++ b/storage/src/Database.cpp
@@ -170,14 +170,15 @@ bool Database::get_message_count(uint64_t& count) {
             count = sqlite3_column_int64(get_row_count_stmt, 0);
             success = true;
         } else {
-            LOKI_LOG(error, "Could not execute `count` db statement");
+            LOKI_LOG(critical, "Could not execute `count` db statement");
             break;
         }
     }
 
     rc = sqlite3_reset(get_by_index_stmt);
     if (rc != SQLITE_OK) {
-        LOKI_LOG(error, "sqlite reset error: [{}], {}", rc, sqlite3_errmsg(db));
+        LOKI_LOG(critical, "sqlite reset error: [{}], {}", rc,
+                 sqlite3_errmsg(db));
         success = false;
     }
 
@@ -221,7 +222,7 @@ bool Database::retrieve_by_index(uint64_t index, Item& item) {
             success = true;
             break;
         } else {
-            LOKI_LOG(error,
+            LOKI_LOG(critical,
                      "Could not execute `retrieve by index` db statement");
             break;
         }
@@ -229,7 +230,8 @@ bool Database::retrieve_by_index(uint64_t index, Item& item) {
 
     rc = sqlite3_reset(get_by_index_stmt);
     if (rc != SQLITE_OK) {
-        LOKI_LOG(error, "sqlite reset error: [{}], {}", rc, sqlite3_errmsg(db));
+        LOKI_LOG(critical, "sqlite reset error: [{}], {}", rc,
+                 sqlite3_errmsg(db));
         success = false;
     }
 
@@ -254,7 +256,7 @@ bool Database::retrieve_by_hash(const std::string& msg_hash, Item& item) {
             break;
         } else {
             LOKI_LOG(
-                error,
+                critical,
                 "Could not execute `retrieve by hash` db statement, ec: {}",
                 rc);
             break;
@@ -263,7 +265,8 @@ bool Database::retrieve_by_hash(const std::string& msg_hash, Item& item) {
 
     rc = sqlite3_reset(get_by_hash_stmt);
     if (rc != SQLITE_OK) {
-        LOKI_LOG(error, "sqlite reset error: [{}], {}", rc, sqlite3_errmsg(db));
+        LOKI_LOG(critical, "sqlite reset error: [{}], {}", rc,
+                 sqlite3_errmsg(db));
         success = false;
     }
 
@@ -302,7 +305,7 @@ bool Database::store(const std::string& hash, const std::string& pubKey,
             result = true;
             break;
         } else {
-            LOKI_LOG(error, "Could not execute `store` db statement, ec: {}",
+            LOKI_LOG(critical, "Could not execute `store` db statement, ec: {}",
                      rc);
             break;
         }
@@ -310,7 +313,8 @@ bool Database::store(const std::string& hash, const std::string& pubKey,
 
     rc = sqlite3_reset(stmt);
     if (rc != SQLITE_OK && rc != SQLITE_CONSTRAINT) {
-        LOKI_LOG(error, "sqlite reset error: [{}], {}", rc, sqlite3_errmsg(db));
+        LOKI_LOG(critical, "sqlite reset error: [{}], {}", rc,
+                 sqlite3_errmsg(db));
     }
     return result;
 }
@@ -366,15 +370,16 @@ bool Database::retrieve(const std::string& pubKey, std::vector<Item>& items,
             auto item = extract_item(stmt);
             items.push_back(std::move(item));
         } else {
-            LOKI_LOG(error, "Could not execute `retrieve` db statement, ec: {}",
-                     rc);
+            LOKI_LOG(critical,
+                     "Could not execute `retrieve` db statement, ec: {}", rc);
             break;
         }
     }
 
     int rc = sqlite3_reset(stmt);
     if (rc != SQLITE_OK) {
-        LOKI_LOG(error, "sqlite reset error: [{}], {}", rc, sqlite3_errmsg(db));
+        LOKI_LOG(critical, "sqlite reset error: [{}], {}", rc,
+                 sqlite3_errmsg(db));
         success = false;
     }
     return success;


### PR DESCRIPTION
- reduce severity of most log messages from `error` to `debug` (most of them having to do with other nodes, not the current node)
- add `get_logs` endpoint to provide most recent error log entires (limited to 1 request per second)