### PR TITLE
Record whether storage test was rejected by testee

### DIFF
--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -85,7 +85,8 @@ class FailedRequestHandler
     void init_timer();
 };
 
-enum class MessageTestStatus { SUCCESS, RETRY, ERROR };
+/// WRONG_REQ - request was ignored as not valid (e.g. incorrect tester)
+enum class MessageTestStatus { SUCCESS, RETRY, ERROR, WRONG_REQ };
 
 /// All service node logic that is not network-specific
 class ServiceNode {
@@ -200,6 +201,11 @@ class ServiceNode {
 
     /// Report `sn` to Lokid as unreachable
     void report_node_reachability(const sn_pub_key_t& sn, bool reachable);
+
+    void process_storage_test_response(const sn_record_t& testee,
+                                       const storage::Item& item,
+                                       uint64_t test_height,
+                                       sn_response_t&& res);
 
     /// Check if status is OK and handle failed test otherwise; note
     /// that we want a copy of `sn` here because of the way it is called

--- a/httpserver/stats.h
+++ b/httpserver/stats.h
@@ -11,7 +11,7 @@ struct time_entry_t {
     time_t timestamp;
 };
 
-enum class ResultType { OK, MISMATCH, OTHER };
+enum class ResultType { OK, MISMATCH, OTHER, REJECTED };
 
 struct test_result_t {
 
@@ -26,6 +26,8 @@ inline const char* to_str(ResultType result) {
         return "OK";
     case ResultType::MISMATCH:
         return "MISMATCH";
+    case ResultType::REJECTED:
+        return "REJECTED";
     case ResultType::OTHER:
     default:
         return "OTHER";


### PR DESCRIPTION
- send different response if storage test parameters seem wrong (e.g. wrong tester)
- record whether storage test was rejected rather than simply failed