### PR TITLE
Allow more frequent requests between SN. Bump version to 1.0.9.

### DIFF
--- a/httpserver/rate_limiter.h
+++ b/httpserver/rate_limiter.h
@@ -14,7 +14,10 @@ class RateLimiter {
   public:
     // TODO: make those two constants command line parameters?
     constexpr static uint32_t BUCKET_SIZE = 600;
-    constexpr static uint32_t TOKEN_RATE = 300;
+
+    // Tokens (requests) per second
+    constexpr static uint32_t TOKEN_RATE = 300; // Too much for a client??
+    constexpr static uint32_t TOKEN_RATE_SN = 600;
     constexpr static uint32_t MAX_CLIENTS = 10000;
 
     bool should_rate_limit(const std::string& identifier,
@@ -37,6 +40,8 @@ class RateLimiter {
 
     void clean_client_buckets(std::chrono::steady_clock::time_point now);
 
+    // Add tokens based on the amount of time elapsed
     void fill_bucket(TokenBucket& bucket,
-                     std::chrono::steady_clock::time_point now);
+                     std::chrono::steady_clock::time_point now,
+                     bool service_node = false);
 };

--- a/httpserver/version.h
+++ b/httpserver/version.h
@@ -6,7 +6,7 @@
 
 #define VERSION_MAJOR 1
 #define VERSION_MINOR 0
-#define VERSION_PATCH 8
+#define VERSION_PATCH 9
 
 #define LOKI_STRINGIFY2(val) #val
 #define LOKI_STRINGIFY(val) LOKI_STRINGIFY2(val)


### PR DESCRIPTION
This will be necessary SNs will be used for messenger proxy requests.