### PR TITLE
Allow LNS requests for Session clients

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -35,8 +35,6 @@ namespace http = boost::beast::http; // from <boost/beast/http.hpp>
 
 /// +===========================================
 
-static constexpr auto LOKI_EPHEMKEY_HEADER = "X-Loki-EphemKey";
-
 static constexpr auto LOKI_FILE_SERVER_TARGET_HEADER =
     "X-Loki-File-Server-Target";
 static constexpr auto LOKI_FILE_SERVER_VERB_HEADER = "X-Loki-File-Server-Verb";
@@ -63,25 +61,22 @@ std::shared_ptr<request_t> build_post_request(const char* target,
 }
 
 void make_http_request(boost::asio::io_context& ioc,
-                       const std::string& sn_address, uint16_t port,
+                       const std::string& address, uint16_t port,
                        const std::shared_ptr<request_t>& req,
                        http_callback_t&& cb) {
 
     error_code ec;
     tcp::endpoint endpoint;
     tcp::resolver resolver(ioc);
-#ifdef INTEGRATION_TEST
+
     tcp::resolver::iterator destination =
-        resolver.resolve("0.0.0.0", "http", ec);
-#else
-    tcp::resolver::iterator destination =
-        resolver.resolve(sn_address, "http", ec);
-#endif
+        resolver.resolve(address, "http", ec);
+
     if (ec) {
         LOKI_LOG(error,
                  "http: Failed to parse the IP address <{}>. Error code = {}. "
                  "Message: {}",
-                 sn_address, ec.value(), ec.message());
+                 address, ec.value(), ec.message());
         return;
     }
     while (destination != tcp::resolver::iterator()) {
@@ -558,25 +553,31 @@ void connection_t::process_onion_req() {
     // Need to make sure we are not blocking waiting for the response
     delay_response_ = true;
 
-    auto on_response = [this](loki::Response res) {
+    auto on_response = [wself = std::weak_ptr<connection_t>{shared_from_this()}](loki::Response res) {
         LOKI_LOG(debug, "Got an onion response as guard node");
 
+        auto self = wself.lock();
+        if (!self) {
+            LOKI_LOG(debug, "Connection is no longer valid, dropping onion response");
+            return;
+        }
+
         if (res.status() == Status::OK) {
-            response_.result(http::status::ok);
+            self->response_.result(http::status::ok);
 
             // OK here simply means that the response we got is
             // coming from the target node as opposed to any other
             // node on the path. The encrypted body will contain
             // its own response status.
 
-            this->body_stream_ << res.message();
+            self->body_stream_ << res.message();
         } else {
             // res.status() is for us, should we only report a generic
             // error to indicate onion request failure?
-            response_.result(static_cast<int>(res.status()));
+            self->response_.result(static_cast<int>(res.status()));
         }
 
-        this->write_response();
+        self->write_response();
     };
 
     try {
@@ -867,22 +868,6 @@ void connection_t::process_swarm_req(boost::string_view target) {
     } else if (target == "/swarms/ping_test/v1") {
         LOKI_LOG(trace, "Received ping_test");
         response_.result(http::status::ok);
-    } else if (target == "/swarms/proxy_exit") {
-        LOKI_LOG(debug,
-                 "Processing proxy request: we are the destination node");
-
-        const auto it = req.find(LOKI_SENDER_KEY_HEADER);
-        /// TODO: handle the error better?
-        if (it != req.end()) {
-
-            const std::string key = {it->value().data(), it->value().size()};
-
-            auto res = request_handler_.process_proxy_exit(key, req.body());
-            this->set_response(res);
-        } else {
-            LOKI_LOG(debug, "Error: {} header is missing",
-                     LOKI_SENDER_KEY_HEADER);
-        }
     }
 }
 
@@ -1109,29 +1094,50 @@ void connection_t::process_client_req_rate_limited() {
     // to work, spamming us with "retrieve" requests. The workaround for now
     // is to delay responding to the request for a few seconds
 
+    // Client requests can be asynchronous, so only respond in a callback
+    this->delay_response_ = true;
+
+    // TODO: remove this when we remove long-polling from (most) clients
     if (lp_requested) {
         LOKI_LOG(debug, "Received a long-polling request");
-        this->delay_response_ = true;
 
         auto delay_timer = std::make_shared<boost::asio::steady_timer>(ioc_);
 
         delay_timer->expires_after(std::chrono::seconds(2));
         delay_timer->async_wait([self = shared_from_this(), delay_timer, plaintext = std::move(plain_text)](const error_code& ec) {
 
-            const auto res = self->request_handler_.process_client_req(plaintext);
+            self->request_handler_.process_client_req(plaintext, [wself = std::weak_ptr<connection_t>{self}](loki::Response res) {
 
-            LOKI_LOG(debug, "Respond to a long-polling client");
-            self->set_response(res);
-            self->write_response();
+                auto self = wself.lock();
+                if (!self) {
+                    LOKI_LOG(debug, "Connection is no longer valid, dropping response");
+                    return;
+                }
+
+                LOKI_LOG(debug, "Respond to a long-polling client");
+                self->set_response(res);
+                self->write_response();
+            });
         });
 
 
     } else {
-        const auto res = request_handler_.process_client_req(plain_text);
-        LOKI_LOG(debug, "Respond to a non-long polling client");
-        this->set_response(res);
-    }
+        request_handler_.process_client_req(
+            plain_text,
+            [wself = std::weak_ptr<connection_t>{shared_from_this()}](loki::Response res) {
 
+                // // A connection could have been destroyed by the deadline timer
+                auto self = wself.lock();
+                if (!self) {
+                    LOKI_LOG(debug, "Connection is no longer valid, dropping proxy response");
+                    return;
+                }
+
+                LOKI_LOG(debug, "Respond to a non-long polling client");
+                self->set_response(res);
+                self->write_response();
+            });
+    }
 
 }
 
@@ -1155,7 +1161,7 @@ void connection_t::register_deadline() {
                      ec.message());
         }
 
-        LOKI_LOG(debug, "Closing [connection_t] socket due to timeout");
+        LOKI_LOG(debug, "[{}] Closing [connection_t] socket due to timeout", self->conn_idx);
         self->clean_up();
     });
 }

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -217,7 +217,8 @@ int main(int argc, char* argv[]) {
             ioc, worker_ioc, options.port, lokimq_server, lokid_key_pair,
             options.data_dir, lokid_client, options.force_start);
 
