### PR TITLE
Reachability testing via lokimq ports

### DIFF
--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -22,7 +22,7 @@ std::string LokimqServer::peer_lookup(lokimq::string_view pubkey_bin) const {
     if (sn) {
         return fmt::format("tcp://{}:{}", sn->ip(), sn->lmq_port());
     } else {
-        LOKI_LOG(debug, "[LMQ] peer node not found!");
+        LOKI_LOG(debug, "[LMQ] peer node not found {}!", pubkey_bin);
         return "";
     }
 }

--- a/httpserver/reachability_testing.h
+++ b/httpserver/reachability_testing.h
@@ -18,13 +18,28 @@ class reach_record_t {
     // The time the node failed for the first time
     // (and hasn't come back online)
     time_point_t first_failure;
-    time_point_t last_tested;
+    time_point_t last_failure;
     // whether it's been reported to Lokid
     bool reported = false;
+
+    // whether reachable over http
+    bool http_ok = true;
+    // whether reachable over zmq
+    bool zmq_ok = true;
 
     reach_record_t();
 };
 } // namespace detail
+
+enum class ReachType {
+  HTTP,
+  ZMQ
+};
+
+enum class ReportType {
+  GOOD,
+  BAD
+};
 
 class reachability_records_t {
 
@@ -41,9 +56,12 @@ class reachability_records_t {
     // and those that failed our earlier tests (but not reported yet)
     // std::vector<> priority_nodes() const;
 
-    // Records node as unreachable, return `true` if the node should be
-    // reported to Lokid as being unreachable for a long time
-    bool record_unreachable(const sn_pub_key_t& sn);
+    // Records node as reachable/unreachable according to `val`
+    void record_reachable(const sn_pub_key_t& sn, ReachType type, bool val);
+
+    // return `true` if the node should be reported to Lokid as being
+    // reachable or unreachable for a long time depending on `type`
+    bool should_report_as(const sn_pub_key_t& sn, ReportType type);
 
     // Expires a node, removing it from offline nodes.  Returns true if found
     // and removed, false if it didn't exist.

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -752,16 +752,16 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
     swarm_->update_state(bu.swarms, bu.decommissioned_nodes, events, true);
 
     if (!events.new_snodes.empty()) {
-        bootstrap_peers(events.new_snodes);
+        this->bootstrap_peers(events.new_snodes);
     }
 
     if (!events.new_swarms.empty()) {
-        bootstrap_swarms(events.new_swarms);
+        this->bootstrap_swarms(events.new_swarms);
     }
 
     if (events.dissolved) {
         /// Go through all our PK and push them accordingly
-        salvage_data();
+        this->salvage_data();
     }
 
 #ifndef INTEGRATION_TEST
@@ -935,10 +935,14 @@ void ServiceNode::sign_request(std::shared_ptr<request_t>& req) const {
 
 void ServiceNode::test_reachability(const sn_record_t& sn) {
 
+    LockGuard guard(sn_mutex_);
+
     LOKI_LOG(debug, "Testing node for reachability {}", sn);
 
     auto callback = [this, sn](sn_response_t&& res) {
-        this->process_reach_test_response(std::move(res), sn.pub_key_base32z());
+
+        const bool success = res.error_code == SNodeError::NO_ERROR;
+        this->process_reach_test_result(sn.pub_key_base32z(), ReachType::HTTP, success);
     };
 
     nlohmann::json json_body;
@@ -947,6 +951,13 @@ void ServiceNode::test_reachability(const sn_record_t& sn) {
     this->sign_request(req);
 
     make_sn_request(ioc_, sn, req, std::move(callback));
+
+    // test lmq port:
+    lmq_server_.lmq()->connect_remote(fmt::format("tcp://{}:{}", sn.ip(), sn.lmq_port()), [this, sn] (lokimq::ConnectionID c) {
+        this->process_reach_test_result(sn.pub_key_base32z(), ReachType::ZMQ, true);
+    }, [this, sn](lokimq::ConnectionID c, lokimq::string_view err) {
+        this->process_reach_test_result(sn.pub_key_base32z(), ReachType::ZMQ, false);
+    }, sn.pubkey_x25519_bin());
 }
 
 void ServiceNode::lokid_ping_timer_tick() {
@@ -1251,24 +1262,31 @@ void ServiceNode::report_node_reachability(const sn_pub_key_t& sn_pk,
                                      params, std::move(cb));
 }
 
-void ServiceNode::process_reach_test_response(sn_response_t&& res,
-                                              const sn_pub_key_t& pk) {
+void ServiceNode::process_reach_test_result(const sn_pub_key_t& pk, ReachType type, bool success) {
 
     LockGuard guard(sn_mutex_);
 
-    if (res.error_code == SNodeError::NO_ERROR) {
+    if (success) {
+
+        reach_records_.record_reachable(pk, type, true);
+
         // NOTE: We don't need to report healthy nodes that previously has been
         // not been reported to Lokid as unreachable but I'm worried there might
         // be some race conditions, so do it anyway for now.
-        this->report_node_reachability(pk, true);
-        return;
+
+        if (reach_records_.should_report_as(pk, ReportType::GOOD)) {
+            this->report_node_reachability(pk, true);
+        }
+
+    } else {
+        reach_records_.record_reachable(pk, type, false);
+
+        if (reach_records_.should_report_as(pk, ReportType::BAD)) {
+            // instead of this, we should set http to `unreachable`
+            this->report_node_reachability(pk, false);
+        }
     }
 
-    const bool should_report = reach_records_.record_unreachable(pk);
-
-    if (should_report) {
-        this->report_node_reachability(pk, false);
-    }
 }
 
 void ServiceNode::process_blockchain_test_response(

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -224,10 +224,7 @@ class ServiceNode {
                                        uint64_t test_height,
                                        sn_response_t&& res);
 
-    /// Check if status is OK and handle failed test otherwise; note
-    /// that we want a copy of `sn` here because of the way it is called
-    void process_reach_test_response(sn_response_t&& res,
-                                     const sn_pub_key_t& sn);
+    void process_reach_test_result(const sn_pub_key_t& pk, ReachType type, bool success);
 
     /// From a peer
     void process_blockchain_test_response(sn_response_t&& res,


### PR DESCRIPTION
- check that both http and zmq ports need to be open
- if the node fails for 2 hours straight, report to lokid