### PR TITLE
Allow messenger clients to proxy to Loki's file server

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -301,8 +301,6 @@ connection_t::connection_t(boost::asio::io_context& ioc, ssl::context& ssl_ctx,
 
     request_.body_limit(1024 * 1024 * 10); // 10 mb
 
-    std::cerr << request_.get() << std::endl;
-
     start_timestamp_ = std::chrono::steady_clock::now();
 }
 

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -176,8 +176,8 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     ssl::stream<tcp::socket&> stream_;
     const Security& security_;
 
-    // The request message.
-    request_t request_;
+    // Contains the request message
+    http::request_parser<http::string_body> request_;
 
     // The response message.
     response_t response_;

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -34,6 +34,10 @@ using request_t = http::request<http::string_body>;
 using response_t = http::response<http::string_body>;
 
 namespace loki {
+
+std::shared_ptr<request_t> build_post_request(const char* target,
+                                              std::string&& data);
+
 struct message_t;
 struct Security;
 
@@ -107,8 +111,6 @@ class LokidClient {
 
 constexpr auto SESSION_TIME_LIMIT = std::chrono::seconds(30);
 
-// TODO: the name should indicate that we are actually trying to send data
-// unlike in `make_post_request`
 void make_http_request(boost::asio::io_context& ioc, const std::string& ip,
                        uint16_t port, const std::shared_ptr<request_t>& req,
                        http_callback_t&& cb);
@@ -286,7 +288,9 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
 
     void process_swarm_req(boost::string_view target);
 
-    void process_proxy_req(boost::string_view target);
+    void process_proxy_req();
+
+    void process_file_proxy_req();
 
     // Check whether we have spent enough time on this connection.
     void register_deadline();

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -64,8 +64,6 @@ void make_https_request(boost::asio::io_context& ioc, const std::string& url,
         query.erase(0, sizeof(prefix) - 1);
     }
 
-    boost::algorithm::erase_all(query, prefix);
-
     auto resolve_handler = [&ioc, req, query, cb = std::move(cb)] (
                                const boost::system::error_code& ec,
                                boost::asio::ip::tcp::resolver::results_type resolve_results) mutable {

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -4,6 +4,7 @@
 #include "signature.h"
 
 #include <openssl/x509.h>
+#include <boost/algorithm/string/erase.hpp>
 
 namespace loki {
 
@@ -50,6 +51,44 @@ void make_https_request(boost::asio::io_context& ioc,
     session->start();
 }
 
+void make_https_request(boost::asio::io_context& ioc, const std::string& url,
+                        const std::shared_ptr<request_t>& req,
+                        http_callback_t&& cb) {
+
+    static boost::asio::ip::tcp::resolver resolver(ioc);
+
+    constexpr char prefix[] = "https://";
+    std::string query = url;
+
+    if (url.find(prefix) == 0) {
+        query.erase(0, sizeof(prefix) - 1);
+    }
+
+    boost::algorithm::erase_all(query, prefix);
+
+    auto resolve_handler = [&ioc, req, query, cb = std::move(cb)] (
+                               const boost::system::error_code& ec,
+                               boost::asio::ip::tcp::resolver::results_type resolve_results) mutable {
+        if (ec) {
+            LOKI_LOG(error, "DNS resolution error for {}: {}", query, ec.message());
+            return;
+        }
+
+        static ssl::context ctx{ssl::context::tlsv12_client};
+
+        auto session = std::make_shared<HttpsClientSession>(
+            ioc, ctx, std::move(resolve_results), req, std::move(cb), boost::none);
+
+        session->start();
+    };
+
+    constexpr char https_port[] = "443";
+
+    resolver.async_resolve(query, https_port,
+                           boost::asio::ip::tcp::resolver::query::numeric_service,
+                           resolve_handler);
+}
+
 static std::string x509_to_string(X509* x509) {
     BIO* bio_out = BIO_new(BIO_s_mem());
     if (!bio_out) {
@@ -73,10 +112,10 @@ HttpsClientSession::HttpsClientSession(
     boost::asio::io_context& ioc, ssl::context& ssl_ctx,
     tcp::resolver::results_type resolve_results,
     const std::shared_ptr<request_t>& req, http_callback_t&& cb,
-    const std::string& sn_pubkey_b32z)
+    boost::optional<const std::string&> sn_pubkey_b32z)
     : ioc_(ioc), ssl_ctx_(ssl_ctx), resolve_results_(resolve_results),
       callback_(cb), deadline_timer_(ioc), stream_(ioc, ssl_ctx_), req_(req),
-      server_pub_key_b32z(sn_pubkey_b32z) {
+      server_pub_key_b32z_(sn_pubkey_b32z) {
 
     get_net_stats().https_connections_out++;
 
@@ -138,6 +177,7 @@ void HttpsClientSession::on_connect() {
     get_net_stats().record_socket_open(sockfd);
 
     stream_.set_verify_mode(ssl::verify_none);
+
     stream_.set_verify_callback(
         [this](bool preverified, ssl::verify_context& ctx) -> bool {
             if (!preverified) {
@@ -156,7 +196,7 @@ void HttpsClientSession::on_connect() {
 void HttpsClientSession::on_handshake(boost::system::error_code ec) {
     if (ec) {
         LOKI_LOG(error, "Failed to perform a handshake with {}: {}",
-                 server_pub_key_b32z, ec.message());
+                 server_pub_key_b32z_ ? *server_pub_key_b32z_ : "(not snode)", ec.message());
 
         return;
     }
@@ -186,16 +226,20 @@ void HttpsClientSession::on_write(error_code ec, size_t bytes_transferred) {
 }
 
 bool HttpsClientSession::verify_signature() {
+
+    if (server_pub_key_b32z_)
+        return true;
+
     const auto it = res_.find(LOKI_SNODE_SIGNATURE_HEADER);
     if (it == res_.end()) {
         LOKI_LOG(warn, "no signature found in header from {}",
-                 server_pub_key_b32z);
+                 *server_pub_key_b32z_);
         return false;
     }
     // signature is expected to be base64 enoded
     const auto signature = it->value().to_string();
     const auto hash = hash_data(server_cert_);
-    return check_signature(signature, hash, server_pub_key_b32z);
+    return check_signature(signature, hash, *server_pub_key_b32z_);
 }
 
 void HttpsClientSession::on_read(error_code ec, size_t bytes_transferred) {
@@ -207,8 +251,8 @@ void HttpsClientSession::on_read(error_code ec, size_t bytes_transferred) {
         if (http::to_status_class(res_.result_int()) ==
             http::status_class::successful) {
 
-            if (!verify_signature()) {
-                LOKI_LOG(debug, "Bad signature from {}", server_pub_key_b32z);
+            if (server_pub_key_b32z_ && !verify_signature()) {
+                LOKI_LOG(debug, "Bad signature from {}", *server_pub_key_b32z_);
                 trigger_callback(SNodeError::ERROR_OTHER, nullptr, res_);
             } else {
                 auto body = std::make_shared<std::string>(res_.body());

--- a/httpserver/https_client.h
+++ b/httpserver/https_client.h
@@ -11,6 +11,10 @@ void make_https_request(boost::asio::io_context& ioc, const std::string& ip,
                         const std::shared_ptr<request_t>& req,
                         http_callback_t&& cb);
 
+void make_https_request(boost::asio::io_context& ioc, const std::string& url,
+                        const std::shared_ptr<request_t>& req,
+                        http_callback_t&& cb);
+
 class HttpsClientSession
     : public std::enable_shared_from_this<HttpsClientSession> {
 
@@ -35,7 +39,9 @@ class HttpsClientSession
     /// sent to multiple snodes
     std::shared_ptr<request_t> req_;
     response_t res_;
-    std::string server_pub_key_b32z;
+
+    // Snode's pub key (none if signature verification is not used / not a snode)
+    boost::optional<std::string> server_pub_key_b32z_;
 
     bool used_callback_ = false;
 
@@ -60,7 +66,8 @@ class HttpsClientSession
     HttpsClientSession(boost::asio::io_context& ioc, ssl::context& ssl_ctx,
                        tcp::resolver::results_type resolve_results,
                        const std::shared_ptr<request_t>& req,
-                       http_callback_t&& cb, const std::string& sn_pubkey_b32z);
+                       http_callback_t&& cb,
+                       boost::optional<const std::string&> sn_pubkey_b32z);
 
     // initiate the client connection
     void start();

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -106,19 +106,8 @@ constexpr std::chrono::minutes POW_DIFFICULTY_UPDATE_INTERVAL = 10min;
 constexpr std::chrono::seconds VERSION_CHECK_INTERVAL = 10min;
 constexpr int CLIENT_RETRIEVE_MESSAGE_LIMIT = 10;
 
-static std::shared_ptr<request_t> make_post_request(const char* target,
-                                                    std::string&& data) {
-    auto req = std::make_shared<request_t>();
-    req->body() = std::move(data);
-    req->method(http::verb::post);
-    req->set(http::field::host, "service node");
-    req->target(target);
-    req->prepare_payload();
-    return req;
-}
-
 static std::shared_ptr<request_t> make_push_all_request(std::string&& data) {
-    return make_post_request("/swarms/push_batch/v1", std::move(data));
+    return build_post_request("/swarms/push_batch/v1", std::move(data));
 }
 
 static bool verify_message(const message_t& msg,
@@ -542,7 +531,7 @@ void ServiceNode::process_proxy_req(const std::string& req_body,
 
     auto body_clone = req_body;
 
-    auto req = make_post_request("/swarms/proxy_exit", std::move(body_clone));
+    auto req = build_post_request("/swarms/proxy_exit", std::move(body_clone));
 
     req->insert(LOKI_SENDER_KEY_HEADER, sender_key);
 
@@ -817,7 +806,7 @@ void ServiceNode::test_reachability(const sn_record_t& sn) {
 
     nlohmann::json json_body;
 
-    auto req = make_post_request("/swarms/ping_test/v1", json_body.dump());
+    auto req = build_post_request("/swarms/ping_test/v1", json_body.dump());
     this->sign_request(req);
 
     make_sn_request(ioc_, sn, req, std::move(callback));
@@ -1016,7 +1005,7 @@ void ServiceNode::send_storage_test_req(const sn_record_t& testee,
     json_body["height"] = test_height;
     json_body["hash"] = item.hash;
 
-    auto req = make_post_request("/swarms/storage_test/v1", json_body.dump());
+    auto req = build_post_request("/swarms/storage_test/v1", json_body.dump());
 
     this->sign_request(req);
 
@@ -1040,7 +1029,7 @@ void ServiceNode::send_blockchain_test_req(const sn_record_t& testee,
     json_body["height"] = test_height;
 
     auto req =
-        make_post_request("/swarms/blockchain_test/v1", json_body.dump());
+        build_post_request("/swarms/blockchain_test/v1", json_body.dump());
     this->sign_request(req);
 
     make_sn_request(ioc_, testee, req,


### PR DESCRIPTION
- allow to proxy to `https://file.lokinet.org` exclusively;
- unlike proxy to snodes, there is no encryption other than tls;