### PR TITLE
Use get_n_service_node's poll_block_hash for swam updates

### DIFF
--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -29,6 +29,7 @@ struct block_update_t {
     uint64_t height;
     std::string block_hash;
     int hardfork;
+    bool unchanged = false;
 };
 
 


### PR DESCRIPTION
This lets lokid respond with a "unchanged" result when the block hasn't change which saves a lot of effort & data: currently storage server pumps around 400kB/s of data from lokid rpc.  The poll_block_hash (added in lokid 6) lets lokid just not generate or send the redundant data in the first place (it includes `"unchanged":true` to indicate that the block hash hasn't changed and completely omits the service node states).