### PR TITLE
Fix inactive nodes not responding to reachability tests

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -560,6 +560,12 @@ void connection_t::process_request() {
     switch (request_.method()) {
     case http::verb::post: {
         std::string reason;
+
+        // Respond to ping even if we are not ready
+        if (target == "/swarms/ping_test/v1") {
+            this->process_swarm_req(target);
+            break;
+        }
         if (!service_node_.snode_ready(reason)) {
             LOKI_LOG(debug,
                      "Ignoring post request; storage server not ready: {}",
@@ -598,8 +604,6 @@ void connection_t::process_request() {
 
             this->process_swarm_req(target);
 
-        } else if (target == "/swarms/ping_test/v1") {
-            this->process_swarm_req(target);
         }
 #ifdef INTEGRATION_TEST
         else if (target == "/retrieve_all") {

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -99,7 +99,7 @@ constexpr std::chrono::milliseconds SWARM_UPDATE_INTERVAL = 200ms;
 constexpr std::chrono::milliseconds SWARM_UPDATE_INTERVAL = 1000ms;
 #endif
 constexpr std::chrono::seconds STATS_CLEANUP_INTERVAL = 60min;
-constexpr std::chrono::seconds PING_PEERS_INTERVAL = 2s;
+constexpr std::chrono::seconds PING_PEERS_INTERVAL = 10s;
 constexpr std::chrono::minutes LOKID_PING_INTERVAL = 5min;
 constexpr std::chrono::minutes POW_DIFFICULTY_UPDATE_INTERVAL = 10min;
 constexpr std::chrono::seconds VERSION_CHECK_INTERVAL = 10min;


### PR DESCRIPTION
- Responds to reachability tests even if the node is inactive (syncing, decommissioned, or not in any swarm). This is mostly done for decommissioned nodes as we wouldn't be able to test them otherwise.
- Increased interval to 10s for reachability tests.