### PR TITLE
Make --version print without initializing logger

### DIFF
--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -72,6 +72,11 @@ int main(int argc, char* argv[]) {
         return EXIT_SUCCESS;
     }
 
+    if (options.print_version) {
+        std::cout << version_info();
+        return EXIT_SUCCESS;
+    }
+
     if (options.data_dir.empty()) {
         if (auto home_dir = get_home_dir()) {
             if (options.testnet) {
@@ -105,9 +110,6 @@ int main(int argc, char* argv[]) {
 
     // Always print version for the logs
     print_version();
-    if (options.print_version) {
-        return EXIT_SUCCESS;
-    }
 
     if (options.ip == "127.0.0.1") {
         LOKI_LOG(critical,

--- a/httpserver/version.h
+++ b/httpserver/version.h
@@ -28,9 +28,12 @@
 #define STORAGE_SERVER_BUILD_TIME "?"
 #endif
 
-static void print_version() {
-    LOKI_LOG(info,
-             "Loki Storage Server v{}\n git commit hash: {}\n build time: {}",
+inline std::string version_info() {
+    return fmt::format(
+             "Loki Storage Server v{}\n git commit hash: {}\n build time: {}\n",
              STORAGE_SERVER_VERSION_STRING, STORAGE_SERVER_GIT_HASH_STRING,
              STORAGE_SERVER_BUILD_TIME);
+}
+inline void print_version() {
+    LOKI_LOG(info, "{}", version_info());
 }


### PR DESCRIPTION
Currently --version is sort of awkward: it doesn't print anything at all
if you run it with `--log-level warning` (or if you have that in a
config file), and it prints the version info *after* initializing (and
printing various info about) the logger, which makes the output kind of
messy.

This simplifies it to print the version (and exit) much earlier in the
startup when `--version` is given (and leaves the existing logged
version print as is).

(This also makes a minor tweak to the current `print_version` from
`static` to `inline` so that the linker can throw away the duplicates
rather than keeping duplicates for each compilation unit that includes
version.h.)