### PR TITLE
Lokid 6.x key fetching & local RPC ip override

### DIFF
--- a/common/include/loki_logger.h
+++ b/common/include/loki_logger.h
@@ -5,7 +5,7 @@
 #define LOKI_LOG_N(LVL, msg, ...)                                              \
     spdlog::get("loki_logger")->LVL("[{}] " msg, __func__, __VA_ARGS__)
 #define LOKI_LOG_2(LVL, msg)                                                   \
-    spdlog::get("loki_logger")->LVL("[{}] " msg, __func__);
+    spdlog::get("loki_logger")->LVL("[{}] " msg, __func__)
 
 #define GET_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, NAME, ...) NAME
 #define LOKI_LOG(...)                                                          \

--- a/crypto/include/lokid_key.h
+++ b/crypto/include/lokid_key.h
@@ -15,7 +15,7 @@ struct lokid_key_pair_t {
     public_key_t public_key;
 };
 
-private_key_t parseLokidKey(const std::string& path);
+private_key_t lokidKeyFromHex(const std::string& private_key_hex);
 
 public_key_t calcPublicKey(const private_key_t& private_key);
 

--- a/httpserver/command_line.cpp
+++ b/httpserver/command_line.cpp
@@ -20,7 +20,6 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
     po::options_description all, hidden;
     // clang-format off
     desc_.add_options()
-        ("lokid-key", po::value(&options_.lokid_key_path), "Path to the Service Node key file")
         ("data-dir", po::value(&options_.data_dir), "Path to persistent data (defaults to ~/.loki/storage)")
         ("config-file", po::value(&config_file), "Path to custom config file (defaults to `storage-server.conf' inside --data-dir)")
         ("log-level", po::value(&options_.log_level), "Log verbosity level, see Log Levels below for accepted values")
@@ -35,7 +34,8 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
         // and `port=` in the config file to specify them.
     hidden.add_options()
         ("ip", po::value(&options_.ip), "IP to listen on")
-        ("port", po::value(&options_.port), "Port to listen on");
+        ("port", po::value(&options_.port), "Port to listen on")
+        ("lokid-key", po::value<std::string>(), "(deprecated)");
     // clang-format on
 
     all.add(desc_).add(hidden);

--- a/httpserver/command_line.cpp
+++ b/httpserver/command_line.cpp
@@ -24,6 +24,7 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
         ("data-dir", po::value(&options_.data_dir), "Path to persistent data (defaults to ~/.loki/storage)")
         ("config-file", po::value(&config_file), "Path to custom config file (defaults to `storage-server.conf' inside --data-dir)")
         ("log-level", po::value(&options_.log_level), "Log verbosity level, see Log Levels below for accepted values")
+        ("lokid-rpc-ip", po::value(&options_.lokid_rpc_port), "RPC IP on which the local Loki daemon is listening (usually localhost)")
         ("lokid-rpc-port", po::value(&options_.lokid_rpc_port), "RPC port on which the local Loki daemon is listening")
         ("testnet", po::bool_switch(&options_.testnet), "Start storage server in testnet mode")
         ("force-start", po::bool_switch(&options_.force_start), "Ignore the initialisation ready check")

