### PR TITLE
Derive tester/testee based on older (more stable) block

### DIFF
--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -255,6 +255,10 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
                                   const std::string& tester_addr,
                                   const std::string& msg_hash);
 
+    void process_blockchain_test_req(uint64_t height,
+                                     const std::string& tester_pk,
+                                     bc_test_params_t params);
+
     bool parse_header(const char* key);
 
     template <typename... Args>

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -19,7 +19,7 @@
 #include "stats.h"
 #include "swarm.h"
 
-static constexpr size_t BLOCK_HASH_CACHE_SIZE = 20;
+static constexpr size_t BLOCK_HASH_CACHE_SIZE = 30;
 static constexpr int STORAGE_SERVER_HARDFORK = 12;
 
 class Database;
@@ -186,11 +186,12 @@ class ServiceNode {
                               sn_record_t& testee);
 
     /// Send a request to a SN under test
-    void send_storage_test_req(const sn_record_t& testee,
+    void send_storage_test_req(const sn_record_t& testee, uint64_t test_height,
                                const storage::Item& item);
 
     void send_blockchain_test_req(const sn_record_t& testee,
                                   bc_test_params_t params,
+                                  uint64_t test_height,
                                   blockchain_test_answer_t answer);
 
     /// From a peer


### PR DESCRIPTION
- Derive tester/testee based on the firth most recent block (instead of the most recent block) to minimise discrepancies between nodes due to alternative chains. This is not meant to be bulletproof, just an improvement over what we have now; we could have used checkpoints, but they come with they come with their own problems).
- Add `height` parameter to blockchain test requests, so we can check tester/testee in the future (turns out it wasn't already there for blockchain testing, but was/is for storage testing).
- Use pubkey instead of snode address to avoid extra memory allocations.