### PR TITLE
Clean up log messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ ENV BOOST_ROOT /usr/src/app/boost_${BOOST_VERSION}
 RUN cd loki-storage-server \
     && mkdir -p build \
     && cd build \
-    && cmake .. -DBOOST_ROOT=$BOOST_ROOT \
+    && cmake .. -DBOOST_ROOT=$BOOST_ROOT -Dsodium_USE_STATIC_LIBS=ON \
     && cmake --build . -- -j8
 
 RUN loki-storage-server/build/httpserver/loki-storage --version 

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -340,7 +340,7 @@ void connection_t::on_handshake(boost::system::error_code ec) {
     LOKI_LOG(trace, "Open https socket: {}", sockfd);
     get_net_stats().record_socket_open(sockfd);
     if (ec) {
-        LOKI_LOG(warn, "ssl handshake failed: ec: {} ({})", ec.value(),
+        LOKI_LOG(debug, "ssl handshake failed: ec: {} ({})", ec.value(),
                  ec.message());
         this->clean_up();
         deadline_.cancel();

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -97,6 +97,8 @@ class FailedRequestHandler
 /// WRONG_REQ - request was ignored as not valid (e.g. incorrect tester)
 enum class MessageTestStatus { SUCCESS, RETRY, ERROR, WRONG_REQ };
 
+enum class SnodeStatus { UNKNOWN, UNSTAKED, DECOMMISSIONED, ACTIVE };
+
 /// All service node logic that is not network-specific
 class ServiceNode {
     using pub_key_t = std::string;
@@ -118,6 +120,8 @@ class ServiceNode {
     std::string block_hash_;
     std::unique_ptr<Swarm> swarm_;
     std::unique_ptr<Database> db_;
+
+    SnodeStatus status_ = SnodeStatus::UNKNOWN;
 
     sn_record_t our_address_;
 

--- a/httpserver/swarm.cpp
+++ b/httpserver/swarm.cpp
@@ -168,7 +168,7 @@ static all_swarms_t apply_ips(const all_swarms_t& swarms_to_keep,
         }
     }
 
-    LOKI_LOG(info, "Updated {} entries from seed", updates_count);
+    LOKI_LOG(debug, "Updated {} entries from lokid", updates_count);
     return result_swarms;
 }
 


### PR DESCRIPTION
- Distinguish between decommissioned and unstaked nodes and adjust logs accordingly