### PR TITLE
loki-mq updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/gabime/spdlog.git
 [submodule "vendors/loki-mq"]
 	path = vendors/loki-mq
-	url = git@github.com:loki-project/loki-mq.git
+	url = https://github.com/loki-project/loki-mq.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,6 @@ set(sodium_USE_STATIC_LIBS ON)
 find_package(sodium REQUIRED)
 include_directories(${sodium_INCLUDE_DIR})
 
-include_directories("${CMAKE_CURRENT_LIST_DIR}/vendors/loki-mq/cppzmq")
-include_directories("${CMAKE_CURRENT_LIST_DIR}/vendors/loki-mq/mapbox-variant/include")
-
 loki_add_subdirectory(common)
 loki_add_subdirectory(utils)
 loki_add_subdirectory(crypto)

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -47,6 +47,7 @@ loki_add_subdirectory(../storage storage)
 loki_add_subdirectory(../utils utils)
 loki_add_subdirectory(../pow pow)
 loki_add_subdirectory(../crypto crypto)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "disable shared libraries") # Tells loki-mq to do a static build
 loki_add_subdirectory(../vendors/loki-mq loki-mq)
 find_package(OpenSSL REQUIRED)
 

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -65,12 +65,11 @@ target_link_libraries(httpserver_lib PUBLIC utils)
 target_link_libraries(httpserver_lib PUBLIC pow)
 target_link_libraries(httpserver_lib PUBLIC resolv)
 target_link_libraries(httpserver_lib PUBLIC crypto)
-target_link_libraries(httpserver_lib PUBLIC lokimq)
+target_link_libraries(httpserver_lib PUBLIC lokimq::lokimq)
 
 set_property(TARGET httpserver_lib PROPERTY CXX_STANDARD 14)
 
 target_include_directories(httpserver_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS})
-target_include_directories(httpserver_lib PUBLIC ../vendors/loki-mq/lokimq)
 target_link_libraries(httpserver_lib PUBLIC ${Boost_LIBRARIES})
 
 set(BIN_NAME loki-storage)

--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -7,7 +7,7 @@
 #include "request_handler.h"
 #include "utils.hpp"
 
-#include "lokimq.h"
+#include <lokimq/lokimq.h>
 
 namespace loki {
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -8,7 +8,7 @@
 #include "loki_common.h"
 #include "loki_logger.h"
 #include "lokid_key.h"
-#include "lokimq.h"
+#include <lokimq/lokimq.h>
 #include "net_stats.h"
 #include "serialization.h"
 #include "signature.h"


### PR DESCRIPTION
Use the exported cmake target (which gives both link libraries and any required include directories when used via `target_link_libraries`), and fix the includes to be the intended `lokimq/lokimq.h` instead of just `lokimq.h` so that potential future lokimq code that uses the full path include won't break storage server.

Also updates loki-mq to the latest (which is the same code, but with a bunch of build fixes and with the code rearranged/cleaned up to compile in multiple units, plus gained a version 1.0.0 and version header).