### PR TITLE
Update to lmq 1.0.5 & fix compilation

### DIFF
--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -3,11 +3,10 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <lokimq/string_view.h>
 
 namespace lokimq {
 class LokiMQ;
-class simple_string_view;
-using string_view = simple_string_view;
 struct Allow;
 class Message;
 } // namespace lokimq


### PR DESCRIPTION
Updates to 1.0.5 with a fix that can cause message reception delays of up to 250ms.  (Though I believe only under certain connect/disconnect patterns).

1.0.5 also broke SS's forward declaration of `string_view` (because it grew the capability of handling char types other than `char`); the underlying simple_string_view class is an implementation detail that isn't meant to be used (and may not exist at all: lokimq uses std::string_view instead if the compiler provides it).