### PR TITLE
RNG optimizations

### DIFF
--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -1286,10 +1286,7 @@ bool ServiceNode::select_random_message(Item& item) {
 
     // SNodes don't have to agree on this, rather they should use different
     // messages
-    const uint64_t seed =
-        std::chrono::high_resolution_clock::now().time_since_epoch().count();
-    std::mt19937_64 mt(seed);
-    const auto msg_idx = util::uniform_distribution_portable(mt, message_count);
+    const auto msg_idx = util::uniform_distribution_portable(message_count);
 
     if (!db_->retrieve_by_index(msg_idx, item)) {
         LOKI_LOG(error, "Could not retrieve message by index: {}", msg_idx);
@@ -1366,14 +1363,7 @@ void ServiceNode::initiate_peer_test() {
 
         bc_test_params_t params;
         params.max_height = block_height_ - SAFETY_BUFFER_BLOCKS;
-
-        const uint64_t rng_seed = std::chrono::high_resolution_clock::now()
-                                      .time_since_epoch()
-                                      .count();
-
-        // TODO: This is slow, fix it!
-        std::mt19937_64 mt(rng_seed);
-        params.seed = mt();
+        params.seed = util::rng()();
 
         auto callback =
             std::bind(&ServiceNode::send_blockchain_test_req, this, testee,

--- a/utils/include/utils.hpp
+++ b/utils/include/utils.hpp
@@ -138,7 +138,10 @@ inline std::string as_hex(const String &s) {
     return as_hex(begin(s), end(s));
 }
 
-/// Returns a random number from [0, n) using a static generator
+/// Returns a reference to a randomly seeded, thread-local RNG.
+std::mt19937_64& rng();
+
+/// Returns a random number from [0, n) using `rng()`
 uint64_t uniform_distribution_portable(uint64_t n);
 
 /// Returns a random number from [0, n); (copied from lokid)

--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -134,10 +134,13 @@ bool parseTTL(const std::string& ttlString, uint64_t& ttl) {
     return true;
 }
 
-uint64_t uniform_distribution_portable(uint64_t n) {
+std::mt19937_64& rng() {
+    static thread_local std::mt19937_64 generator{std::random_device{}()};
+    return generator;
+}
 
-    static thread_local std::mt19937_64 generator;
-    return uniform_distribution_portable(generator, n);
+uint64_t uniform_distribution_portable(uint64_t n) {
+    return uniform_distribution_portable(rng(), n);
 }
 
 uint64_t uniform_distribution_portable(std::mt19937_64& mersenne_twister,


### PR DESCRIPTION
- Expose the thread-local static RNG in `utils`
- Make the thread-local static RNG actually seed itself from `std::random_device` rather than using the default fixed seed.
- Don't create and seed a new RNG from the system clock when a new random number is needed: the seeding is quite slow and it's much better for both performance and randomness to just draw from an existing `std::mt19937_64` object.  (Regarding randomness: MT19937 has a much larger state, 2^19937, than the 2^64 states of possible 64-bit seed values).
- Eliminates a FIXME about the slow performance caused by the above.