### PR TITLE
Disconnect after connect_remote

### DIFF
--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -953,11 +953,18 @@ void ServiceNode::test_reachability(const sn_record_t& sn) {
     make_sn_request(ioc_, sn, req, std::move(callback));
 
     // test lmq port:
-    lmq_server_.lmq()->connect_remote(fmt::format("tcp://{}:{}", sn.ip(), sn.lmq_port()), [this, sn] (lokimq::ConnectionID c) {
-        this->process_reach_test_result(sn.pub_key_base32z(), ReachType::ZMQ, true);
-    }, [this, sn](lokimq::ConnectionID c, lokimq::string_view err) {
-        this->process_reach_test_result(sn.pub_key_base32z(), ReachType::ZMQ, false);
-    }, sn.pubkey_x25519_bin());
+    lmq_server_.lmq()->connect_remote(
+        fmt::format("tcp://{}:{}", sn.ip(), sn.lmq_port()),
+        [this, sn](lokimq::ConnectionID c) {
+            this->process_reach_test_result(sn.pub_key_base32z(),
+                                            ReachType::ZMQ, true);
+            this->lmq_server_.lmq()->disconnect(c);
+        },
+        [this, sn](lokimq::ConnectionID c, lokimq::string_view err) {
+            this->process_reach_test_result(sn.pub_key_base32z(),
+                                            ReachType::ZMQ, false);
+        },
+        sn.pubkey_x25519_bin());
 }
 
 void ServiceNode::lokid_ping_timer_tick() {


### PR DESCRIPTION
- `connect_remote` has no timeout by default