### PR TITLE
Use default testnet rpc port under --testnet

### DIFF
--- a/httpserver/command_line.cpp
+++ b/httpserver/command_line.cpp
@@ -70,6 +70,10 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
         return;
     }
 
+    if (options_.testnet && !vm.count("lokid-rpc-port")) {
+        options_.lokid_rpc_port = 38157;
+    }
+
     if (!vm.count("ip") || !vm.count("port")) {
         throw std::runtime_error(
             "Invalid option: address and/or port missing.");

--- a/httpserver/command_line.h
+++ b/httpserver/command_line.h
@@ -7,7 +7,7 @@ namespace loki {
 
 struct command_line_options {
     uint16_t port;
-    uint16_t lokid_rpc_port = 22023;
+    uint16_t lokid_rpc_port = 22023; // Or 38157 if `testnet`
     bool force_start = false;
     bool print_version = false;
     bool print_help = false;


### PR DESCRIPTION
Currently if you specify `--testnet` but leave the default lokid rpc port
you still get 22023 which was unexpected; this updates the default to
lokid's default 38157 if `--testnet` is given but the lokid rpc port is
not explicitly specified.