### PR TITLE
Allow messenger clients to proxy to other snodes

### DIFF
--- a/httpserver/https_client.h
+++ b/httpserver/https_client.h
@@ -45,8 +45,9 @@ class HttpsClientSession
 
     void on_read(boost::system::error_code ec, std::size_t bytes_transferred);
 
-    void trigger_callback(SNodeError error,
-                          std::shared_ptr<std::string>&& body);
+    void
+    trigger_callback(SNodeError error, std::shared_ptr<std::string>&& body,
+                     boost::optional<response_t> raw_response = boost::none);
 
     void on_handshake(boost::system::error_code ec);
     bool verify_signature();

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -526,6 +526,30 @@ void ServiceNode::process_push(const message_t& msg) {
     save_if_new(msg);
 }
 
+void ServiceNode::process_proxy_req(const std::string& req_body,
+                                    const std::string& sender_key,
+                                    const std::string& target_snode,
+                                    http_callback_t&& on_proxy_response) {
+
+    auto sn = swarm_->find_node_by_ed25519_pk(target_snode);
+
+    if (!sn) {
+        LOKI_LOG(debug, "Could not find target snode for proxy: {}", target_snode);
+    }
+
+    LOKI_LOG(info, "Target Snode: {}", target_snode);
+
+    auto body_clone = req_body;
+
+    auto req = make_post_request("/swarms/proxy_exit", std::move(body_clone));
+
+    req->insert(LOKI_SENDER_KEY_HEADER, sender_key);
+
+    this->sign_request(req);
+
+    make_sn_request(ioc_, *sn, req, std::move(on_proxy_response));
+}
+
 void ServiceNode::save_if_new(const message_t& msg) {
 
     if (db_->store(msg.hash, msg.pub_key, msg.data, msg.ttl, msg.timestamp,
@@ -776,6 +800,7 @@ void ServiceNode::ping_peers_tick() {
 }
 
 void ServiceNode::sign_request(std::shared_ptr<request_t> &req) const {
+    // TODO: investigate why we are not signing headers
     const auto hash = hash_data(req->body());
     const auto signature = generate_signature(hash, lokid_key_pair_);
     attach_signature(req, signature);

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -535,6 +535,7 @@ void ServiceNode::process_proxy_req(const std::string& req_body,
 
     if (!sn) {
         LOKI_LOG(debug, "Could not find target snode for proxy: {}", target_snode);
+        return;
     }
 
     LOKI_LOG(info, "Target Snode: {}", target_snode);

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -270,6 +270,11 @@ class ServiceNode {
     /// Process message received from a client, return false if not in a swarm
     bool process_store(const message_t& msg);
 
+    void
+    process_proxy_req(const std::string& req, const std::string& sender_key,
+                      const std::string& target_snode,
+                      std::function<void(sn_response_t)>&& on_proxy_response);
+
     /// Process message relayed from another SN from our swarm
     void process_push(const message_t& msg);
 

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -222,6 +222,18 @@ boost::optional<sn_record_t> Swarm::find_node_by_port(uint16_t port) const {
 }
 
 boost::optional<sn_record_t>
+Swarm::find_node_by_ed25519_pk(const std::string& pk) const {
+
+    for (const auto& sn : all_funded_nodes_) {
+        if (sn.pubkey_ed25519_hex() == pk) {
+            return sn;
+        }
+    }
+
+    return boost::none;
+}
+
+boost::optional<sn_record_t>
 Swarm::get_node_by_pk(const sn_pub_key_t& pk) const {
 
     for (const auto& sn : all_funded_nodes_) {

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -104,6 +104,9 @@ class Swarm {
 
     // Get the node with public key `pk` if exists
     boost::optional<sn_record_t> get_node_by_pk(const sn_pub_key_t& pk) const;
+
+    boost::optional<sn_record_t>
+    find_node_by_ed25519_pk(const sn_pub_key_t& address) const;
 };
 
 } // namespace loki


### PR DESCRIPTION
Added a `/proxy` http target that expects:
1. "X-Target-Snode-Key" header: ed25519 public key of the target snode (the one we ultimately want to reach) in hex.
2. "X-Sender-Public-Key" header: x25519 ephemeral public key generated by the messenger client in hex.
3. Regular messenger http request (body + headers) serialised as json and encrypted with ECDH using "X-Sender-Public-Key" and the snode's x25519 public key.

"First hop" snode will find the target snode and forward the body along with "X-Sender-Public-Key" to that snode. Target snode will decrypt the request and process it normally with the only difference that that it will encrypt the entire response with ECDH for the original client and put the entire response as the body in response to "first hop" snode. "First hop" snode in turn will forward the encrypted response back to the client.

Note: only the last commit in this PR is new, the others are the same as in #295.