### PR TITLE
Inactive nodes maintain the full snode list

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -914,7 +914,7 @@ void connection_t::process_request() {
 
     /// This method is responsible for filling out response_
 
-    LOKI_LOG(trace, "connection_t::process_request");
+    LOKI_LOG(debug, "connection_t::process_request");
     response_.version(req.version());
     response_.keep_alive(false);
 

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -74,10 +74,11 @@ class Swarm {
     /// Extract relevant information from incoming swarm composition
     SwarmEvents derive_swarm_events(const all_swarms_t& swarms) const;
 
-    /// Update swarm state according to `events`
+    /// Update swarm state according to `events`. If not `is_active`
+    /// only update the list of all nodes
     void update_state(const all_swarms_t& swarms,
                       const std::vector<sn_record_t>& decommissioned,
-                      const SwarmEvents& events);
+                      const SwarmEvents& events, bool is_active);
 
     void apply_swarm_changes(const all_swarms_t& new_swarms);
 


### PR DESCRIPTION
Without the full snode list inactive nodes will drop any lmq request from healthy nodes resulting in a timeout-long delay in onion requests.