### PR TITLE
Bookkeeping for reachability of nodes; reporting them to Lokid

### DIFF
--- a/common/include/loki_common.h
+++ b/common/include/loki_common.h
@@ -20,7 +20,9 @@ struct sn_record_t {
   private:
     uint16_t port_;
     std::string sn_address_; // Snode address (pubkey plus .snode)
-    std::string pub_key_;    // base32z
+    // TODO: create separate types for different encodings of pubkeys,
+    // so if we confuse them, it will be a compiler error
+    std::string pub_key_base_32z_;
     std::string pub_key_hex_;
     std::string ip_; // Snode ip
   public:
@@ -43,12 +45,12 @@ struct sn_record_t {
 
         sn_address_ = addr;
         sn_address_.append(".snode");
-        pub_key_ = addr;
+        pub_key_base_32z_ = addr;
     }
 
     uint16_t port() const { return port_; }
     const std::string& sn_address() const { return sn_address_; }
-    const std::string& pub_key() const { return pub_key_; }
+    const std::string& pub_key_base32z() const { return pub_key_base_32z_; }
     const std::string& pub_key_hex() const { return pub_key_hex_; }
     const std::string& ip() const { return ip_; }
 

--- a/common/include/loki_common.h
+++ b/common/include/loki_common.h
@@ -20,7 +20,7 @@ struct sn_record_t {
   private:
     uint16_t port_;
     std::string sn_address_; // Snode address (pubkey plus .snode)
-    std::string pub_key_; // base32z
+    std::string pub_key_;    // base32z
     std::string pub_key_hex_;
     std::string ip_; // Snode ip
   public:
@@ -70,13 +70,11 @@ class user_pubkey_t {
 
     user_pubkey_t() {}
 
-    user_pubkey_t(std::string&& pk) : pubkey_(std::move(pk)) {
-    }
+    user_pubkey_t(std::string&& pk) : pubkey_(std::move(pk)) {}
 
     user_pubkey_t(const std::string& pk) : pubkey_(pk) {}
 
-public:
-
+  public:
     static user_pubkey_t create(std::string&& pk, bool& success) {
         success = true;
         if (pk.size() != USER_PUBKEY_SIZE) {
@@ -95,9 +93,7 @@ public:
         return user_pubkey_t(pk);
     }
 
-    const std::string& str() const {
-        return pubkey_;
-    }
+    const std::string& str() const { return pubkey_; }
 };
 
 namespace loki {

--- a/common/include/loki_common.h
+++ b/common/include/loki_common.h
@@ -9,6 +9,9 @@
 
 #include <boost/optional.hpp>
 
+// TODO: this should be a proper struct w/o heap allocation!
+using sn_pub_key_t = std::string;
+
 struct sn_record_t {
 
     // our 32 byte pub keys should always be 52 bytes long in base32z
@@ -16,13 +19,14 @@ struct sn_record_t {
 
   private:
     uint16_t port_;
-    std::string sn_address_; // Snode address
-    std::string pub_key_;
+    std::string sn_address_; // Snode address (pubkey plus .snode)
+    std::string pub_key_; // base32z
+    std::string pub_key_hex_;
     std::string ip_; // Snode ip
   public:
     sn_record_t(uint16_t port, const std::string& address,
-                const std::string& ip)
-        : port_(port), ip_(ip) {
+                const std::string& pk_hex, const std::string& ip)
+        : port_(port), pub_key_hex_(pk_hex), ip_(ip) {
         set_address(address);
     }
 
@@ -45,6 +49,7 @@ struct sn_record_t {
     uint16_t port() const { return port_; }
     const std::string& sn_address() const { return sn_address_; }
     const std::string& pub_key() const { return pub_key_; }
+    const std::string& pub_key_hex() const { return pub_key_hex_; }
     const std::string& ip() const { return ip_; }
 
     template <typename OStream>

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -18,6 +18,7 @@ set(HEADER_FILES
     command_line.h
     net_stats.h
     dns_text_records.h
+    reachability_testing.h
     )
 
 set(SRC_FILES
@@ -32,6 +33,7 @@ set(SRC_FILES
     security.cpp
     command_line.cpp
     dns_text_records.cpp
+    reachability_testing.cpp
     )
 
 add_library(httpserver_lib STATIC ${HEADER_FILES} ${SRC_FILES})

--- a/httpserver/dns_text_records.cpp
+++ b/httpserver/dns_text_records.cpp
@@ -181,7 +181,7 @@ void check_latest_version() {
     } else {
         LOKI_LOG(debug,
                  "You are using the latest version of the storage server ({})",
-                 latest_version_str);
+                 STORAGE_SERVER_VERSION_STRING);
     }
 }
 

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -697,11 +697,13 @@ void connection_t::process_store(const json& params) {
     const auto data = params["data"].get<std::string>();
 
     bool created;
-    auto pk = user_pubkey_t::create(params["pubKey"].get<std::string>(), created);
+    auto pk =
+        user_pubkey_t::create(params["pubKey"].get<std::string>(), created);
 
     if (!created) {
         response_.result(http::status::bad_request);
-        body_stream_ << fmt::format("Pubkey must be {} characters long\n", USER_PUBKEY_SIZE);
+        body_stream_ << fmt::format("Pubkey must be {} characters long\n",
+                                    USER_PUBKEY_SIZE);
         LOKI_LOG(error, "Pubkey must be {} characters long", USER_PUBKEY_SIZE);
         return;
     }
@@ -805,16 +807,17 @@ void connection_t::process_snodes_by_pk(const json& params) {
     }
 
     bool success;
-    const auto pk = user_pubkey_t::create(params["pubKey"].get<std::string>(), success);
+    const auto pk =
+        user_pubkey_t::create(params["pubKey"].get<std::string>(), success);
     if (!success) {
         response_.result(http::status::bad_request);
-        body_stream_ << fmt::format("Pubkey must be {} characters long\n", USER_PUBKEY_SIZE);
+        body_stream_ << fmt::format("Pubkey must be {} characters long\n",
+                                    USER_PUBKEY_SIZE);
         LOKI_LOG(debug, "Pubkey must be {} characters long ", USER_PUBKEY_SIZE);
         return;
     }
 
-    const std::vector<sn_record_t> nodes =
-        service_node_.get_snodes_by_pk(pk);
+    const std::vector<sn_record_t> nodes = service_node_.get_snodes_by_pk(pk);
     const json res_body = snodes_to_json(nodes);
 
     response_.result(http::status::ok);
@@ -968,11 +971,13 @@ void connection_t::process_retrieve(const json& params) {
     }
 
     bool success;
-    const auto pk = user_pubkey_t::create(params["pubKey"].get<std::string>(), success);
+    const auto pk =
+        user_pubkey_t::create(params["pubKey"].get<std::string>(), success);
 
     if (!success) {
         response_.result(http::status::bad_request);
-        body_stream_ << fmt::format("Pubkey must be {} characters long\n", USER_PUBKEY_SIZE);
+        body_stream_ << fmt::format("Pubkey must be {} characters long\n",
+                                    USER_PUBKEY_SIZE);
         LOKI_LOG(debug, "Pubkey must be {} characters long ", USER_PUBKEY_SIZE);
         return;
     }

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -278,26 +278,30 @@ void run(boost::asio::io_context& ioc, const std::string& ip, uint16_t port,
 
 namespace fmt {
 
-  template <>
-  struct formatter<loki::SNodeError> {
+template <>
+struct formatter<loki::SNodeError> {
 
     template <typename ParseContext>
-    constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
-
-    template <typename FormatContext>
-    auto format(const loki::SNodeError& err, FormatContext &ctx) {
-
-      switch (err) {
-        case loki::SNodeError::NO_ERROR: return format_to(ctx.out(), "NO_ERROR");
-        case loki::SNodeError::ERROR_OTHER: return format_to(ctx.out(), "ERROR_OTHER");
-        case loki::SNodeError::NO_REACH: return format_to(ctx.out(), "NO_REACH");
-        case loki::SNodeError::HTTP_ERROR: return format_to(ctx.out(), "HTTP_ERROR");
-        default: return format_to(ctx.out(), "[UNKNOWN]");
-      }
-      
+    constexpr auto parse(ParseContext& ctx) {
+        return ctx.begin();
     }
 
-  };
+    template <typename FormatContext>
+    auto format(const loki::SNodeError& err, FormatContext& ctx) {
 
+        switch (err) {
+        case loki::SNodeError::NO_ERROR:
+            return format_to(ctx.out(), "NO_ERROR");
+        case loki::SNodeError::ERROR_OTHER:
+            return format_to(ctx.out(), "ERROR_OTHER");
+        case loki::SNodeError::NO_REACH:
+            return format_to(ctx.out(), "NO_REACH");
+        case loki::SNodeError::HTTP_ERROR:
+            return format_to(ctx.out(), "HTTP_ERROR");
+        default:
+            return format_to(ctx.out(), "[UNKNOWN]");
+        }
+    }
+};
 
-}
+} // namespace fmt

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -25,6 +25,8 @@ void make_https_request(boost::asio::io_context& ioc,
     if (sn_address == "0.0.0.0") {
         LOKI_LOG(warn, "Could not initiate request to snode (we don't know "
                        "their IP yet).");
+
+        cb(sn_response_t{SNodeError::NO_REACH, nullptr});
         return;
     }
 

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -23,7 +23,7 @@ void make_https_request(boost::asio::io_context& ioc,
 #else
 
     if (sn_address == "0.0.0.0") {
-        LOKI_LOG(warn, "Could not initiate request to snode (we don't know "
+        LOKI_LOG(debug, "Could not initiate request to snode (we don't know "
                        "their IP yet).");
 
         cb(sn_response_t{SNodeError::NO_REACH, nullptr});

--- a/httpserver/reachability_testing.cpp
+++ b/httpserver/reachability_testing.cpp
@@ -1,0 +1,92 @@
+
+#include "loki_logger.h"
+#include "reachability_testing.h"
+
+using std::chrono::steady_clock;
+using namespace std::chrono_literals;
+
+namespace loki {
+
+namespace detail {
+
+reach_record_t::reach_record_t() {
+    this->first_failure = steady_clock::now();
+    this->last_tested = this->first_failure;
+}
+
+} // namespace detail
+
+/// How long to wait until reporting unreachable nodes to Lokid
+constexpr std::chrono::minutes UNREACH_GRACE_PERIOD = 120min;
+
+bool reachability_records_t::record_unreachable(const sn_pub_key_t& sn) {
+
+    auto it = offline_nodes_.find(sn);
+
+    if (it == offline_nodes_.end()) {
+        LOKI_LOG(info, "adding a new node to UNREACHABLE: {}", sn);
+        offline_nodes_.insert({sn, {}});
+    } else {
+        LOKI_LOG(info, "node is ALREAY known to be UNREACHABLE: {}", sn);
+
+        it->second.last_tested = steady_clock::now();
+
+        const auto elapsed = it->second.last_tested - it->second.first_failure;
+        const auto elapsed_sec =
+            std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+        LOKI_LOG(info, "    - first time failed {} seconds ago", elapsed_sec);
+
+        /// TODO: Might still want to report as unreachable since this status
+        /// gets reset to `true` on Lokid restart
+        if (elapsed > UNREACH_GRACE_PERIOD && !it->second.reported) {
+            LOKI_LOG(warn, "    - will REPORT this node to Lokid!");
+            return true;
+        } else {
+            if (it->second.reported) {
+                LOKI_LOG(warn, "    - Already reported node: {}", sn);
+            }
+        }
+    }
+
+    return false;
+}
+
+bool reachability_records_t::record_reachable(const sn_pub_key_t& sn) {
+    expire(sn);
+}
+
+bool reachability_records_t::expire(const sn_pub_key_t& sn) {
+
+    if (offline_nodes_.erase(sn)) {
+        LOKI_LOG(warn, "    - removed entry for {}", sn);
+    }
+
+}
+
+void reachability_records_t::set_reported(const sn_pub_key_t& sn) {
+
+    auto it = offline_nodes_.find(sn);
+    if (it != offline_nodes_.end()) {
+        it->second.reported = true;
+    }
+}
+
+boost::optional<sn_pub_key_t> reachability_records_t::next_to_test() {
+
+    const auto it = std::min_element(
+        offline_nodes_.begin(), offline_nodes_.end(),
+        [&](const auto& lhs, const auto& rhs) {
+            return lhs.second.last_tested < rhs.second.last_tested;
+        });
+
+    if (it == offline_nodes_.end()) {
+        return boost::none;
+    } else {
+
+        LOKI_LOG(warn, "~~~ Selecting to be re-tested: {}", it->first);
+
+        return it->first;
+    }
+}
+
+} // namespace loki

--- a/httpserver/reachability_testing.cpp
+++ b/httpserver/reachability_testing.cpp
@@ -1,6 +1,6 @@
 
-#include "loki_logger.h"
 #include "reachability_testing.h"
+#include "loki_logger.h"
 
 using std::chrono::steady_clock;
 using namespace std::chrono_literals;
@@ -60,7 +60,6 @@ bool reachability_records_t::expire(const sn_pub_key_t& sn) {
     if (offline_nodes_.erase(sn)) {
         LOKI_LOG(warn, "    - removed entry for {}", sn);
     }
-
 }
 
 void reachability_records_t::set_reported(const sn_pub_key_t& sn) {

--- a/httpserver/reachability_testing.h
+++ b/httpserver/reachability_testing.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "loki_common.h"
-#include <unordered_map>
 #include <chrono>
+#include <unordered_map>
 
 namespace loki {
 
@@ -16,14 +16,13 @@ class reach_record_t {
 
     using time_point_t = std::chrono::time_point<std::chrono::steady_clock>;
 
-public:
+  public:
     time_point_t first_failure;
     time_point_t last_tested;
     // whether it's been reported to Lokid
     bool reported = false;
 
     reach_record_t();
-
 };
 } // namespace detail
 

--- a/httpserver/reachability_testing.h
+++ b/httpserver/reachability_testing.h
@@ -11,12 +11,12 @@ namespace detail {
 /// TODO: make this class "private"?
 class reach_record_t {
 
-    // The time the node failed for the first time
-    // (and hasn't come back online)
 
     using time_point_t = std::chrono::time_point<std::chrono::steady_clock>;
 
   public:
+    // The time the node failed for the first time
+    // (and hasn't come back online)
     time_point_t first_failure;
     time_point_t last_tested;
     // whether it's been reported to Lokid

--- a/httpserver/reachability_testing.h
+++ b/httpserver/reachability_testing.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "loki_common.h"
+#include <unordered_map>
+#include <chrono>
+
+namespace loki {
+
+namespace detail {
+
+/// TODO: make this class "private"?
+class reach_record_t {
+
+    // The time the node failed for the first time
+    // (and hasn't come back online)
+
+    using time_point_t = std::chrono::time_point<std::chrono::steady_clock>;
+
+public:
+    time_point_t first_failure;
+    time_point_t last_tested;
+    // whether it's been reported to Lokid
+    bool reported = false;
+
+    reach_record_t();
+
+};
+} // namespace detail
+
+class reachability_records_t {
+
+    // TODO: sn_records are heavy (3 strings), so how about we only store the
+    // pubkey?
+
+    // Nodes that failed the reachability test
+    // Note: I don't expect this list to be large, so
+    // `std::vector` is probably faster than `std::set` here
+    std::unordered_map<sn_pub_key_t, detail::reach_record_t> offline_nodes_;
+
+  public:
+    // Return nodes that should be tested first: decommissioned nodes
+    // and those that failed our earlier tests (but not reported yet)
+    // std::vector<> priority_nodes() const;
+
+    // Records node as unreachable, return `true` if the node should be
+    // reported to Lokid as being unreachable for a long time
+    bool record_unreachable(const sn_pub_key_t& sn);
+
+    bool record_reachable(const sn_pub_key_t& sn);
+
+    bool expire(const sn_pub_key_t& sn);
+
+    void set_reported(const sn_pub_key_t& sn);
+
+    // Retrun the least recently tested node
+    boost::optional<sn_pub_key_t> next_to_test();
+};
+
+} // namespace loki

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -235,7 +235,21 @@ parse_swarm_update(const std::shared_ptr<std::string>& response_body) {
             const sn_record_t sn{port, std::move(snode_address), pubkey,
                                  std::move(snode_ip)};
 
-            swarm_map[swarm_id].push_back(sn);
+            const bool fully_funded = sn_json.at("funded").get<bool>();
+
+            /// We want to include (test) decommissioned nodes, but not
+            /// partially funded ones.
+            if (!fully_funded) {
+                continue;
+            }
+
+            /// Storing decommissioned nodes (with dummy swarm id) in
+            /// a separate data structure as it seems less error prone
+            if (swarm_id == INVALID_SWARM_ID) {
+                bu.decommissioned_nodes.push_back(sn);
+            } else {
+                swarm_map[swarm_id].push_back(sn);
+            }
         }
 
         bu.height = body.at("result").at("height").get<uint64_t>();
@@ -268,6 +282,7 @@ void ServiceNode::bootstrap_data() {
     fields["height"] = true;
     fields["block_hash"] = true;
     fields["hardfork"] = true;
+    fields["funded"] = true;
 
     params["fields"] = fields;
 
@@ -286,6 +301,8 @@ void ServiceNode::bootstrap_data() {
                 if (res.error_code == SNodeError::NO_ERROR) {
                     try {
                         const block_update_t bu = parse_swarm_update(res.body);
+                        // TODO: this should be disabled in the "testnet" mode
+                        // (or changed to point to testnet seeds)
                         on_bootstrap_update(bu);
                     } catch (const std::exception& e) {
                         LOKI_LOG(
@@ -344,7 +361,7 @@ ServiceNode::~ServiceNode() {
 };
 
 void ServiceNode::relay_data_reliable(const std::shared_ptr<request_t>& req,
-                                  const sn_record_t& sn) const {
+                                      const sn_record_t& sn) const {
 
     LOKI_LOG(debug, "Relaying data to: {}", sn);
 
@@ -605,7 +622,7 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
         }
     }
 
-    swarm_->update_state(bu.swarms, events);
+    swarm_->update_state(bu.swarms, bu.decommissioned_nodes, events);
 
     if (!events.new_snodes.empty()) {
         bootstrap_peers(events.new_snodes);
@@ -615,7 +632,7 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
         bootstrap_swarms(events.new_swarms);
     }
 
-    if (events.decommissioned) {
+    if (events.dissolved) {
         /// Go through all our PK and push them accordingly
         salvage_data();
     }
@@ -656,11 +673,12 @@ void ServiceNode::swarm_timer_tick() {
     fields["height"] = true;
     fields["block_hash"] = true;
     fields["hardfork"] = true;
+    fields["funded"] = true;
 
     params["fields"] = fields;
 
     /// TODO: include decommissioned
-    params["active_only"] = true;
+    params["active_only"] = false;
 
     lokid_client_.make_lokid_request(
         "get_n_service_nodes", params, [this](const sn_response_t&& res) {
@@ -697,14 +715,24 @@ void ServiceNode::ping_peers_tick() {
     this->peer_ping_timer_.async_wait(
         std::bind(&ServiceNode::ping_peers_tick, this));
 
+
+    /// TODO: To be safe, let's not even test peers until we
+    /// have reached the right hardfork height
+
     /// We always test one node already known to be offline
     /// plus one random other node (could even be the same node)
 
-    const auto other_node = swarm_->choose_other_node();
+    const auto random_node = swarm_->choose_funded_node();
 
-    if (other_node) {
-        LOKI_LOG(debug, "Selected random node for testing: {}", (*other_node).pub_key());
-        test_reachability(*other_node);
+    if (random_node) {
+
+        if (random_node == our_address_) {
+            LOKI_LOG(debug, "Would test our own node, skipping");
+        } else {
+            LOKI_LOG(debug, "Selected random node for testing: {}",
+                     (*random_node).pub_key());
+            test_reachability(*random_node);
+        }
     } else {
         LOKI_LOG(debug, "No nodes to test for reachability");
     }
@@ -716,17 +744,18 @@ void ServiceNode::ping_peers_tick() {
     const auto offline_node = reach_records_.next_to_test();
 
     if (offline_node) {
-        const boost::optional<sn_record_t> sn = swarm_->get_node_by_pk(*offline_node);
+        const boost::optional<sn_record_t> sn =
+            swarm_->get_node_by_pk(*offline_node);
         LOKI_LOG(debug, "No nodes offline nodes to ping test yet");
         if (sn) {
             test_reachability(*sn);
         } else {
-            LOKI_LOG(debug, "Node does not seem to exist anymore: {}", *offline_node);
+            LOKI_LOG(debug, "Node does not seem to exist anymore: {}",
+                     *offline_node);
             // delete its entry from test records as irrelevant
             reach_records_.expire(*offline_node);
         }
     }
-
 }
 
 void ServiceNode::test_reachability(const sn_record_t& sn) {
@@ -750,7 +779,6 @@ void ServiceNode::test_reachability(const sn_record_t& sn) {
 #endif
 
     make_sn_request(ioc_, sn, req, std::move(callback));
-
 }
 
 void ServiceNode::lokid_ping_timer_tick() {
@@ -1004,17 +1032,19 @@ void ServiceNode::report_node_reachability(const sn_pub_key_t& sn_pk,
 
         if (success) {
             if (reachable) {
-                LOKI_LOG(debug, "Successfully reported node as reachable: {}", sn_pk);
+                LOKI_LOG(debug, "Successfully reported node as reachable: {}",
+                         sn_pk);
                 this->reach_records_.expire(sn_pk);
             } else {
-                LOKI_LOG(debug, "Successfully reported node as unreachable {}", sn_pk);
+                LOKI_LOG(debug, "Successfully reported node as unreachable {}",
+                         sn_pk);
                 this->reach_records_.set_reported(sn_pk);
             }
         }
     };
 
-    lokid_client_.make_lokid_request("report_peer_storage_server_status", params,
-                                     std::move(cb));
+    lokid_client_.make_lokid_request("report_peer_storage_server_status",
+                                     params, std::move(cb));
 }
 
 void ServiceNode::process_reach_test_response(sn_response_t&& res,
@@ -1312,7 +1342,7 @@ void ServiceNode::bootstrap_swarms(
         LOKI_LOG(info, "Bootstrapping swarms: {}", vec_to_string(swarms));
     }
 
-    const auto& all_swarms = swarm_->all_swarms();
+    const auto& all_swarms = swarm_->all_valid_swarms();
 
     std::vector<Item> all_entries;
     if (!get_all_messages(all_entries)) {
@@ -1554,14 +1584,15 @@ bool ServiceNode::is_pubkey_for_us(const user_pubkey_t& pk) const {
     return swarm_->is_pubkey_for_us(pk);
 }
 
-std::vector<sn_record_t> ServiceNode::get_snodes_by_pk(const user_pubkey_t& pk) {
+std::vector<sn_record_t>
+ServiceNode::get_snodes_by_pk(const user_pubkey_t& pk) {
 
     if (!swarm_) {
         LOKI_LOG(error, "Swarm data missing");
         return {};
     }
 
-    const auto& all_swarms = swarm_->all_swarms();
+    const auto& all_swarms = swarm_->all_valid_swarms();
 
     swarm_id_t swarm_id = get_swarm_by_pk(all_swarms, pk);
 
@@ -1586,17 +1617,7 @@ bool ServiceNode::is_snode_address_known(const std::string& sn_address) {
         return {};
     }
 
-    const auto& all_swarms = swarm_->all_swarms();
-
-    return std::any_of(all_swarms.begin(), all_swarms.end(),
-                       [&sn_address](const SwarmInfo& swarm_info) {
-                           return std::any_of(
-                               swarm_info.snodes.begin(),
-                               swarm_info.snodes.end(),
-                               [&sn_address](const sn_record_t& sn_record) {
-                                   return sn_record.sn_address() == sn_address;
-                               });
-                       });
+    return swarm_->is_fully_funded_node(sn_address);
 }
 
 } // namespace loki

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -718,6 +718,10 @@ void ServiceNode::ping_peers_tick() {
 
     /// TODO: To be safe, let's not even test peers until we
     /// have reached the right hardfork height
+    if (hardfork_ < ENFORCED_REACHABILITY_HARDFORK) {
+        LOKI_LOG(debug, "Have not reached HF13, skipping reachability tests");
+        return;
+    }
 
     /// We always test one node already known to be offline
     /// plus one random other node (could even be the same node)

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -1006,12 +1006,12 @@ void ServiceNode::report_node_reachability(const sn_pub_key_t& sn_pk,
 
     auto cb = [this, sn_pk, reachable](const sn_response_t&& res) {
         if (res.error_code != SNodeError::NO_ERROR) {
-            LOKI_LOG(error, "Could not report node status");
+            LOKI_LOG(warn, "Could not report node status");
             return;
         }
 
         if (!res.body) {
-            LOKI_LOG(error, "Empty body on Lokid report node status");
+            LOKI_LOG(warn, "Empty body on Lokid report node status");
             return;
         }
 
@@ -1026,7 +1026,7 @@ void ServiceNode::report_node_reachability(const sn_pub_key_t& sn_pk,
             if (status == "OK") {
                 success = true;
             } else {
-                LOKI_LOG(error, "Could not report node. Status: {}", status);
+                LOKI_LOG(warn, "Could not report node. Status: {}", status);
             }
         } catch (...) {
             LOKI_LOG(error,

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -22,6 +22,7 @@
 
 static constexpr size_t BLOCK_HASH_CACHE_SIZE = 20;
 static constexpr int STORAGE_SERVER_HARDFORK = 12;
+static constexpr int ENFORCED_REACHABILITY_HARDFORK = 13;
 
 class Database;
 

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -16,6 +16,7 @@
 #include "loki_common.h"
 #include "lokid_key.h"
 #include "pow.hpp"
+#include "reachability_testing.h"
 #include "stats.h"
 #include "swarm.h"
 
@@ -130,6 +131,8 @@ class ServiceNode {
 
     loki::lokid_key_pair_t lokid_key_pair_;
 
+    reachability_records_t reach_records_;
+
     void push_message(const message_t& msg);
 
     void save_if_new(const message_t& msg);
@@ -192,6 +195,13 @@ class ServiceNode {
     void send_blockchain_test_req(const sn_record_t& testee,
                                   bc_test_params_t params,
                                   blockchain_test_answer_t answer);
+
+    /// Report `sn` to Lokid as unreachable
+    void report_node_reachability(const sn_pub_key_t& sn, bool reachable);
+
+    /// Check if status is OK and handle failed test otherwise; note
+    /// that we want a copy of `sn` here because of the way it is called
+    void process_reach_test_response(sn_response_t&& res, const sn_pub_key_t& sn);
 
     /// From a peer
     void process_blockchain_test_response(sn_response_t&& res,

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -201,7 +201,8 @@ class ServiceNode {
 
     /// Check if status is OK and handle failed test otherwise; note
     /// that we want a copy of `sn` here because of the way it is called
-    void process_reach_test_response(sn_response_t&& res, const sn_pub_key_t& sn);
+    void process_reach_test_response(sn_response_t&& res,
+                                     const sn_pub_key_t& sn);
 
     /// From a peer
     void process_blockchain_test_response(sn_response_t&& res,

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -192,6 +192,10 @@ void Swarm::update_state(const all_swarms_t& swarms,
             all_funded_nodes_.push_back(sn);
         }
     }
+
+    for (const auto& sn : decommissioned) {
+        all_funded_nodes_.push_back(sn);
+    }
 }
 
 boost::optional<sn_record_t> Swarm::choose_funded_node() const {

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -208,6 +208,18 @@ boost::optional<sn_record_t> Swarm::choose_other_node() const {
     return all_other_nodes_[idx];
 }
 
+boost::optional<sn_record_t> Swarm::get_node_by_pk(const sn_pub_key_t &pk) const {
+
+    for (const auto& si : all_cur_swarms_) {
+        for (const auto& sn : si.snodes) {
+            if (sn.pub_key() == pk)
+                return sn;
+        }
+    }
+
+    return boost::none;
+}
+
 static uint64_t hex_to_u64(const user_pubkey_t& pk) {
 
     /// Create a buffer for 16 characters null terminated

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -211,7 +211,7 @@ Swarm::get_node_by_pk(const sn_pub_key_t& pk) const {
 
     for (const auto& si : all_valid_swarms_) {
         for (const auto& sn : si.snodes) {
-            if (sn.pub_key() == pk)
+            if (sn.pub_key_base32z() == pk)
                 return sn;
         }
     }

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -88,6 +88,9 @@ class Swarm {
     // Select a node from all existing nodes (excluding us); throws if there is
     // no other nodes
     boost::optional<sn_record_t> choose_other_node() const;
+
+    // Get the node with public key `pk` if exists
+    boost::optional<sn_record_t> get_node_by_pk(const sn_pub_key_t &pk) const;
 };
 
 } // namespace loki

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -25,6 +25,7 @@ using all_swarms_t = std::vector<SwarmInfo>;
 
 struct block_update_t {
     all_swarms_t swarms;
+    std::vector<sn_record_t> decommissioned_nodes;
     uint64_t height;
     std::string block_hash;
     int hardfork;
@@ -37,9 +38,9 @@ struct SwarmEvents {
 
     /// our (potentially new) swarm id
     swarm_id_t our_swarm_id;
-    /// whether our swarm got decommissioned and we
+    /// whether our swarm got dissolved and we
     /// need to salvage our stale data
-    bool decommissioned = false;
+    bool dissolved = false;
     /// detected new swarms that need to be bootstrapped
     std::vector<swarm_id_t> new_swarms;
     /// detected new snodes in our swarm
@@ -51,11 +52,12 @@ struct SwarmEvents {
 class Swarm {
 
     swarm_id_t cur_swarm_id_ = INVALID_SWARM_ID;
-    std::vector<SwarmInfo> all_cur_swarms_;
+    /// Note: this excludes the "dummy" swarm
+    std::vector<SwarmInfo> all_valid_swarms_;
     sn_record_t our_address_;
     std::vector<sn_record_t> swarm_peers_;
-
-    std::vector<sn_record_t> all_other_nodes_;
+    /// This includes decommissioned nodes
+    std::vector<sn_record_t> all_funded_nodes_;
 
     /// Check if `sid` is an existing (active) swarm
     bool is_existing_swarm(swarm_id_t sid) const;
@@ -69,15 +71,23 @@ class Swarm {
     SwarmEvents derive_swarm_events(const all_swarms_t& swarms) const;
 
     /// Update swarm state according to `events`
-    void update_state(const all_swarms_t& swarms, const SwarmEvents& events);
+    void update_state(const all_swarms_t& swarms,
+                      const std::vector<sn_record_t>& decommissioned,
+                      const SwarmEvents& events);
 
     void apply_swarm_changes(const all_swarms_t& new_swarms);
 
     bool is_pubkey_for_us(const user_pubkey_t& pk) const;
 
+    /// Whether `sn_address` is found in any of the swarms, including the
+    /// dummy swarm with decommissioned nodes
+    bool is_fully_funded_node(const std::string& sn_address) const;
+
     const std::vector<sn_record_t>& other_nodes() const;
 
-    const std::vector<SwarmInfo>& all_swarms() const { return all_cur_swarms_; }
+    const std::vector<SwarmInfo>& all_valid_swarms() const {
+        return all_valid_swarms_;
+    }
 
     swarm_id_t our_swarm_id() const { return cur_swarm_id_; }
 
@@ -87,10 +97,10 @@ class Swarm {
 
     // Select a node from all existing nodes (excluding us); throws if there is
     // no other nodes
-    boost::optional<sn_record_t> choose_other_node() const;
+    boost::optional<sn_record_t> choose_funded_node() const;
 
     // Get the node with public key `pk` if exists
-    boost::optional<sn_record_t> get_node_by_pk(const sn_pub_key_t &pk) const;
+    boost::optional<sn_record_t> get_node_by_pk(const sn_pub_key_t& pk) const;
 };
 
 } // namespace loki

--- a/utils/include/utils.hpp
+++ b/utils/include/utils.hpp
@@ -106,7 +106,7 @@ bool base32z_decode(const Stack& stack, V& value) {
     return true;
 }
 
-std::string hex64_to_base32z(const std::string& src);
+std::string hex_to_base32z(const std::string& src);
 
 /// Returns a random number from [0, n) using a static generator
 uint64_t uniform_distribution_portable(uint64_t n);

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -23,7 +23,7 @@ constexpr uint8_t hexpair_to_byte(const char& hi, const char& lo) {
     return hex_to_nibble(hi) << 4 | hex_to_nibble(lo);
 }
 
-std::string hex64_to_base32z(const std::string& src) {
+std::string hex_to_base32z(const std::string& src) {
     // decode to binary
     std::vector<uint8_t> bin;
     // odd sized is invalid


### PR DESCRIPTION
- Keep track of all nodes that failed the reachability test.
- Periodically test two nodes: one randomly selected and one that is known to have failed previously (this is done to give failing nodes a better chance to be recommissioned as soon as possible once they are back online).
- When a node is not reachable for longer than 120mins (to match uptime proofs) it will be reported to Lokid via a new endpoint. The same endpoint is used to report previously offending nodes as healthy.
- To be on the safe side and keep things simple, there is currently some redundancy in how many times a node's status is reported to Lokid.