### PR TITLE
Notify operator when their node seems unreachable

### DIFF
--- a/common/include/loki_common.h
+++ b/common/include/loki_common.h
@@ -6,11 +6,14 @@
 #include <ostream>
 #include <string>
 #include <vector>
+#include <chrono>
 
 #include <boost/optional.hpp>
 
 // TODO: this should be a proper struct w/o heap allocation!
 using sn_pub_key_t = std::string;
+
+using time_point_t = std::chrono::time_point<std::chrono::steady_clock>;
 
 struct sn_record_t {
 

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -502,7 +502,8 @@ void connection_t::process_storage_test_req(uint64_t height,
         this->body_stream_ << json_res.dump();
         response_.result(http::status::ok);
     } else {
-        LOKI_LOG(error, "Failed storage test, tried {} times.",
+        // Promote this to `error` once we enforce storage testing
+        LOKI_LOG(debug, "Failed storage test, tried {} times.",
                  repetition_count_);
         nlohmann::json json_res;
         json_res["status"] = "other";
@@ -880,6 +881,7 @@ void connection_t::process_swarm_req(boost::string_view target) {
 
     } else if (target == "/swarms/ping_test/v1") {
         LOKI_LOG(trace, "Received ping_test");
+        service_node_.update_last_ping(ReachType::HTTP);
         response_.result(http::status::ok);
     }
 }

--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -109,6 +109,7 @@ void LokimqServer::handle_onion_request(lokimq::Message& message) {
         // error message in the log on 2.0.3+ nodes. (the reply code here doesn't actually matter;
         // the ping test only requires that we provide *some* response).
         LOKI_LOG(debug, "Remote pinged me");
+        service_node_->update_last_ping(ReachType::ZMQ);
         on_response(loki::Response{Status::OK, "pong"});
         return;
     }

--- a/httpserver/reachability_testing.h
+++ b/httpserver/reachability_testing.h
@@ -4,15 +4,16 @@
 #include <chrono>
 #include <unordered_map>
 
+using namespace std::chrono_literals;
+
+constexpr std::chrono::seconds PING_PEERS_INTERVAL = 10s;
+
 namespace loki {
 
 namespace detail {
 
 /// TODO: make this class "private"?
 class reach_record_t {
-
-
-    using time_point_t = std::chrono::time_point<std::chrono::steady_clock>;
 
   public:
     // The time the node failed for the first time
@@ -52,9 +53,18 @@ class reachability_records_t {
     std::unordered_map<sn_pub_key_t, detail::reach_record_t> offline_nodes_;
 
   public:
-    // Return nodes that should be tested first: decommissioned nodes
-    // and those that failed our earlier tests (but not reported yet)
-    // std::vector<> priority_nodes() const;
+
+    // The time we were last tested and reached by some other node over lmq
+    time_point_t latest_incoming_lmq_;
+    // The time we were last tested and reached by some other node over http
+    time_point_t latest_incoming_http_;
+
+    // These will be set to `false` if we stop receiving lmq/http pings
+    bool lmq_ok = true;
+    bool http_ok = true;
+
+    // Check whether we received incoming pings recently
+    void check_incoming_tests(time_point_t reset_time);
 
     // Records node as reachable/unreachable according to `val`
     void record_reachable(const sn_pub_key_t& sn, ReachType type, bool val);

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -35,10 +35,7 @@ using http_server::connection_t;
 using LockGuard = std::lock_guard<std::recursive_mutex>;
 
 constexpr std::array<std::chrono::seconds, 8> RETRY_INTERVALS = {
-    std::chrono::seconds(1),   std::chrono::seconds(5),
-    std::chrono::seconds(10),  std::chrono::seconds(20),
-    std::chrono::seconds(40),  std::chrono::seconds(80),
-    std::chrono::seconds(160), std::chrono::seconds(320)};
+    1s, 5s, 10s, 20s, 40s, 80s, 160s, 320s};
 
 constexpr std::chrono::milliseconds RELAY_INTERVAL = 350ms;
 
@@ -106,7 +103,6 @@ constexpr std::chrono::milliseconds SWARM_UPDATE_INTERVAL = 200ms;
 constexpr std::chrono::milliseconds SWARM_UPDATE_INTERVAL = 1000ms;
 #endif
 constexpr std::chrono::seconds STATS_CLEANUP_INTERVAL = 60min;
-constexpr std::chrono::seconds PING_PEERS_INTERVAL = 10s;
 constexpr std::chrono::minutes LOKID_PING_INTERVAL = 5min;
 constexpr std::chrono::minutes POW_DIFFICULTY_UPDATE_INTERVAL = 10min;
 constexpr std::chrono::seconds VERSION_CHECK_INTERVAL = 10min;
@@ -192,9 +188,9 @@ ServiceNode::ServiceNode(boost::asio::io_context& ioc,
     lokid_ping_timer_tick();
     cleanup_timer_tick();
 
-#ifndef INTEGRATION_TEST
+// #ifndef INTEGRATION_TEST
     ping_peers_tick();
-#endif
+// #endif
 
     worker_thread_ = boost::thread([this]() { worker_ioc_.run(); });
     boost::asio::post(worker_ioc_, [this]() {
@@ -439,8 +435,6 @@ void ServiceNode::send_onion_to_sn(const sn_record_t& sn,
                                    const std::string& payload,
                                    const std::string& eph_key,
                                    ss_client::Callback cb) const {
-
-    // NO mutex needed (I think)
 
     lmq_server_->request(
         sn.pubkey_x25519_bin(), "sn.onion_req", std::move(cb),
@@ -779,6 +773,24 @@ void ServiceNode::cleanup_timer_tick() {
         boost::bind(&ServiceNode::cleanup_timer_tick, this));
 }
 
+void ServiceNode::update_last_ping(ReachType type) {
+
+    switch (type) {
+        case ReachType::HTTP: {
+            reach_records_.latest_incoming_http_ = std::chrono::steady_clock::now();
+            break;
+        }
+        case ReachType::ZMQ: {
+            reach_records_.latest_incoming_lmq_ = std::chrono::steady_clock::now();
+            break;
+        }
+        default:
+            LOKI_LOG(error, "Connection type not supported");
+            assert(false);
+            break;
+    }
+}
+
 void ServiceNode::ping_peers_tick() {
 
     // Used as a callback to needs a mutex even if it is private
@@ -788,12 +800,8 @@ void ServiceNode::ping_peers_tick() {
     this->peer_ping_timer_.async_wait(
         std::bind(&ServiceNode::ping_peers_tick, this));
 
-    /// TODO: To be safe, let's not even test peers until we
-    /// have reached the right hardfork height
-    if (hardfork_ < ENFORCED_REACHABILITY_HARDFORK) {
-        LOKI_LOG(debug, "Have not reached HF13, skipping reachability tests");
-        return;
-    }
+    // Check if we've been tested (reached) recently ourselves
+    reach_records_.check_incoming_tests(all_stats_.get_reset_time());
 
     if (!this->swarm_->is_valid()) {
         LOKI_LOG(debug, "Skipping this round of peer testing (decommissioned)");
@@ -1655,7 +1663,9 @@ static nlohmann::json to_json(const all_stats_t& stats) {
     json["previous_period_retrieve_requests"] =
         stats.get_previous_period_retrieve_requests();
 
-    json["reset_time"] = stats.get_reset_time();
+    json["reset_time"] = std::chrono::duration_cast<std::chrono::seconds>(
+                             stats.get_reset_time().time_since_epoch())
+                             .count();
 
     nlohmann::json peers;
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -795,6 +795,11 @@ void ServiceNode::ping_peers_tick() {
         return;
     }
 
+    if (!this->swarm_->is_valid()) {
+        LOKI_LOG(debug, "Skipping this round of peer testing (decommissioned)");
+        return;
+    }
+
     /// We always test one node already known to be offline
     /// plus one random other node (could even be the same node)
 

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -253,6 +253,8 @@ class ServiceNode {
 
     ~ServiceNode();
 
+    // Record the time of our last being tested over lmq/http
+    void update_last_ping(ReachType type);
 
     // These two are only needed because we store stats in Service Node,
     // might move it out later

--- a/httpserver/stats.h
+++ b/httpserver/stats.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "loki_common.h"
-#include <ctime>
 #include <deque>
 #include <unordered_map>
 #include <atomic>
@@ -70,7 +69,7 @@ class all_stats_t {
     uint64_t previous_period_onion_requests = 0;
     std::atomic<uint64_t> recent_onion_requests{0};
 
-    time_t reset_time_ = time(nullptr);
+    time_point_t reset_time_ = std::chrono::steady_clock::now();
     // =============================
 
     /// update period moving recent request counters to
@@ -164,7 +163,7 @@ class all_stats_t {
         return previous_period_retrieve_requests;
     }
 
-    time_t get_reset_time() const { return reset_time_; }
+    time_point_t get_reset_time() const { return reset_time_; }
 };
 
 } // namespace loki


### PR DESCRIPTION
- Displays a warning when the node hasn't been pinged (independently over zmq and http) by any other node for a long time (3 min currently).
- Decomissioned nodes no longer attempt to ping other nodes (they would fail anyway).
- Silence storage testing errors (since they are not enforced yet).