--- a/httpserver/command_line.h
+++ b/httpserver/command_line.h
@@ -7,6 +7,7 @@ namespace loki {
 
 struct command_line_options {
     uint16_t port;
+    std::string lokid_rpc_ip = "127.0.0.1";
     uint16_t lokid_rpc_port = 22023; // Or 38157 if `testnet`
     bool force_start = false;
     bool print_version = false;

--- a/httpserver/command_line.h
+++ b/httpserver/command_line.h
@@ -15,7 +15,6 @@ struct command_line_options {
     bool testnet = false;
     std::string ip;
     std::string log_level = "info";
-    std::string lokid_key_path;
     std::string data_dir;
 };
 

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -98,14 +98,14 @@ static std::string arr32_to_hex(const std::array<uint8_t, 32>& arr) {
     return std::string(hex);
 }
 // ======================== Lokid Client ========================
-LokidClient::LokidClient(boost::asio::io_context& ioc, uint16_t port)
-    : ioc_(ioc), lokid_rpc_port_(port) {}
+LokidClient::LokidClient(boost::asio::io_context& ioc, std::string ip, uint16_t port)
+    : ioc_(ioc), lokid_rpc_ip_(std::move(ip)), lokid_rpc_port_(port) {}
 
 void LokidClient::make_lokid_request(boost::string_view method,
                                      const nlohmann::json& params,
                                      http_callback_t&& cb) const {
 
-    make_custom_lokid_request(local_ip_, lokid_rpc_port_, method, params,
+    make_custom_lokid_request(lokid_rpc_ip_, lokid_rpc_port_, method, params,
                               std::move(cb));
 }
 

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -87,16 +87,6 @@ void make_http_request(boost::asio::io_context& ioc,
     session->start();
 }
 
-static std::string arr32_to_hex(const std::array<uint8_t, 32>& arr) {
-
-    constexpr size_t res_len = 32 * 2 + 1;
-
-    char hex[res_len];
-
-    sodium_bin2hex(hex, res_len, arr.data(), 32);
-
-    return std::string(hex);
-}
 // ======================== Lokid Client ========================
 LokidClient::LokidClient(boost::asio::io_context& ioc, std::string ip, uint16_t port)
     : ioc_(ioc), lokid_rpc_ip_(std::move(ip)), lokid_rpc_port_(port) {}
@@ -134,6 +124,47 @@ void LokidClient::make_custom_lokid_request(const std::string& daemon_ip,
 
     make_http_request(ioc_, daemon_ip, daemon_port, req, std::move(cb));
 }
+
+private_key_t LokidClient::wait_for_privkey() {
+    // fetch SN private key from lokid; do this synchronously because we can't finish startup
+    // until we have it.
+    loki::private_key_t private_key;
+    LOKI_LOG(info, "Retrieving SN key from lokid");
+    boost::asio::steady_timer delay{ioc_};
+    std::function<void(loki::sn_response_t &&res)> key_fetch;
+    key_fetch = [&](loki::sn_response_t res) {
+        try {
+            if (res.error_code != loki::SNodeError::NO_ERROR)
+                throw std::runtime_error(loki::error_string(res.error_code));
+            else if (!res.body)
+                throw std::runtime_error("empty body");
+            else {
+                auto r = nlohmann::json::parse(*res.body);
+                const auto &privkey = r.at("result").at("service_node_privkey").get_ref<const std::string &>();
+                if (privkey.size() != 2 * loki::KEY_LENGTH && !std::all_of(privkey.begin(), privkey.end(),
+                            [](char c) { return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'); }))
+                    throw std::runtime_error("returned value is not hex");
+                else {
+                    private_key = loki::lokidKeyFromHex(privkey);
+                    // run out of work, which will end the event loop
+                }
+            }
+        } catch (const std::exception &e) {
+            LOKI_LOG(critical, "Error retrieving SN privkey from lokid @ {}:{}: {}.  Is lokid running?  Retrying in 5s",
+                     lokid_rpc_ip_, lokid_rpc_port_, e.what());
+
+            delay.expires_after(std::chrono::seconds{5});
+            delay.async_wait([this, &key_fetch](const boost::system::error_code &) {
+                    make_lokid_request("get_service_node_privkey", {}, key_fetch); });
+        }
+    };
+    make_lokid_request("get_service_node_privkey", {}, key_fetch);
+    ioc_.run(); // runs until we get success above
+    ioc_.restart();
+
+    return private_key;
+}
+
 // =============================================================
 
 namespace http_server {

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -61,12 +61,12 @@ using http_callback_t = std::function<void(sn_response_t)>;
 
 class LokidClient {
 
-    const uint16_t lokid_rpc_port_;
-    const char* local_ip_ = "127.0.0.1";
     boost::asio::io_context& ioc_;
+    std::string lokid_rpc_ip_;
+    const uint16_t lokid_rpc_port_;
 
   public:
-    LokidClient(boost::asio::io_context& ioc, uint16_t port);
+    LokidClient(boost::asio::io_context& ioc, std::string ip, uint16_t port);
     void make_lokid_request(boost::string_view method,
                             const nlohmann::json& params,
                             http_callback_t&& cb) const;

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -104,7 +104,7 @@ int main(int argc, char* argv[]) {
     LOKI_LOG(info, "Setting log level to {}", options.log_level);
     LOKI_LOG(info, "Setting database location to {}", options.data_dir);
     LOKI_LOG(info, "Setting Lokid key path to {}", options.lokid_key_path);
-    LOKI_LOG(info, "Setting Lokid RPC port to {}", options.lokid_rpc_port);
+    LOKI_LOG(info, "Setting Lokid RPC to {}:{}", options.lokid_rpc_ip, options.lokid_rpc_port);
     LOKI_LOG(info, "Listening at address {} port {}", options.ip, options.port);
 
 #ifdef DISABLE_SNODE_SIGNATURE
@@ -141,7 +141,7 @@ int main(int argc, char* argv[]) {
 
         loki::lokid_key_pair_t lokid_key_pair{private_key, public_key};
 
-        auto lokid_client = loki::LokidClient(ioc, options.lokid_rpc_port);
+        auto lokid_client = loki::LokidClient(ioc, options.lokid_rpc_ip, options.lokid_rpc_port);
 
         loki::ServiceNode service_node(ioc, worker_ioc, options.port,
                                        lokid_key_pair, options.data_dir,

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -103,7 +103,6 @@ int main(int argc, char* argv[]) {
 
     LOKI_LOG(info, "Setting log level to {}", options.log_level);
     LOKI_LOG(info, "Setting database location to {}", options.data_dir);
-    LOKI_LOG(info, "Setting Lokid key path to {}", options.lokid_key_path);
     LOKI_LOG(info, "Setting Lokid RPC to {}:{}", options.lokid_rpc_ip, options.lokid_rpc_port);
     LOKI_LOG(info, "Listening at address {} port {}", options.ip, options.port);
 
@@ -131,17 +130,17 @@ int main(int argc, char* argv[]) {
 
     try {
 
-        // ed25519 key
-        const auto private_key = loki::parseLokidKey(options.lokid_key_path);
+        auto lokid_client = loki::LokidClient(ioc, options.lokid_rpc_ip, options.lokid_rpc_port);
+
+        const auto private_key = lokid_client.wait_for_privkey();
         const auto public_key = loki::calcPublicKey(private_key);
+        LOKI_LOG(info, "Retrieved keys from Lokid; our SN pubkey is: {}", util::as_hex(public_key));
 
         // TODO: avoid conversion to vector
         const std::vector<uint8_t> priv(private_key.begin(), private_key.end());
         ChannelEncryption<std::string> channel_encryption(priv);
 
         loki::lokid_key_pair_t lokid_key_pair{private_key, public_key};
-
-        auto lokid_client = loki::LokidClient(ioc, options.lokid_rpc_ip, options.lokid_rpc_port);
 
         loki::ServiceNode service_node(ioc, worker_ioc, options.port,
                                        lokid_key_pair, options.data_dir,

--- a/utils/include/utils.hpp
+++ b/utils/include/utils.hpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <array>
 
 namespace util {
 
@@ -107,6 +108,31 @@ bool base32z_decode(const Stack& stack, V& value) {
 }
 
 std::string hex_to_base32z(const std::string& src);
+
+std::string hex_to_bytes(const std::string &hex);
+
+// Creates a hex string from a character sequence.
+template <typename It>
+std::string as_hex(It begin, It end) {
+    constexpr std::array<char, 16> lut{{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'}};
+    std::string hex;
+    using std::distance;
+    hex.reserve(distance(begin, end) * 2);
+    while (begin != end) {
+        char c = *begin;
+        hex += lut[(c & 0xf0) >> 4];
+        hex += lut[c & 0x0f];
+        ++begin;
+    }
+    return hex;
+}
+
+template <typename String>
+inline std::string as_hex(const String &s) {
+    using std::begin;
+    using std::end;
+    return as_hex(begin(s), end(s));
+}
 
 /// Returns a random number from [0, n) using a static generator
 uint64_t uniform_distribution_portable(uint64_t n);

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -16,15 +16,23 @@ uint64_t get_time_ms() {
 }
 
 constexpr uint8_t hex_to_nibble(const char& ch) {
-    return (ch >= '0' && ch <= '9')
-               ? ch - 48
-               : ((ch >= 'A' && ch <= 'F')
-                      ? ch - 55
-                      : ((ch >= 'a' && ch <= 'f') ? ch - 87 : 0));
+    return
+        (ch >= '0' && ch <= '9') ? ch - '0' :
+        (ch >= 'A' && ch <= 'F') ? ch - 'A' + 10 :
+        (ch >= 'a' && ch <= 'f') ? ch - 'a' + 10 :
+        0;
 }
 
 constexpr uint8_t hexpair_to_byte(const char& hi, const char& lo) {
     return hex_to_nibble(hi) << 4 | hex_to_nibble(lo);
+}
+
+std::string hex_to_bytes(const std::string &hex) {
+    std::string result;
+    result.reserve(hex.size() / 2);
+    for (size_t i = 0, end = hex.size() & ~1; i < end; i += 2)
+        result.push_back(hexpair_to_byte(hex[i], hex[i+1]));
+    return result;
 }
 
 std::string hex_to_base32z(const std::string& src) {


### PR DESCRIPTION
This changes storage server to fetch the SN private key via the RPC call added in lokid 6.x (which is also used by lokinet) at startup (i.e. before starting the main event loop), and allows the local RPC ip to be specified on the command-line.

As a useful side effect of this change it delays storage server startup until lokid is ready and running as a service node, which means we get earlier diagnostics about failures from storage server.  It also means that lokid is very likely to get a ping from the storage server right away--currently if you restart both storage server starts up must faster and so the first ping typically fails, which means lokid can't send uptime proofs until after the second ping.

The `--lokid-key` option is still accepted as an argument but now ignored (so that people with it in a config file can still start up).

This also adds a templated function to convert byte sequences to hex to be able to print it.  (Also removes one from http_connection.cpp that did the same via sodium for a specific `std::array<uint8_t, 32>`, but that wasn't actually called anywhere).

---

Notes for follow-on work that switches to ed25519 keys, the ed25519 privkey is available by changing the `service_node_privkey` key to `service_node_ed25519_privkey`.  Note that that one returns a 64-byte (128 hex digit) string rather than a 32-byte string, which is what sodium wants (the internal format is, I believe, pubkey immediately followed by privkey.) but won't fit in the current `private_key_t` typedef.