### PR TITLE
More robust clean-up for incoming connections

### DIFF
--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -231,6 +231,9 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     /// (synchronously).
     void process_request();
 
+    /// Unsubscribe listener (if any) and shutdown the connection
+    void clean_up();
+
     void process_store(const nlohmann::json& params);
 
     void process_retrieve(const nlohmann::json& params);

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -124,7 +124,7 @@ void HttpsClientSession::start() {
                              ec.value(), ec.message());
                 }
             } else {
-                LOKI_LOG(warn, "client socket timed out");
+                LOKI_LOG(debug, "client socket timed out");
                 self->do_close();
             }
         });
@@ -263,7 +263,8 @@ void HttpsClientSession::on_shutdown(boost::system::error_code ec) {
         // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
         ec.assign(0, ec.category());
     } else if (ec) {
-        LOKI_LOG(error, "could not shutdown stream gracefully: {} ({})",
+        // This one is too noisy, so demoted to debug:
+        LOKI_LOG(debug, "could not shutdown stream gracefully: {} ({})",
                  ec.message(), ec.value());
     }
 


### PR DESCRIPTION
- makes sure we remove all listeners whenever we cancel the deadline timer