### PR TITLE
Improve error handling in proxy requests

### DIFF
--- a/common/src/loki_logger.cpp
+++ b/common/src/loki_logger.cpp
@@ -56,8 +56,11 @@ void init_logging(const std::string& data_dir,
     auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
     console_sink->set_level(log_level);
 
+    // setting this to `true` can be useful for debugging on testnet
+    bool rotate_on_open = false;
+
     auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-        log_location, LOG_FILE_SIZE_LIMIT, EXTRA_FILES);
+        log_location, LOG_FILE_SIZE_LIMIT, EXTRA_FILES, rotate_on_open);
     file_sink->set_level(log_level);
 
     auto developer_sink = std::make_shared<loki::dev_sink_mt>();

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -603,7 +603,11 @@ void connection_t::process_onion_req() {
 
 void connection_t::process_proxy_req() {
 
-    LOKI_LOG(debug, "Processing proxy request: we are first hop");
+    static int req_counter = 0;
+
+    const int req_idx = req_counter;
+
+    LOKI_LOG(debug, "[{}] Processing proxy request: we are first hop", req_idx);
 
     service_node_.record_proxy_request();
 
@@ -623,11 +627,9 @@ void connection_t::process_proxy_req() {
     const auto& sender_key = header_[LOKI_SENDER_KEY_HEADER];
     const auto& target_snode_key = header_[LOKI_TARGET_SNODE_KEY];
 
+    LOKI_LOG(debug, "[{}] Destination: {}", req_idx, target_snode_key);
+
     auto sn = service_node_.find_node_by_ed25519_pk(target_snode_key);
-
-    static int req_counter = 0;
-
-    const int req_idx = req_counter;
 
     // TODO: make an https response out of what we got back
     auto on_proxy_response = [wself = std::weak_ptr<connection_t>{shared_from_this()}, req_idx](
@@ -641,14 +643,27 @@ void connection_t::process_proxy_req() {
             return;
         }
 
-        if (success && data.size() == 1) {
+        if (!success) {
+            LOKI_LOG(debug, "Proxy response FAILED (timeout), idx: {}", req_idx);
+            self->response_.result(http::status::gateway_timeout);
+        } else if (data.size() == 2) {
+            LOKI_LOG(debug, "Proxy respose with status, idx: {}", req_idx);
 
+            try {
+                int status = std::stoi(data[0]);
+                self->response_.result(status);
+                self->body_stream_ << data[1];
+            } catch (const std::exception&) {
+                self->response_.result(http::status::internal_server_error);
+            }
+
+        } else if (data.size() != 1) {
+            LOKI_LOG(debug, "Proxy response FAILED (wrong data size), idx: {}", req_idx);
+            self->response_.result(http::status::internal_server_error);
+        } else {
             LOKI_LOG(debug, "PROXY RESPONSE OK, idx: {}", req_idx);
-
             self->body_stream_ << data[0];
             self->response_.result(http::status::ok);
-        } else {
-            LOKI_LOG(debug, "PROXY RESPONSE FAILED, idx: {}", req_idx);
         }
 
         // This will return an empty, but failed response to the client

--- a/httpserver/reachability_testing.cpp
+++ b/httpserver/reachability_testing.cpp
@@ -59,6 +59,9 @@ bool reachability_records_t::should_report_as(const sn_pub_key_t& sn, ReportType
         } else if (elapsed > UNREACH_GRACE_PERIOD) {
             LOKI_LOG(debug, "[reach] Will REPORT {} to Lokid!", sn);
             return true;
+        } else {
+            // No need to report yet
+            return false;
         }
 
     }

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -151,6 +151,8 @@ static all_swarms_t apply_ips(const all_swarms_t& swarms_to_keep,
 
     all_swarms_t result_swarms = swarms_to_keep;
     const auto other_snode_map = get_snode_map_from_swarms(other_swarms);
+
+    int updates_count = 0;
     for (auto& swarm : result_swarms) {
         for (auto& snode : swarm.snodes) {
             const auto other_snode_it =
@@ -160,10 +162,13 @@ static all_swarms_t apply_ips(const all_swarms_t& swarms_to_keep,
                 // Keep swarms_to_keep but don't overwrite with default IPs
                 if (snode.ip() == "0.0.0.0") {
                     snode.set_ip(other_snode.ip());
+                    updates_count++;
                 }
             }
         }
     }
+
+    LOKI_LOG(info, "Updated {} entries from seed", updates_count);
     return result_swarms;
 }
 


### PR DESCRIPTION
- only bootstrap from seed after first having contacted local lokid (we can't apply ip changes when the node list is empty)
- forward more errors in proxy requests to the client