### PR TITLE
Fix making unnecessary swarm requests to lokid in some exceptional cases

### DIFF
--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -704,11 +704,13 @@ void ServiceNode::swarm_timer_tick() {
             } else {
                 LOKI_LOG(critical, "Failed to contact local Lokid");
             }
-        });
 
-    swarm_update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
-    swarm_update_timer_.async_wait(
-        boost::bind(&ServiceNode::swarm_timer_tick, this));
+            // It would make more sense to wait the difference between the time
+            // elapsed and SWARM_UPDATE_INTERVAL, but this is good enough:
+            swarm_update_timer_.expires_after(SWARM_UPDATE_INTERVAL);
+            swarm_update_timer_.async_wait(
+                boost::bind(&ServiceNode::swarm_timer_tick, this));
+        });
 }
 
 void ServiceNode::cleanup_timer_tick() {


### PR DESCRIPTION
It doesn't make sense to call `get_n_service_nodes` while the previous call of the same type is still being executed. Here we start the timer only after we are done with the previous call (whether it was successful or not).