### PR TITLE
LokiMQ SN authenication overhaul

### DIFF
--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -27,23 +27,6 @@ std::string LokimqServer::peer_lookup(lokimq::string_view pubkey_bin) const {
     }
 }
 
-lokimq::Allow
-LokimqServer::auth_level_lookup(lokimq::string_view ip,
-                                lokimq::string_view pubkey) const {
-
-    LOKI_LOG(debug, "[LMQ] Auth Level Lookup for {}", util::as_hex(pubkey));
-
-    // TODO: make SN accept string_view
-    boost::optional<sn_record_t> sn =
-        this->service_node_->find_node_by_x25519_bin(std::string(pubkey));
-
-    bool is_sn = sn ? true : false;
-
-    LOKI_LOG(debug, "[LMQ]    is service node: {}", is_sn);
-
-    return lokimq::Allow{lokimq::AuthLevel::none, is_sn};
-};
-
 void LokimqServer::handle_sn_data(lokimq::Message& message) {
 
     LOKI_LOG(debug, "[LMQ] handle_sn_data");
@@ -175,8 +158,6 @@ void LokimqServer::init(ServiceNode* sn, RequestHandler* rh,
 
     auto lookup_fn = [this](auto pk) { return this->peer_lookup(pk); };
 
-    auto allow_fn = [this](auto ip, auto pk) { return this->auth_level_lookup(ip, pk); };
-
     lokimq_.reset(new LokiMQ{pubkey,
                              seckey,
                              true /* is service node */,
@@ -199,7 +180,7 @@ void LokimqServer::init(ServiceNode* sn, RequestHandler* rh,
 
     lokimq_->set_general_threads(1);
 
-    lokimq_->listen_curve(fmt::format("tcp://0.0.0.0:{}", port_), allow_fn);
+    lokimq_->listen_curve(fmt::format("tcp://0.0.0.0:{}", port_));
 
     lokimq_->MAX_MSG_SIZE = 10 * 1024 * 1024; // 10 MB (needed by the fileserver)
 

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -31,10 +31,6 @@ class LokimqServer {
     // Get nodes' address
     std::string peer_lookup(lokimq::string_view pubkey_bin) const;
 
-    // Check if the node is SN
-    lokimq::Allow auth_level_lookup(lokimq::string_view ip,
-                                    lokimq::string_view pubkey) const;
-
     // Handle Session data coming from peer SN
     void handle_sn_data(lokimq::Message& message);
 

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -55,9 +55,11 @@ class LokimqServer {
 
     uint16_t port() { return port_; }
 
-    // TODO: maybe we should separate LokiMQ and LokimqServer, so we don't have
-    // to do this: Get underlying LokiMQ instance
-    LokiMQ* lmq() { return lokimq_.get(); }
+    /// True if LokiMQ instance has been set
+    explicit operator bool() const { return (bool) lokimq_; }
+    /// Dereferencing via * or -> accesses the contained LokiMQ instance.
+    LokiMQ& operator*() const { return *lokimq_; }
+    LokiMQ* operator->() const { return lokimq_.get(); }
 };
 
 } // namespace loki

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -438,7 +438,7 @@ void ServiceNode::send_onion_to_sn(const sn_record_t& sn,
 
     // NO mutex needed (I think)
 
-    lmq_server_.lmq()->request(
+    lmq_server_->request(
         sn.pubkey_x25519_bin(), "sn.onion_req", std::move(cb),
         lokimq::send_option::request_timeout{10s}, eph_key, payload);
 }
@@ -454,7 +454,7 @@ void ServiceNode::send_to_sn(const sn_record_t& sn, ss_client::ReqMethod method,
     case ss_client::ReqMethod::DATA: {
         LOKI_LOG(debug, "Sending sn.data request to {}",
                  util::as_hex(sn.pubkey_x25519_bin()));
-        lmq_server_.lmq()->request(sn.pubkey_x25519_bin(), "sn.data",
+        lmq_server_->request(sn.pubkey_x25519_bin(), "sn.data",
                                    std::move(cb), req.body);
         break;
     }
@@ -466,7 +466,7 @@ void ServiceNode::send_to_sn(const sn_record_t& sn, ss_client::ReqMethod method,
         if (client_key != req.headers.end()) {
             LOKI_LOG(debug, "Sending sn.proxy_exit request to {}",
                      util::as_hex(sn.pubkey_x25519_bin()));
-            lmq_server_.lmq()->request(sn.pubkey_x25519_bin(), "sn.proxy_exit",
+            lmq_server_->request(sn.pubkey_x25519_bin(), "sn.proxy_exit",
                                        std::move(cb), client_key->second,
                                        req.body);
         } else {
@@ -857,7 +857,7 @@ void ServiceNode::test_reachability(const sn_record_t& sn) {
     LOKI_LOG(debug, "Testing node for reachability over LMQ: {}", sn);
 
     // test lmq port:
-    lmq_server_.lmq()->request(
+    lmq_server_->request(
         sn.pubkey_x25519_bin(), "sn.onion_req",
         [this, sn](bool success, const auto&) {
             LOKI_LOG(debug, "Got success={} testing response from {}", success,

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -275,7 +275,7 @@ parse_swarm_update(const std::shared_ptr<std::string>& response_body) {
             // lokidKeyFromHex works for pub keys too
             const public_key_t pubkey_x25519 =
                 lokidKeyFromHex(pubkey_x25519_hex);
-            const std::string pubkey_x25519_bin = key_to_string(pubkey_x25519);
+            std::string pubkey_x25519_bin = key_to_string(pubkey_x25519);
 
             const auto& pubkey_ed25519 =
                 sn_json.at("pubkey_ed25519").get_ref<const std::string&>();
@@ -304,6 +304,9 @@ parse_swarm_update(const std::shared_ptr<std::string>& response_body) {
                 bu.decommissioned_nodes.push_back(sn);
             } else {
                 swarm_map[swarm_id].push_back(sn);
+
+                if (pubkey_x25519_bin.size() == 32)
+                    bu.active_x25519_pubkeys.insert(std::move(pubkey_x25519_bin));
             }
         }
 
@@ -364,11 +367,12 @@ void ServiceNode::bootstrap_data() {
                     LOKI_LOG(info, "Parsing response from seed {}",
                              seed_node.first);
                     try {
-                        const block_update_t bu = parse_swarm_update(res.body);
+                        block_update_t bu = parse_swarm_update(res.body);
+
                         // TODO: this should be disabled in the "testnet" mode
                         // (or changed to point to testnet seeds)
                         if (!bu.unchanged) {
-                            this->on_bootstrap_update(bu);
+                            this->on_bootstrap_update(std::move(bu));
                         }
 
                         LOKI_LOG(info, "Bootstrapped from {}", seed_node.first);
@@ -554,16 +558,19 @@ void ServiceNode::save_bulk(const std::vector<Item>& items) {
     LOKI_LOG(trace, "saved messages count: {}", items.size());
 }
 
-void ServiceNode::on_bootstrap_update(const block_update_t& bu) {
+void ServiceNode::on_bootstrap_update(block_update_t&& bu) {
 
     // Used in a callback to needs a mutex even if it is private
     LockGuard guard(sn_mutex_);
 
     swarm_->apply_swarm_changes(bu.swarms);
     target_height_ = std::max(target_height_, bu.height);
+
+    if (syncing_ && lmq_server_)
+        lmq_server_->set_active_sns(std::move(bu.active_x25519_pubkeys));
 }
 
-void ServiceNode::on_swarm_update(const block_update_t& bu) {
+void ServiceNode::on_swarm_update(block_update_t&& bu) {
 
     // Used in a callback to needs a mutex even if it is private
     LockGuard guard(sn_mutex_);
@@ -609,6 +616,9 @@ void ServiceNode::on_swarm_update(const block_update_t& bu) {
         LOKI_LOG(trace, "already seen this block");
         return;
     }
+
+    if (lmq_server_)
+        lmq_server_->set_active_sns(std::move(bu.active_x25519_pubkeys));
 
     const SwarmEvents events = swarm_->derive_swarm_events(bu.swarms);
 
@@ -739,9 +749,9 @@ void ServiceNode::swarm_timer_tick() {
 #endif
                     }
 
-                    const block_update_t bu = parse_swarm_update(res.body);
+                    block_update_t bu = parse_swarm_update(res.body);
                     if (!bu.unchanged)
-                        on_swarm_update(bu);
+                        on_swarm_update(std::move(bu));
                 } catch (const std::exception& e) {
                     LOKI_LOG(error, "Exception caught on swarm update: {}",
                              e.what());

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -162,9 +162,9 @@ class ServiceNode {
     // Save items to the database, notifying listeners as necessary
     void save_bulk(const std::vector<storage::Item>& items);
 
-    void on_bootstrap_update(const block_update_t& bu);
+    void on_bootstrap_update(block_update_t&& bu);
 
-    void on_swarm_update(const block_update_t& bu);
+    void on_swarm_update(block_update_t&& bu);
 
     void bootstrap_data();
 

--- a/httpserver/swarm.h
+++ b/httpserver/swarm.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <lokimq/auth.h>
 
 #include "loki_common.h"
 
@@ -26,6 +27,7 @@ using all_swarms_t = std::vector<SwarmInfo>;
 struct block_update_t {
     all_swarms_t swarms;
     std::vector<sn_record_t> decommissioned_nodes;
+    lokimq::pubkey_set active_x25519_pubkeys;
     uint64_t height;
     std::string block_hash;
     int hardfork;


### PR DESCRIPTION
Assigning a connection's SN status at connection time is not working
well: it results in excess reconnections and test failures, since
currently the behaviour goes something like this:

- SS has many other SSes connected to it.
- SS restarts
- Other SSes see the closed connection and reconnect
- Many of these reconnections are fast enough that the SS doesn't have
  the SS list loaded yet, and so they all get service node status set to
  false.
- One of the SSes makes a request (either onion routing something, or
  doing a reachability test).
- SS says "BYE" to tell the remote to disconnect.
- Remote disconnects, and the request fails.
- Remote tests again sometime later and reconnects, this time
  gets noticed as a SN and allowed.

There's a related overhang issue where a connected SN keeps its SN
status on the connection as long as it keeps the connection open even if
it is no longer an active SN.

I've changed LokiMQ to make this work better by doing SN status checking
at the time the command is invoked.  This required some API-incompatible
restructuring, however: it isn't feasible, for performance reasons, to
invoke the Allow callback on each request, so this means LMQ needs to
maintain its own list of active service nodes, and SS needs to tell LMQ
whenever the list of service nodes changes.

This commit updates LokiMQ and implements the updating logic in SS.