### PR TITLE
Delay accepting new connections if failed

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -151,13 +151,16 @@ accept_connection(boost::asio::io_context& ioc,
 
     acceptor.async_accept([&](const error_code& ec, tcp::socket socket) {
         LOKI_LOG(trace, "connection accepted");
-        if (!ec)
+        if (!ec) {
+
             std::make_shared<connection_t>(ioc, ssl_ctx, std::move(socket), sn,
                                            channel_encryption, rate_limiter,
                                            security)
                 ->start();
 
-        if (ec) {
+            accept_connection(ioc, ssl_ctx, acceptor, sn, channel_encryption,
+                              rate_limiter, security);
+        } else {
             LOKI_LOG(
                 error,
                 "Could not accept a new connection {}: {}. Will only start "
@@ -179,9 +182,6 @@ accept_connection(boost::asio::io_context& ioc,
                                   channel_encryption, rate_limiter, security);
             });
         }
-
-        accept_connection(ioc, ssl_ctx, acceptor, sn, channel_encryption,
-                          rate_limiter, security);
     });
 }
 

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -171,7 +171,7 @@ void HttpsClientSession::on_write(error_code ec, size_t bytes_transferred) {
 
     LOKI_LOG(trace, "on write");
     if (ec) {
-        LOKI_LOG(error, "Error on write, ec: {}. Message: {}", ec.value(),
+        LOKI_LOG(error, "Https error on write, ec: {}. Message: {}", ec.value(),
                  ec.message());
         trigger_callback(SNodeError::ERROR_OTHER, nullptr);
         return;
@@ -262,10 +262,9 @@ void HttpsClientSession::on_shutdown(boost::system::error_code ec) {
         // Rationale:
         // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
         ec.assign(0, ec.category());
-    }
-    if (ec) {
-        LOKI_LOG(error, "could not shutdown stream gracefully: {}",
-                 ec.message());
+    } else if (ec) {
+        LOKI_LOG(error, "could not shutdown stream gracefully: {} ({})",
+                 ec.message(), ec.value());
     }
 
     const auto sockfd = stream_.lowest_layer().native_handle();


### PR DESCRIPTION
If we fail to accept a new connection we are unlikely to be able to succeed immediately after, so we introduce a short delay.