### PR TITLE
Add systemd notify support

### DIFF
--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -85,4 +85,22 @@ message(STATUS "using git commit hash ${SHORT_HASH}")
 message(STATUS "using UTC build time ${BUILD_TIME}")
 target_compile_definitions(httpserver PRIVATE -DSTORAGE_SERVER_GIT_HASH_STRING="${SHORT_HASH}")
 target_compile_definitions(httpserver PRIVATE -DSTORAGE_SERVER_BUILD_TIME="${BUILD_TIME}")
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(SYSTEMD libsystemd)
+    # Default ENABLE_SYSTEMD to true if we found it
+    option(ENABLE_SYSTEMD "enable systemd integration for sd_notify" ${SYSTEMD_FOUND})
+
+    if(ENABLE_SYSTEMD)
+        if(NOT SYSTEMD_FOUND)
+            message(FATAL_ERROR "libsystemd not found")
+        endif()
+        target_compile_definitions(httpserver PRIVATE ENABLE_SYSTEMD)
+        target_include_directories(httpserver PRIVATE ${SYSTEMD_INCLUDE_DIRS})
+        target_link_libraries(httpserver PRIVATE ${SYSTEMD_LIBRARIES})
+    endif()
+endif()
+
+
 #

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -1606,6 +1606,27 @@ std::string ServiceNode::get_stats() const {
     return val.dump(indent);
 }
 
+std::string ServiceNode::get_status_line() const {
+    // This produces a short, single-line status string, used when running as a systemd Type=notify
+    // service to update the service Status line.  The status message has to be fairly short: has to
+    // fit on one line, and if it's too long systemd just truncates it when displaying it.
+    std::ostringstream s;
+    s << 'v' << STORAGE_SERVER_VERSION_STRING;
+    if (!loki::is_mainnet()) s << " (TESTNET)";
+
+    if (!swarm_ || !swarm_->is_valid())
+        s << "; NO SWARM";
+    if (syncing_)
+        s << "; SYNCING";
+    uint64_t total_stored;
+    if (db_->get_message_count(total_stored))
+        s << "; " << total_stored << " msgs";
+    s << "; reqs(S/R): " << all_stats_.get_total_store_requests() << '/' << all_stats_.get_total_retrieve_requests();
+    s << "; conns(in/http/https): " << get_net_stats().connections_in << '/' << get_net_stats().http_connections_out <<
+        '/' << get_net_stats().https_connections_out;
+    return s.str();
+}
+
 int ServiceNode::get_curr_pow_difficulty() const {
     return curr_pow_difficulty_.difficulty;
 }

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -1614,10 +1614,19 @@ std::string ServiceNode::get_status_line() const {
     s << 'v' << STORAGE_SERVER_VERSION_STRING;
     if (!loki::is_mainnet()) s << " (TESTNET)";
 
-    if (!swarm_ || !swarm_->is_valid())
-        s << "; NO SWARM";
     if (syncing_)
         s << "; SYNCING";
+    s << "; sw=";
+    if (!swarm_ || !swarm_->is_valid())
+        s << "NONE";
+    else {
+        std::string swarm = std::to_string(swarm_->our_swarm_id());
+        if (swarm.size() <= 6)
+            s << swarm;
+        else
+            s << swarm.substr(0, 4) << u8"…" << swarm.back();
+        s << "(n=" << (1 + swarm_->other_nodes().size()) << ")";
+    }
     uint64_t total_stored;
     if (db_->get_message_count(total_stored))
         s << "; " << total_stored << " msgs";

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -311,6 +311,8 @@ class ServiceNode {
     set_difficulty_history(const std::vector<pow_difficulty_t>& new_history);
 
     std::string get_stats() const;
+
+    std::string get_status_line() const;
 };
 
 } // namespace loki


### PR DESCRIPTION
This allows running storage server as a Type=notify service, with systemd watchdog pings and a service status line.

Aside from allowing systemd watchdog to restart it, this gives a Status line (in `systemctl status loki-storage-server`) such as:

     Status: "v1.0.9; sw=1743…1(n=5); 1325 msgs; reqs(S/R): 0/7; conns(in/http/https): 1/0/1"