-        loki::RequestHandler request_handler(ioc, service_node, channel_encryption);
+        loki::RequestHandler request_handler(ioc, service_node, lokid_client,
+                                             channel_encryption);
 
         lokimq_server.init(&service_node, &request_handler,
                            lokid_key_pair_x25519);

--- a/httpserver/request_handler.cpp
+++ b/httpserver/request_handler.cpp
@@ -1,6 +1,7 @@
 #include "loki_logger.h"
 #include "request_handler.h"
 #include "service_node.h"
+#include "http_connection.h"
 #include "utils.hpp"
 #include "channel_encryption.hpp"
 
@@ -25,8 +26,10 @@ std::string to_string(const Response& res) {
 }
 
 RequestHandler::RequestHandler(boost::asio::io_context& ioc, ServiceNode& sn,
+                               const LokidClient& lokid_client,
                                const ChannelEncryption<std::string>& ce)
-    : ioc_(ioc), service_node_(sn), channel_cipher_(ce) {}
+    : ioc_(ioc), service_node_(sn), lokid_client_(lokid_client),
+      channel_cipher_(ce) {}
 
 static json snodes_to_json(const std::vector<sn_record_t>& snodes) {
 
@@ -287,14 +290,14 @@ Response RequestHandler::process_retrieve(const json& params) {
     return Response{Status::OK, res_body.dump(), ContentType::json};
 }
 
-Response RequestHandler::process_client_req(const std::string& req_json) {
+void RequestHandler::process_client_req(const std::string& req_json, std::function<void(loki::Response)> cb) {
 
     LOKI_LOG(trace, "process_client_req str <{}>", req_json);
 
     const json body = json::parse(req_json, nullptr, false);
     if (body == nlohmann::detail::value_t::discarded) {
         LOKI_LOG(debug, "Bad client request: invalid json");
-        return Response{Status::BAD_REQUEST, "invalid json\n"};
+        cb(Response{Status::BAD_REQUEST, "invalid json\n"});
     }
 
     LOKI_LOG(trace, "process_client_req json <{}>", body.dump(2));
@@ -302,34 +305,44 @@ Response RequestHandler::process_client_req(const std::string& req_json) {
     const auto method_it = body.find("method");
     if (method_it == body.end() || !method_it->is_string()) {
         LOKI_LOG(debug, "Bad client request: no method field");
-        return Response{Status::BAD_REQUEST, "invalid json: no `method` field\n"};
+        cb(Response{Status::BAD_REQUEST, "invalid json: no `method` field\n"});
     }
 
     const auto& method_name = method_it->get_ref<const std::string&>();
 
+    LOKI_LOG(trace, "  - method name: {}", method_name);
+
     const auto params_it = body.find("params");
     if (params_it == body.end() || !params_it->is_object()) {
         LOKI_LOG(debug, "Bad client request: no params field");
-        return Response{Status::BAD_REQUEST, "invalid json: no `params` field\n"};
+        cb(Response{Status::BAD_REQUEST, "invalid json: no `params` field\n"});
     }
 
     if (method_name == "store") {
         LOKI_LOG(debug, "Process client request: store");
-        return this->process_store(*params_it);
+        cb(this->process_store(*params_it));
 
     } else if (method_name == "retrieve") {
         LOKI_LOG(debug, "Process client request: retrieve");
-        return this->process_retrieve(*params_it);
+        cb(this->process_retrieve(*params_it));
         // TODO: maybe we should check if (some old) clients requests long-polling and
         // then wait before responding to prevent spam
 
     } else if (method_name == "get_snodes_for_pubkey") {
         LOKI_LOG(debug, "Process client request: snodes for pubkey");
-        return this->process_snodes_by_pk(*params_it);
+        cb(this->process_snodes_by_pk(*params_it));
+    } else if (method_name == "get_lns_mapping") {
+
+        const auto name_it = params_it->find("name_hash");
+        if (name_it == params_it->end()) {
+            cb(Response{Status::BAD_REQUEST, "Field <name_hash> is missing"});
+        } else {
+            this->process_lns_request(*name_it, std::move(cb));
+        }
 
     } else {
         LOKI_LOG(debug, "Bad client request: unknown method '{}'", method_name);
-        return Response{Status::BAD_REQUEST, fmt::format("no method {}", method_name)};
+        cb(Response{Status::BAD_REQUEST, fmt::format("no method {}", method_name)});
     }
 }
 
@@ -356,15 +369,54 @@ Response RequestHandler::wrap_proxy_response(const Response& res,
     return Response{Status::OK, std::move(ciphertext), ContentType::json};
 }
 
-Response RequestHandler::process_onion_exit(const std::string& eph_key,
-                                            const std::string& payload) {
+void RequestHandler::process_lns_request(
+    lokimq::string_view name_hash, std::function<void(loki::Response)> cb) {
+
+    json params;
+    json array = json::array();
+    json entry;
+
+    entry["name_hash"] = name_hash;
+
+    json types = json::array();
+    types.push_back(0);
+    entry["types"] = types;
+
+    array.push_back(entry);
+    params["entries"] = array;
+
+    // this should not be called "sn response"
+    auto on_lokid_res = [cb = std::move(cb)](sn_response_t sn) {
+        if (sn.error_code == SNodeError::NO_ERROR && sn.body) {
+            cb({Status::OK, *sn.body});
+        } else {
+            cb({Status::BAD_REQUEST, "unknown lokid error"});
+        }
+    };
+
+#ifdef INTEGRATION_TEST
+    // use mainnet seed
+    lokid_client_.make_custom_lokid_request("public.loki.foundation", 22023,
+                                                "lns_names_to_owners", params,
+                                                std::move(on_lokid_res));
+#else
+    lokid_client_.make_lokid_request("lns_names_to_owners", params, std::move(on_lokid_res));
+#endif
+
+}
+
+void
+RequestHandler::process_onion_exit(const std::string& eph_key,
+                                   const std::string& payload,
+                                   std::function<void(loki::Response)> cb) {
 
     LOKI_LOG(debug, "Processing onion exit!");
 
     std::string body;
 
     if (!service_node_.snode_ready(boost::none)) {
-        return {Status::SERVICE_UNAVAILABLE, "Snode not ready"};
+        cb({Status::SERVICE_UNAVAILABLE, "Snode not ready"});
+        return;
     }
 
     try {
@@ -377,21 +429,20 @@ Response RequestHandler::process_onion_exit(const std::string& eph_key,
     } catch (std::exception& e) {
         auto msg = fmt::format("JSON parsing error: {}", e.what());
         LOKI_LOG(error, "{}", msg);
-        return {Status::BAD_REQUEST, msg};
+        cb({Status::BAD_REQUEST, msg});
+        return;
     }
 
-    const auto res = this->process_client_req(body);
-
-    LOKI_LOG(debug, "about to respond with: {}", to_string(res));
-
-    return res;
+    this->process_client_req(body, std::move(cb));
 }
 
-Response RequestHandler::process_proxy_exit(const std::string& client_key,
-                                            const std::string& payload) {
+void RequestHandler::process_proxy_exit(
+    const std::string& client_key, const std::string& payload,
+    std::function<void(loki::Response)> cb) {
 
     if (!service_node_.snode_ready(boost::none)) {
-        return {Status::SERVICE_UNAVAILABLE, "Snode not ready"};
+        cb({Status::SERVICE_UNAVAILABLE, "Snode not ready"});
+        return;
     }
 
     LOKI_LOG(debug, "Process proxy exit");
@@ -416,18 +467,21 @@ Response RequestHandler::process_proxy_exit(const std::string& client_key,
         auto msg = fmt::format("JSON parsing error: {}", e.what());
         LOKI_LOG(error, "{}", msg);
 
-        return {Status::BAD_REQUEST, msg};
+        cb({Status::BAD_REQUEST, msg});
     }
 
     if (lp_used) {
         LOKI_LOG(debug, "Long polling requested over a proxy request");
     }
 
-    const auto res = this->process_client_req(body);
+    this->process_client_req(body, [this, cb = std::move(cb), client_key](loki::Response res) {
 
-    LOKI_LOG(trace, "about to respond with: {}", to_string(res));
+        LOKI_LOG(trace, "about to respond with: {}", to_string(res));
 
-    return wrap_proxy_response(res, client_key, false /* use cbc */);
+        cb(wrap_proxy_response(res, client_key, false /* use cbc */));
+
+    });
+
 }
 
 Response RequestHandler::process_onion_to_url(
@@ -492,12 +546,17 @@ void RequestHandler::process_onion_req(const std::string& ciphertext,
         const json inner_json = json::parse(plaintext, nullptr, true);
 
         if (inner_json.find("body") != inner_json.end()) {
-            LOKI_LOG(debug, "We are the final destination in the onion request!");
+            LOKI_LOG(debug,
+                     "We are the final destination in the onion request!");
 
-            loki::Response res = this->process_onion_exit(ephem_key, plaintext);
-            
-            auto wrapped_res = this->wrap_proxy_response(res, ephem_key, true /* use aes gcm */);
-            cb(std::move(wrapped_res));
+            this->process_onion_exit(
+                ephem_key, plaintext,
+                [this, ephem_key, cb = std::move(cb)](loki::Response res) {
+                    auto wrapped_res = this->wrap_proxy_response(
+                        res, ephem_key, true /* use aes gcm */);
+                    cb(std::move(wrapped_res));
+                });
+
             return;
         } else if (inner_json.find("host") != inner_json.end()) {
 


### PR DESCRIPTION
- Add `get_lns_mapping` endpoint for Session, which takes one parameter `name_hash` and makes an LNS request to Lokid on behalf of the client.
- Fix onion requests potentially resulting in a crash due to request timeout.
- Remove some unused HTTP code for SN-SN communication.