### PR TITLE
Add lmq endpoint for the notification server

### DIFF
--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 
 add_definitions(-DDISABLE_ENCRYPTION)
 
+# Stop compiling post first error
+add_definitions(-Wfatal-errors)
+
 project(httpserver)
 
 add_library(httpserver_lib STATIC
@@ -19,6 +22,7 @@ add_library(httpserver_lib STATIC
     reachability_testing.cpp
     lmq_server.cpp
     request_handler.cpp
+    notifier.cpp
     )
 
 loki_add_subdirectory(../common common)

--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -924,6 +924,8 @@ void connection_t::process_request() {
 
     const auto target = req.target();
 
+    LOKI_LOG(debug, "target: {}", target);
+
     const bool is_swarm_req = (target.find("/swarms/") == 0);
 
     if (is_swarm_req) {

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -226,7 +226,7 @@ void HttpsClientSession::on_write(error_code ec, size_t bytes_transferred) {
 
 bool HttpsClientSession::verify_signature() {
 
-    if (server_pub_key_b32z_)
+    if (!server_pub_key_b32z_)
         return true;
 
     const auto it = res_.find(LOKI_SNODE_SIGNATURE_HEADER);

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -39,7 +39,16 @@ class LokimqServer {
 
     void handle_onion_request(lokimq::Message& message);
 
+    void handle_notify_add_pubkey(lokimq::Message& message);
+
+    void handle_notify_get_subscriber_count(lokimq::Message& message);
+
+    bool check_pn_server_pubkey(const std::string& pk) const;
+
     uint16_t port_ = 0;
+
+    // binary stored in a string
+    std::string pn_server_key_;
 
   public:
     LokimqServer(uint16_t port);

--- a/httpserver/notifier.cpp
+++ b/httpserver/notifier.cpp
@@ -1,0 +1,60 @@
+#include "notifier.h"
+
+#include "lmq_server.h"
+#include "loki_logger.h"
+
+#include "Item.hpp"
+
+#include "../external/json.hpp"
+
+using lokimq::string_view;
+using nlohmann::json;
+
+namespace loki {
+
+Notifier::Notifier(LokimqServer& lmq) : lmq_(lmq) {}
+
+void Notifier::add_pubkey(const lokimq::ConnectionID& cid,
+                             string_view pubkey) {
+
+    cid_ = cid;
+
+    this->pubkeys_.insert(pubkey.data());
+}
+
+size_t Notifier::subscriber_count() const {
+    return this->pubkeys_.size();
+}
+
+template <typename Message>
+void Notifier::maybe_notify(const Message& msg) {
+
+    LOKI_LOG(trace, "[notify] Maybe notify for pubkey: {}", msg.pub_key);
+
+    if (!cid_) {
+        LOKI_LOG(warn, "[notify] Notification connection is missing");
+        return;
+    }
+
+    if (pubkeys_.find(msg.pub_key) == pubkeys_.end()) {
+        return;
+    }
+
+    json res_body;
+    json messages = json::array();
+
+    json message;
+    message["hash"] = msg.hash;
+    message["expiration"] = msg.timestamp + msg.ttl;
+    message["ttl"] = msg.ttl;
+    message["data"] = msg.data;
+    res_body["message"] = message;
+
+    lmq_->send(*cid_, "MESSAGE", res_body.dump());
+}
+
+template void Notifier::maybe_notify(const storage::Item& msg);
+
+template void Notifier::maybe_notify(const message_t& msg);
+
+} // namespace loki

--- a/httpserver/notifier.h
+++ b/httpserver/notifier.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <unordered_set>
+#include "loki_common.h"
+#include <lokimq/lokimq.h>
+
+namespace loki {
+
+class LokimqServer;
+
+class Notifier {
+
+    LokimqServer& lmq_;
+
+    std::unordered_set<std::string> pubkeys_;
+
+    // For now only one connection is allowed for notification server
+    boost::optional<lokimq::ConnectionID> cid_;
+
+  public:
+    Notifier(LokimqServer& lmq);
+
+    void add_pubkey(const lokimq::ConnectionID& cid, lokimq::string_view pubkey);
+
+    size_t subscriber_count() const;
+
+    template<typename Message>
+    void maybe_notify(const Message& msg);
+};
+
+
+} // namespace loki

--- a/httpserver/request_handler.cpp
+++ b/httpserver/request_handler.cpp
@@ -581,7 +581,7 @@ void RequestHandler::process_onion_req(const std::string& ciphertext,
 
             const auto& host = inner_json.at("host").get_ref<const std::string&>();
             const auto& target = inner_json.at("target").get_ref<const std::string&>();
-            LOKI_LOG(trace, "We are to forward the request to url: {}{}", host, target);
+            LOKI_LOG(debug, "We are to forward the request to url: {}{}", host, target);
 
             // Forward the request to url but only if it ends in `/lsrpc`
             if ((target.rfind("/lsrpc") == target.size() - 6) && (target.find('?') == std::string::npos)) {


### PR DESCRIPTION
- Add an lmq enpoint available to the notification server, which allows subscribing to messenger pubkeys.
- Change the default POW difficulty to 1.
- Fix an authorisation bug in the https client.