### PR TITLE
BSD compilation fixes

### DIFF
--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -43,9 +43,15 @@ target_link_libraries(httpserver_lib PUBLIC OpenSSL::SSL OpenSSL::Crypto)
 target_link_libraries(httpserver_lib PUBLIC storage)
 target_link_libraries(httpserver_lib PUBLIC utils)
 target_link_libraries(httpserver_lib PUBLIC pow)
-target_link_libraries(httpserver_lib PUBLIC resolv)
 target_link_libraries(httpserver_lib PUBLIC crypto)
 target_link_libraries(httpserver_lib PUBLIC lokimq::lokimq)
+
+# libresolv is needed on linux, but not on BSDs, so only link it if we can find it
+find_library(RESOLV resolv)
+if(RESOLV)
+    target_link_libraries(httpserver_lib PUBLIC ${RESOLV})
+endif()
+
 
 set_property(TARGET httpserver_lib PROPERTY CXX_STANDARD 14)
 

--- a/httpserver/dns_text_records.cpp
+++ b/httpserver/dns_text_records.cpp
@@ -2,6 +2,7 @@
 #include "../external/json.hpp"
 #include "pow.hpp"
 #include "version.h"
+#include <netinet/in.h>
 #include <resolv.h>
 
 #include <boost/algorithm/string.hpp>


### PR DESCRIPTION
- Updates lokimq to the latest master (which contains a few small fixes/tweaks, including a freebsd compilation fix).

- Only link to `-lresolv` if it exists (it doesn't on BSDs because the functions are part of libc).

- Fix a missing header needed for the resolv.h functions being used

Fixes #377 