### PR TITLE
Remove headers from cmake add_library

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -2,17 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 
 add_definitions(-DSPDLOG_COMPILED_LIB)
 
-set(SRC_FILES
+add_library(common STATIC
     src/loki_logger.cpp
 )
 
-set(HEADER_FILES
-    include/loki_common.h
-    include/loki_logger.h
-    include/dev_sink.h
-)
-
-add_library(common STATIC ${HEADER_FILES} ${SRC_FILES})
 
 find_package(Boost
     REQUIRED

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -4,26 +4,7 @@ add_definitions(-DDISABLE_ENCRYPTION)
 
 project(httpserver)
 
-set(HEADER_FILES
-    http_connection.h
-    swarm.h
-    service_node.h
-    serialization.h
-    rate_limiter.h
-    ../external/json.hpp
-    https_client.h
-    server_certificates.h
-    stats.h
-    security.h
-    command_line.h
-    net_stats.h
-    dns_text_records.h
-    reachability_testing.h
-    lmq_server.h
-    request_handler.h
-    )
-
-set(SRC_FILES
+add_library(httpserver_lib STATIC
     main.cpp
     http_connection.cpp
     swarm.cpp
@@ -39,8 +20,6 @@ set(SRC_FILES
     lmq_server.cpp
     request_handler.cpp
     )
-
-add_library(httpserver_lib STATIC ${HEADER_FILES} ${SRC_FILES})
 
 loki_add_subdirectory(../common common)
 loki_add_subdirectory(../storage storage)

--- a/pow/CMakeLists.txt
+++ b/pow/CMakeLists.txt
@@ -1,9 +1,7 @@
-set(SOURCES
-    include/pow.hpp
+add_library(pow STATIC
     src/pow.cpp
 )
 
-add_library(pow STATIC ${SOURCES})
 
 loki_add_subdirectory(../utils utils)
 

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -1,12 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 
-set(SOURCES
-    include/Database.hpp
-    include/Item.hpp
+add_library(storage STATIC
     src/Database.cpp
 )
-
-add_library(storage STATIC ${SOURCES})
 
 set_property(TARGET storage PROPERTY CXX_STANDARD 14)
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -2,8 +2,7 @@ if (TARGET utils)
     return()
 endif()
 
-set(SOURCES
-    include/utils.hpp
+add_library(utils STATIC
     src/utils.cpp
 )
 
@@ -11,8 +10,6 @@ find_package(Boost
     REQUIRED
     filesystem
 )
-
-add_library(utils STATIC ${SOURCES})
 
 set_property(TARGET utils PROPERTY CXX_STANDARD 14)
 


### PR DESCRIPTION
Headers aren't supposed to be listed in `add_library` calls and are an
unfortunately common cmake anti-pattern.  (cmake does *not* need headers
listed to know how to check that things need rebuilding when a header
changes, which seems to be the reason people think they have to include
them).

Apparently this antipattern emerged partly because of buggy behaviour in
MSVC pre-2017 that didn't understand how to find headers when loading a
CMake project.