### PR TITLE
Peer testing fix

### DIFF
--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -123,7 +123,7 @@ void LokimqServer::handle_onion_request(lokimq::Message& message) {
         // Before 2.0.3 we reply with a bad request, below, but reply here to avoid putting the
         // error message in the log on 2.0.3+ nodes. (the reply code here doesn't actually matter;
         // the ping test only requires that we provide *some* response).
-        LOKI_LOG(info, "Remote pinged me");
+        LOKI_LOG(debug, "Remote pinged me");
         on_response(loki::Response{Status::OK, "pong"});
         return;
     }

--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -119,6 +119,15 @@ void LokimqServer::handle_onion_request(lokimq::Message& message) {
         lokimq_->send(origin_pk, "REPLY", reply_tag, std::move(status), res.message());
     };
 
+    if (message.data.size() == 1 && message.data[0] == "ping") {
+        // Before 2.0.3 we reply with a bad request, below, but reply here to avoid putting the
+        // error message in the log on 2.0.3+ nodes. (the reply code here doesn't actually matter;
+        // the ping test only requires that we provide *some* response).
+        LOKI_LOG(info, "Remote pinged me");
+        on_response(loki::Response{Status::OK, "pong"});
+        return;
+    }
+
     if (message.data.size() != 2) {
         LOKI_LOG(error, "Expected 2 message parts, got {}", message.data.size());
         on_response(loki::Response{Status::BAD_REQUEST, "Incorrect number of messages"});

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -955,7 +955,7 @@ void ServiceNode::test_reachability(const sn_record_t& sn) {
     // test lmq port:
     lmq_server_.lmq()->request(sn.pubkey_x25519_bin(), "sn.onion_req",
             [this, sn](bool success, const auto&) {
-            LOKI_LOG(info, "Got success={} testing response from {}",
+            LOKI_LOG(debug, "Got success={} testing response from {}",
                     success, sn.pubkey_x25519_hex());
             process_reach_test_result(
                     sn.pub_key_base32z(), ReachType::ZMQ, success);


### PR DESCRIPTION
- try to reuse the same outgoing connection for peer testing, so we don't have to manually close it