### PR TITLE
Fix incorrectly decrementing open http connections on timeout

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -1250,6 +1250,8 @@ HttpClientSession::~HttpClientSession() {
                             sn_response_t{SNodeError::ERROR_OTHER, nullptr}));
     }
 
+    get_net_stats().http_connections_out--;
+
     if (!socket_.is_open()) {
         LOKI_LOG(debug, "Socket is already closed");
         return;
@@ -1273,7 +1275,6 @@ HttpClientSession::~HttpClientSession() {
         LOKI_LOG(error, "On close socket [{}: {}]", ec.value(), ec.message());
     }
 
-    get_net_stats().http_connections_out--;
 }
 
 } // namespace loki


### PR DESCRIPTION
- fixed not decrementing lokid connection count when a request times out, resulting in incorrectly reporting a large number of open http connections in `get_stats`.