### PR TITLE
Http client code improvements and open file descriptor diagnostics

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -105,15 +105,15 @@ void LokidClient::make_lokid_request(boost::string_view method,
                                      const nlohmann::json& params,
                                      http_callback_t&& cb) const {
 
-    make_lokid_request(local_ip_, lokid_rpc_port_, method, params,
-                       std::move(cb));
+    make_custom_lokid_request(local_ip_, lokid_rpc_port_, method, params,
+                              std::move(cb));
 }
 
-void LokidClient::make_lokid_request(const std::string& daemon_ip,
-                                     const uint16_t daemon_port,
-                                     boost::string_view method,
-                                     const nlohmann::json& params,
-                                     http_callback_t&& cb) const {
+void LokidClient::make_custom_lokid_request(const std::string& daemon_ip,
+                                            const uint16_t daemon_port,
+                                            boost::string_view method,
+                                            const nlohmann::json& params,
+                                            http_callback_t&& cb) const {
 
     auto req = std::make_shared<request_t>();
 
@@ -242,8 +242,12 @@ void connection_t::do_handshake() {
 }
 
 void connection_t::on_handshake(boost::system::error_code ec) {
+
+    const auto sockfd = stream_.lowest_layer().native_handle();
+    LOKI_LOG(debug, "Open https socket: {}", sockfd);
+    get_net_stats().record_socket_open(sockfd);
     if (ec) {
-        LOKI_LOG(warn, "ssl handshake failed: {}", ec.message());
+        LOKI_LOG(warn, "ssl handshake failed: ec: {} ({})", ec.value(), ec.message());
         deadline_.cancel();
         return;
     }
@@ -617,6 +621,12 @@ void connection_t::process_request() {
             response_.result(http::status::ok);
             write_response();
             ioc_.stop();
+        } else if (target == "/sleep") {
+            ioc_.post([]() {
+                LOKI_LOG(warn, "Sleeping for some time...");
+                std::this_thread::sleep_for(std::chrono::seconds(30));
+            });
+            response_.result(http::status::ok);
         }
 #endif
         else {
@@ -1166,10 +1176,14 @@ void connection_t::on_shutdown(boost::system::error_code ec) {
         // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
         ec.assign(0, ec.category());
     }
-    if (ec)
+    if (ec) {
         LOKI_LOG(error, "Could not close ssl stream gracefully, ec: {}",
                  ec.message());
+    }
 
+    const auto sockfd = stream_.lowest_layer().native_handle();
+    LOKI_LOG(debug, "Close https socket: {}", sockfd);
+    get_net_stats().record_socket_close(sockfd);
     stream_.lowest_layer().close();
 }
 
@@ -1226,7 +1240,9 @@ HttpClientSession::HttpClientSession(boost::asio::io_context& ioc,
 
 void HttpClientSession::on_connect() {
 
-    LOKI_LOG(trace, "on connect");
+    const auto sockfd = socket_.native_handle();
+    LOKI_LOG(debug, "Open http socket: {}", sockfd);
+    get_net_stats().record_socket_open(sockfd);
     http::async_write(socket_, *req_,
                       std::bind(&HttpClientSession::on_write,
                                 shared_from_this(), std::placeholders::_1,
@@ -1285,11 +1301,21 @@ void HttpClientSession::start() {
         if (ec) {
             // We should make sure that we print the error a few levels above,
             // where we have more context
-            LOKI_LOG(
-                debug,
-                "[http client]: could not connect to {}:{}, message: {} ({})",
-                endpoint_.address().to_string(), endpoint_.port(), ec.message(),
-                ec.value());
+
+            if (ec == boost::system::errc::connection_refused) {
+                LOKI_LOG(debug,
+                         "[http client]: could not connect to {}:{}, message: "
+                         "{} ({})",
+                         endpoint_.address().to_string(), endpoint_.port(),
+                         ec.message(), ec.value());
+            } else {
+                LOKI_LOG(error,
+                         "[http client]: could not connect to {}:{}, message: "
+                         "{} ({})",
+                         endpoint_.address().to_string(), endpoint_.port(),
+                         ec.message(), ec.value());
+            }
+
             trigger_callback(SNodeError::NO_REACH, nullptr);
             return;
         }
@@ -1351,10 +1377,14 @@ void HttpClientSession::clean_up() {
                  ec.message());
     }
 
+    const auto sockfd = socket_.native_handle();
     socket_.close(ec);
 
     if (ec) {
-        LOKI_LOG(error, "On close socket [{}: {}]", ec.value(), ec.message());
+        LOKI_LOG(error, "Closing socket {} failed [{}: {}]", sockfd, ec.value(), ec.message());
+    } else {
+        LOKI_LOG(debug, "Close http socket: {}", sockfd);
+        get_net_stats().record_socket_close(sockfd);
     }
 }
 

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -70,11 +70,11 @@ class LokidClient {
     void make_lokid_request(boost::string_view method,
                             const nlohmann::json& params,
                             http_callback_t&& cb) const;
-    void make_lokid_request(const std::string& daemon_ip,
-                            const uint16_t daemon_port,
-                            boost::string_view method,
-                            const nlohmann::json& params,
-                            http_callback_t&& cb) const;
+    void make_custom_lokid_request(const std::string& daemon_ip,
+                                   const uint16_t daemon_port,
+                                   boost::string_view method,
+                                   const nlohmann::json& params,
+                                   http_callback_t&& cb) const;
 };
 
 constexpr auto SESSION_TIME_LIMIT = std::chrono::seconds(30);

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -104,6 +104,7 @@ class HttpClientSession
     response_t res_;
 
     bool used_callback_ = false;
+    bool needs_cleanup = true;
 
     void on_connect();
 
@@ -113,6 +114,8 @@ class HttpClientSession
 
     void trigger_callback(SNodeError error,
                           std::shared_ptr<std::string>&& body);
+
+    void clean_up();
 
   public:
     // Resolver and socket require an io_context

--- a/httpserver/https_client.h
+++ b/httpserver/https_client.h
@@ -14,6 +14,9 @@ void make_https_request(boost::asio::io_context& ioc, const std::string& ip,
 class HttpsClientSession
     : public std::enable_shared_from_this<HttpsClientSession> {
 
+    // For debugging purposes mostly
+    uint64_t connection_idx;
+
     using tcp = boost::asio::ip::tcp;
 
     boost::asio::io_context& ioc_;

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -8,6 +8,7 @@
 #include "service_node.h"
 #include "swarm.h"
 #include "version.h"
+#include "utils.hpp"
 
 #include <boost/filesystem.hpp>
 #include <sodium.h>
@@ -117,6 +118,15 @@ int main(int argc, char* argv[]) {
     if (sodium_init() != 0) {
         LOKI_LOG(error, "Could not initialize libsodium");
         return EXIT_FAILURE;
+    }
+
+    {
+        const auto fd_limit = util::get_fd_limit();
+        if (fd_limit != -1) {
+            LOKI_LOG(debug, "Open file descriptor limit: {}", fd_limit);
+        } else {
+            LOKI_LOG(debug, "Open descriptor limit: N/A");
+        }
     }
 
     try {

--- a/httpserver/net_stats.h
+++ b/httpserver/net_stats.h
@@ -1,10 +1,33 @@
 #pragma once
 
+#include <set>
+#include "loki_logger.h"
+
 struct net_stats_t {
 
     uint32_t connections_in = 0;
     uint32_t http_connections_out = 0;
     uint32_t https_connections_out = 0;
+
+    std::set<int> open_fds;
+
+    void record_socket_open(int sockfd) {
+#ifdef INTEGRATION_TEST
+        if (open_fds.find(sockfd) != open_fds.end()) {
+            LOKI_LOG(critical, "Already recorded as open: {}!", sockfd);
+        }
+#endif
+        open_fds.insert(sockfd);
+    }
+
+    void record_socket_close(int sockfd) {
+#ifdef INTEGRATION_TEST
+        if (open_fds.find(sockfd) == open_fds.end()) {
+            LOKI_LOG(critical, "Socket is NOT recorded as open: {}", sockfd);
+        }
+#endif
+        open_fds.erase(sockfd);
+    }
 };
 
 inline net_stats_t& get_net_stats() {

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -306,7 +306,7 @@ void ServiceNode::bootstrap_data() {
     auto req_counter = std::make_shared<int>(0);
 
     for (auto seed_node : seed_nodes) {
-        lokid_client_.make_lokid_request(
+        lokid_client_.make_custom_lokid_request(
             seed_node.first, seed_node.second, "get_n_service_nodes", params,
             [this, seed_node, req_counter,
              node_count = seed_nodes.size()](const sn_response_t&& res) {
@@ -1585,6 +1585,7 @@ std::string ServiceNode::get_stats() const {
     val["connections_in"] = get_net_stats().connections_in;
     val["http_connections_out"] = get_net_stats().http_connections_out;
     val["https_connections_out"] = get_net_stats().https_connections_out;
+    val["open_socket_count"] = get_net_stats().open_fds.size();
 
     /// we want pretty (indented) json, but might change that in the future
     constexpr bool PRETTY = true;

--- a/utils/include/utils.hpp
+++ b/utils/include/utils.hpp
@@ -115,4 +115,7 @@ uint64_t uniform_distribution_portable(uint64_t n);
 uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister,
                                        uint64_t n);
 
+/// Return the open file limit (-1 on failure)
+int get_fd_limit();
+
 } // namespace util

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -2,6 +2,10 @@
 
 #include <chrono>
 
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
 namespace util {
 
 uint64_t get_time_ms() {
@@ -111,6 +115,15 @@ uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister,
         x = mersenne_twister();
     while (x >= secure_max);
     return x / (secure_max / n);
+}
+
+int get_fd_limit() {
+
+#ifdef _WIN32
+    return -1;
+#endif
+
+    return sysconf(_SC_OPEN_MAX);
 }
 
 } // namespace util


### PR DESCRIPTION
- deadline timer shutdowns the socket properly (as a bonus this results in fewer errors being printed);
- some accounting of open sockets (exposed via `get_stats`);