### PR TITLE
Add the number of recent store/retrieve requests to stats

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -928,7 +928,7 @@ void connection_t::poll_db(const std::string& pk,
 
 void connection_t::process_retrieve(const json& params) {
 
-    service_node_.all_stats_.client_retrieve_requests++;
+    service_node_.all_stats_.bump_retrieve_requests();
 
     constexpr const char* fields[] = {"pubKey", "lastHash"};
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -536,7 +536,7 @@ bool ServiceNode::process_store(const message_t& msg) {
         return false;
     }
 
-    all_stats_.client_store_requests++;
+    all_stats_.bump_store_requests();
 
     /// store to the database
     save_if_new(msg);
@@ -1307,9 +1307,15 @@ static nlohmann::json to_json(const all_stats_t &stats) {
 
     nlohmann::json json;
 
-    json["client_store_requests"] = stats.client_store_requests;
-    json["client_retrieve_requests"] = stats.client_retrieve_requests;
-    json["reset_time"] = stats.reset_time;
+    json["total_store_requests"] = stats.get_total_store_requests();
+    json["recent_store_requests"] = stats.get_recent_store_requests();
+    json["previous_period_store_requests"] = stats.get_previous_period_store_requests();
+
+    json["total_retrieve_requests"] = stats.get_total_retrieve_requests();
+    json["recent_store_requests"] = stats.get_recent_store_requests();
+    json["previous_period_retrieve_requests"] = stats.get_previous_period_retrieve_requests();
+
+    json["reset_time"] = stats.get_reset_time();
 
     nlohmann::json peers;
 

--- a/httpserver/stats.cpp
+++ b/httpserver/stats.cpp
@@ -34,6 +34,9 @@ void all_stats_t::cleanup() {
         cleanup_old(peer_report_[sn].storage_tests, cutoff);
         cleanup_old(peer_report_[sn].blockchain_tests, cutoff);
     }
+
+    /// updated stats for "previous period"
+    this->next_period();
 }
 
 } // namespace loki

--- a/httpserver/stats.h
+++ b/httpserver/stats.h
@@ -52,17 +52,34 @@ struct peer_stats_t {
 
 class all_stats_t {
 
+    // ===== This node's stats =====
+    uint64_t total_client_store_requests = 0;
+    // Number of requests in the latest x min interval
+    uint64_t previous_period_store_requests = 0;
+    // Number of requests after the latest x min interval
+    uint64_t recent_store_requests = 0;
+
+    uint64_t total_client_retrieve_requests = 0;
+    // Number of requests in the latest x min interval
+    uint64_t previous_period_retrieve_requests = 0;
+    // Number of requests after the latest x min interval
+    uint64_t recent_retrieve_requests = 0;
+
+    time_t reset_time_ = time(nullptr);
+    // =============================
+
+    /// update period moving recent request counters to
+    /// the `previous period`
+    void next_period() {
+        previous_period_store_requests = recent_store_requests;
+        previous_period_retrieve_requests = recent_retrieve_requests;
+        recent_store_requests = 0;
+        recent_retrieve_requests = 0;
+    }
+
   public:
     // stats per every peer in our swarm (including former peers)
     std::unordered_map<sn_record_t, peer_stats_t> peer_report_;
-
-    // ===== This node's stats =====
-    uint64_t client_store_requests = 0;
-    uint64_t client_retrieve_requests = 0;
-
-    time_t reset_time = time(nullptr);
-
-    // =============================
 
     void record_request_failed(const sn_record_t& sn) {
         peer_report_[sn].requests_failed++;
@@ -84,6 +101,43 @@ class all_stats_t {
 
     // remove old test entries and reset counters, update reset time
     void cleanup();
+
+    void bump_store_requests() {
+        total_client_store_requests++;
+        recent_store_requests++;
+    }
+
+    void bump_retrieve_requests() {
+        total_client_retrieve_requests++;
+        recent_retrieve_requests++;
+    }
+
+    uint64_t get_total_store_requests() const {
+        return total_client_store_requests;
+    }
+
+    uint64_t get_recent_store_requests() const {
+        return recent_store_requests;
+    }
+
+    uint64_t get_previous_period_store_requests() const {
+        return previous_period_store_requests;
+    }
+
+    uint64_t get_total_retrieve_requests() const {
+        return total_client_retrieve_requests;
+    }
+
+    uint64_t get_recent_retrieve_requests() const {
+        return recent_retrieve_requests;
+    }
+
+    uint64_t get_previous_period_retrieve_requests() const {
+        return previous_period_retrieve_requests;
+    }
+
+
+    time_t get_reset_time() const { return reset_time_; }
 };
 
 } // namespace loki


### PR DESCRIPTION
Provides stats for the latest 1-hour period in addition to the existing "total since restart".