### PR TITLE
Fix not responding immediately on proxy request

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -553,13 +553,13 @@ void connection_t::process_proxy_req() {
     // print_headers(req);
 #endif
 
-    delay_response_ = true;
-
     if (!parse_header(LOKI_SENDER_KEY_HEADER,
                       LOKI_TARGET_SNODE_KEY)) {
         LOKI_LOG(debug, "Missing headers for a proxy request");
         return;
     }
+
+    delay_response_ = true;
 
     const auto& sender_key = header_[LOKI_SENDER_KEY_HEADER];
     const auto& target_snode_key = header_[LOKI_TARGET_SNODE_KEY];

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -529,6 +529,7 @@ void ServiceNode::process_proxy_req(const std::string& req_body,
 
     if (!sn) {
         LOKI_LOG(debug, "Could not find target snode for proxy: {}", target_snode);
+        on_proxy_response(sn_response_t{SNodeError::ERROR_OTHER, nullptr, boost::none});
         return;
     }
 


### PR DESCRIPTION
Returning early without explicitly calling the completion handler would result in the session being alive until it times out. This fixes that.