### PR TITLE
Fix spdlog compatibility

### DIFF
--- a/common/include/dev_sink.h
+++ b/common/include/dev_sink.h
@@ -9,6 +9,7 @@ namespace loki {
 
 template <typename Mutex>
 class dev_sink : public spdlog::sinks::base_sink<Mutex> {
+    using Base = spdlog::sinks::base_sink<Mutex>;
 
     // Potentially all entries will be returned in a
     // single message, so we should keep the limit
@@ -22,8 +23,8 @@ class dev_sink : public spdlog::sinks::base_sink<Mutex> {
 
   protected:
     void sink_it_(const spdlog::details::log_msg& msg) override {
-        fmt::memory_buffer formatted;
-        spdlog::sinks::sink::formatter_->format(msg, formatted);
+        spdlog::memory_buf_t formatted;
+        Base::formatter_->format(msg, formatted);
 
         if (primary_buffer_.size() >= BUFFER_SIZE) {
             secondary_buffer_ = std::move(primary_buffer_);


### PR DESCRIPTION
Upstream spdlog moves the instance and the absolute namespace qualifier
here breaks the code; this fixes it by going through the base class
which will work for both the bundled and newer spdlog versions.

Also changes the `fmt::memory_buffer` to `spdlog::memory_buf_t` because
the former doesn't work with newer libfmt's (which upstream spdlog and
the devendored debian sid build now use).