### PR TITLE
lokimq segfault fix

### DIFF
--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -129,7 +129,6 @@ void LokimqServer::handle_onion_request(lokimq::Message& message) {
 void LokimqServer::init(ServiceNode* sn, RequestHandler* rh,
                         const lokid_key_pair_t& keypair) {
 
-    namespace ph = std::placeholders;
     using lokimq::Allow;
     using lokimq::string_view;
 
@@ -158,10 +157,9 @@ void LokimqServer::init(ServiceNode* sn, RequestHandler* rh,
 #undef LMQ_LOG_MAP
     };
 
-    auto lookup_fn = std::bind(&LokimqServer::peer_lookup, this, ph::_1);
+    auto lookup_fn = [this](auto pk) { return peer_lookup(pk); };
 
-    auto allow_fn =
-        std::bind(&LokimqServer::auth_level_lookup, this, ph::_1, ph::_2);
+    auto allow_fn = [this](auto ip, auto pk) { return auth_level_lookup(ip, pk); };
 
     lokimq_.reset(new LokiMQ{pubkey,
                              seckey,
@@ -171,23 +169,15 @@ void LokimqServer::init(ServiceNode* sn, RequestHandler* rh,
 
     LOKI_LOG(info, "LokiMQ is listenting on port {}", port_);
 
-    lokimq_->add_category("sn",
-                          lokimq::Access{lokimq::AuthLevel::none, true, false});
-
     lokimq_->log_level(lokimq::LogLevel::warn);
 
     // ============= COMMANDS - BEGIN =============
-
-    lokimq_->add_request_command(
-        "sn", "data", std::bind(&LokimqServer::handle_sn_data, this, ph::_1));
-
-    lokimq_->add_request_command(
-        "sn", "proxy_exit",
-        std::bind(&LokimqServer::handle_sn_proxy_exit, this, ph::_1));
-
-    lokimq_->add_request_command(
-        "sn", "onion_req",
-        std::bind(&LokimqServer::handle_onion_request, this, ph::_1));
+    //
+    lokimq_->add_category("sn", lokimq::Access{lokimq::AuthLevel::none, true, false})
+        .add_request_command("data", [this](auto& m) { handle_sn_data(m); })
+        .add_request_command("proxy_exit", [this](auto& m) { handle_sn_proxy_exit(m); })
+        .add_request_command("onion_req", [this](auto& m) { handle_onion_request(m); })
+        ;
 
     // +============= COMMANDS - END ==============
 

--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -141,7 +141,21 @@ void LokimqServer::init(ServiceNode* sn, RequestHandler* rh,
 
     auto logger = [](lokimq::LogLevel level, const char* file, int line,
                      std::string message) {
-        LOKI_LOG(debug, "[line: {}]: {}", line, message);
+#define LMQ_LOG_MAP(LMQ_LVL, SS_LVL) \
+        case lokimq::LogLevel::LMQ_LVL: \
+            LOKI_LOG(SS_LVL, "[{}:{}]: {}", file, line, message); \
+            break;
+
+        switch(level) {
+            LMQ_LOG_MAP(fatal, critical);
+            LMQ_LOG_MAP(error, error);
+            LMQ_LOG_MAP(warn, warn);
+            LMQ_LOG_MAP(info, info);
+            LMQ_LOG_MAP(trace, trace);
+            default:
+                LOKI_LOG(debug, "[{}:{}]: {}", file, line, message);
+        };
+#undef LMQ_LOG_MAP
     };
 
     auto lookup_fn = std::bind(&LokimqServer::peer_lookup, this, ph::_1);


### PR DESCRIPTION
- Updates lokimq to 1.0.3 to fix segfault when initiating requests.  This was triggered when initiating a request to a remote SN that *was* previously connected to us but isn't any longer: when we try to send, the send fails, then we try again with a new outgoing connection.  This "try again" step was recursing and trying to take over pointer ownership that the previous step had already taken over.

- Includes some other minor code improvements (matching up lmq logging, replacing std::bind, and using nicer LMQ command initialization) that I made when investigating.  They aren't required for the fix, but are nice to have.