### PR TITLE
Fix a crash when expiring

### DIFF
--- a/httpserver/reachability_testing.cpp
+++ b/httpserver/reachability_testing.cpp
@@ -53,9 +53,11 @@ bool reachability_records_t::record_unreachable(const sn_pub_key_t& sn) {
 
 bool reachability_records_t::expire(const sn_pub_key_t& sn) {
 
-    if (offline_nodes_.erase(sn)) {
+    bool erased = offline_nodes_.erase(sn);
+    if (erased)
         LOKI_LOG(debug, "Removed entry for {}", sn);
-    }
+
+    return erased;
 }
 
 void reachability_records_t::set_reported(const sn_pub_key_t& sn) {

--- a/httpserver/reachability_testing.h
+++ b/httpserver/reachability_testing.h
@@ -45,6 +45,8 @@ class reachability_records_t {
     // reported to Lokid as being unreachable for a long time
     bool record_unreachable(const sn_pub_key_t& sn);
 
+    // Expires a node, removing it from offline nodes.  Returns true if found
+    // and removed, false if it didn't exist.
     bool expire(const sn_pub_key_t& sn);
 
     void set_reported(const sn_pub_key_t& sn);


### PR DESCRIPTION
expire() wasn't returning a value causing a crash when called.