### PR TITLE
Add support for v2 onion requests

### DIFF
--- a/common/include/loki_common.h
+++ b/common/include/loki_common.h
@@ -22,16 +22,16 @@ struct sn_record_t {
 
   private:
     uint16_t port_;
+    // Required by LokiMQ
+    uint16_t lmq_port_;
     // TODO: create separate types for different encodings of pubkeys,
     // so if we confuse them, it will be a compiler error
     std::string sn_address_; // Snode address (pubkey plus .snode, was used for lokinet)
     std::string pub_key_base_32z_; // We don't need this! (esp. since it is legacy key)
-    std::string pubkey_x25519_hex_;
-    std::string pubkey_ed25519_hex_;
     std::string pub_key_hex_; // Monero legacy key
-    // Required by LokiMQ
-    uint16_t lmq_port_;
+    std::string pubkey_x25519_hex_;
     std::string pubkey_x25519_bin_;
+    std::string pubkey_ed25519_hex_;
     std::string ip_; // Snode ip
 
 
@@ -185,6 +185,7 @@ inline bool operator<(const sn_record_t& lhs, const sn_record_t& rhs) {
     return lhs.pub_key_hex() < rhs.pub_key_hex();
 }
 
+[[maybe_unused]]
 static std::ostream& operator<<(std::ostream& os, const sn_record_t& sn) {
 #ifdef INTEGRATION_TEST
     return os << sn.port();
@@ -198,6 +199,7 @@ static bool operator==(const sn_record_t& lhs, const sn_record_t& rhs) {
     return lhs.pub_key_hex() == rhs.pub_key_hex();
 }
 
+[[maybe_unused]]
 static bool operator!=(const sn_record_t& lhs, const sn_record_t& rhs) {
     return !operator==(lhs, rhs);
 }

--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 
 project(crypto)
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 
 set(SOURCES

--- a/httpserver/CMakeLists.txt
+++ b/httpserver/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(httpserver_lib STATIC
     reachability_testing.cpp
     lmq_server.cpp
     request_handler.cpp
+    onion_processing.cpp
     notifier.cpp
     )
 
@@ -41,6 +42,9 @@ find_package(Boost
     filesystem
     program_options
 )
+
+# TODO: enable more warnings!
+target_compile_options(httpserver_lib PRIVATE -Werror=return-type)
 
 target_link_libraries(httpserver_lib PUBLIC common)
 target_link_libraries(httpserver_lib PUBLIC OpenSSL::SSL OpenSSL::Crypto)
@@ -65,6 +69,7 @@ target_link_libraries(httpserver_lib PUBLIC ${Boost_LIBRARIES})
 set(BIN_NAME loki-storage)
 
 add_executable(httpserver main.cpp)
+target_compile_options(httpserver PRIVATE -Wall -Wextra -Werror)
 set_target_properties(httpserver PROPERTIES OUTPUT_NAME ${BIN_NAME})
 set_property(TARGET httpserver PROPERTY CXX_STANDARD 17)
 set_property(TARGET httpserver PROPERTY CXX_STANDARD_REQUIRED TRUE)

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -279,7 +279,11 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
 
     void process_swarm_req(std::string_view target);
 
-    void process_onion_req();
+    /// Process onion request from the client (json)
+    void process_onion_req_v1();
+
+    /// Process onion request from the client (binary)
+    void process_onion_req_v2();
 
     void process_proxy_req();
 
@@ -327,6 +331,14 @@ constexpr const char* error_string(SNodeError err) {
         return "[UNKNOWN]";
     }
 }
+
+struct CiphertextPlusJson {
+    std::string ciphertext;
+    std::string json;
+};
+
+// TODO: move this from http_connection.h after refactoring
+auto parse_combined_payload(const std::string& payload) -> CiphertextPlusJson;
 
 } // namespace loki
 

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -100,12 +100,12 @@ class LokidClient {
 
   public:
     LokidClient(boost::asio::io_context& ioc, std::string ip, uint16_t port);
-    void make_lokid_request(boost::string_view method,
+    void make_lokid_request(std::string_view method,
                             const nlohmann::json& params,
                             http_callback_t&& cb) const;
     void make_custom_lokid_request(const std::string& daemon_ip,
                                    const uint16_t daemon_port,
-                                   boost::string_view method,
+                                   std::string_view method,
                                    const nlohmann::json& params,
                                    http_callback_t&& cb) const;
     // Synchronously fetches the private key from lokid.  Designed to be called
@@ -277,7 +277,7 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     /// Syncronously (?) process client store/load requests
     void process_client_req_rate_limited();
 
-    void process_swarm_req(boost::string_view target);
+    void process_swarm_req(std::string_view target);
 
     void process_onion_req();
 

--- a/httpserver/https_client.cpp
+++ b/httpserver/https_client.cpp
@@ -76,7 +76,7 @@ void make_https_request(boost::asio::io_context& ioc, const std::string& url,
         static ssl::context ctx{ssl::context::tlsv12_client};
 
         auto session = std::make_shared<HttpsClientSession>(
-            ioc, ctx, std::move(resolve_results), req, std::move(cb), nullptr);
+            ioc, ctx, std::move(resolve_results), req, std::move(cb), std::nullopt);
 
         session->start();
     };

--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -141,7 +141,7 @@ void LokimqServer::handle_notify_add_pubkey(lokimq::Message& message) {
     }
 
     for (const auto &pubkey : message.data) {
-        service_node_->add_notify_pubkey(message.conn, pubkey);
+        service_node_->add_notify_pubkey(message.conn, std::string(pubkey));
     }
 
     lokimq_->send(message.conn, "OK");

--- a/httpserver/lmq_server.cpp
+++ b/httpserver/lmq_server.cpp
@@ -92,7 +92,7 @@ void LokimqServer::handle_sn_proxy_exit(lokimq::Message& message) {
         });
 }
 
-void LokimqServer::handle_onion_request(lokimq::Message& message) {
+void LokimqServer::handle_onion_request(lokimq::Message& message, bool v2) {
 
     LOKI_LOG(debug, "Got an onion request over LOKIMQ");
 
@@ -126,7 +126,8 @@ void LokimqServer::handle_onion_request(lokimq::Message& message) {
     const auto& eph_key = message.data[0];
     const auto& ciphertext = message.data[1];
 
-    request_handler_->process_onion_req(std::string(ciphertext), std::string(eph_key), on_response);
+    request_handler_->process_onion_req(std::string(ciphertext),
+                                        std::string(eph_key), on_response, v2);
 }
 
 bool LokimqServer::check_pn_server_pubkey(const std::string& pk) const {
@@ -204,17 +205,18 @@ void LokimqServer::init(ServiceNode* sn, RequestHandler* rh,
     LOKI_LOG(info, "LokiMQ is listenting on port {}", port_);
 
     lokimq_->log_level(lokimq::LogLevel::info);
-
+// clang-format off
     lokimq_->add_category("sn", lokimq::Access{lokimq::AuthLevel::none, true, false})
         .add_request_command("data", [this](auto& m) { this->handle_sn_data(m); })
         .add_request_command("proxy_exit", [this](auto& m) { this->handle_sn_proxy_exit(m); })
-        .add_request_command("onion_req", [this](auto& m) { this->handle_onion_request(m); })
+        .add_request_command("onion_req", [this](auto& m) { this->handle_onion_request(m, false); })
+        .add_request_command("onion_req_v2", [this](auto& m) { this->handle_onion_request(m, true); })
         ;
 
     lokimq_->add_category("notify", lokimq::Access{lokimq::AuthLevel::none, false, false})
         .add_command("add_pubkey", [this](auto& m) { this->handle_notify_add_pubkey(m); })
         .add_command("get_subscriber_count", [this](auto& m) { this->handle_notify_get_subscriber_count(m); });
-
+// clang-format on
     lokimq_->set_general_threads(1);
 
     lokimq_->listen_curve(fmt::format("tcp://0.0.0.0:{}", port_));

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -37,7 +37,8 @@ class LokimqServer {
     // Handle Session client requests arrived via proxy
     void handle_sn_proxy_exit(lokimq::Message& message);
 
-    void handle_onion_request(lokimq::Message& message);
+    // v2 indicates whether to use the new (v2) protocol
+    void handle_onion_request(lokimq::Message& message, bool v2);
 
     void handle_notify_add_pubkey(lokimq::Message& message);
 
@@ -61,7 +62,7 @@ class LokimqServer {
     uint16_t port() { return port_; }
 
     /// True if LokiMQ instance has been set
-    explicit operator bool() const { return (bool) lokimq_; }
+    explicit operator bool() const { return (bool)lokimq_; }
     /// Dereferencing via * or -> accesses the contained LokiMQ instance.
     LokiMQ& operator*() const { return *lokimq_; }
     LokiMQ* operator->() const { return lokimq_.get(); }

--- a/httpserver/onion_processing.cpp
+++ b/httpserver/onion_processing.cpp
@@ -1,0 +1,299 @@
+#include "channel_encryption.hpp"
+#include "loki_logger.h"
+#include "request_handler.h"
+#include "service_node.h"
+#include "utils.hpp"
+
+/// This is only included because of `parse_combined_payload`,
+/// in the future it will be moved
+#include "http_connection.h"
+
+#include <variant>
+
+using nlohmann::json;
+
+namespace loki {
+
+/// The request is to be forwarded to another SS node
+struct RelayToNodeInfo {
+    /// Inner ciphertext for next node
+    std::string ciphertext;
+    // Key to be forwarded to next node for decryption
+    std::string ephemeral_key;
+    // Next node's ed25519 key
+    std::string next_node;
+};
+
+/// The request is to be forwarded to some non-SS server
+/// that supports our protocol (e.g. Session File Server)
+struct RelayToServerInfo {
+    // Result of decryption (intact)
+    std::string payload;
+    // Server's address
+    std::string host;
+    // Request's target
+    std::string target;
+};
+
+/// We are the final destination for this request
+struct FinalDesitnationInfo {
+    std::string body;
+};
+
+enum class ProcessCiphertextError {
+    INVALID_CIPHERTEXT,
+    INVALID_JSON,
+};
+
+using ParsedInfo = std::variant<RelayToNodeInfo, RelayToServerInfo,
+                                FinalDesitnationInfo, ProcessCiphertextError>;
+
+
+static auto
+process_ciphertext_v1(const ChannelEncryption<std::string>& decryptor,
+                      const std::string& ciphertext,
+                      const std::string& ephem_key) -> ParsedInfo {
+
+    std::string plaintext;
+
+    try {
+        const std::string ciphertext_bin = util::base64_decode(ciphertext);
+
+        plaintext = decryptor.decrypt_gcm(ciphertext_bin, ephem_key);
+    } catch (const std::exception& e) {
+        LOKI_LOG(debug, "Error decrypting an onion request: {}", e.what());
+        return ProcessCiphertextError::INVALID_CIPHERTEXT;
+    }
+
+    LOKI_LOG(debug, "onion request decrypted: (len: {})", plaintext.size());
+
+    try {
+
+        const json inner_json = json::parse(plaintext, nullptr, true);
+
+        if (inner_json.find("body") != inner_json.end()) {
+
+            auto body = inner_json.at("body").get_ref<const std::string&>();
+
+            LOKI_LOG(debug, "Found body: <{}>", body);
+            return FinalDesitnationInfo{body};
+        } else if (inner_json.find("host") != inner_json.end()) {
+
+            const auto& host =
+                inner_json.at("host").get_ref<const std::string&>();
+            const auto& target =
+                inner_json.at("target").get_ref<const std::string&>();
+            return RelayToServerInfo{plaintext, host, target};
+
+        } else {
+            // We fall back to forwarding a request to the next node
+            const auto& ciphertext =
+                inner_json.at("ciphertext").get_ref<const std::string&>();
+            const auto& dest =
+                inner_json.at("destination").get_ref<const std::string&>();
+            const auto& ekey =
+                inner_json.at("ephemeral_key").get_ref<const std::string&>();
+
+            return RelayToNodeInfo{ciphertext, ekey, dest};
+        }
+
+    } catch (std::exception& e) {
+        LOKI_LOG(debug, "Error parsing inner JSON in onion request: {}",
+                 e.what());
+        return ProcessCiphertextError::INVALID_JSON;
+    }
+}
+
+static auto
+process_ciphertext_v2(const ChannelEncryption<std::string>& decryptor,
+                      const std::string& ciphertext,
+                      const std::string& ephem_key) -> ParsedInfo {
+    std::string plaintext;
+
+    try {
+        plaintext = decryptor.decrypt_gcm(ciphertext, ephem_key);
+    } catch (const std::exception& e) {
+        LOKI_LOG(debug, "Error decrypting an onion request: {}", e.what());
+        return ProcessCiphertextError::INVALID_CIPHERTEXT;
+    }
+
+    LOKI_LOG(debug, "onion request decrypted: (len: {})", plaintext.size());
+
+    const auto parsed = parse_combined_payload(plaintext);
+
+    try {
+
+        const json inner_json = json::parse(parsed.json, nullptr, true);
+
+        /// Kind of unfortunate that we use "headers" (which is empty)
+        /// to identify we are the final destination...
+        if (inner_json.find("headers") != inner_json.end()) {
+
+            LOKI_LOG(trace, "Found body: <{}>", parsed.ciphertext);
+
+            /// In v2 the body is parsed.ciphertext
+            return FinalDesitnationInfo{parsed.ciphertext};
+        } else if (inner_json.find("host") != inner_json.end()) {
+
+            const auto& host =
+                inner_json.at("host").get_ref<const std::string&>();
+            const auto& target =
+                inner_json.at("target").get_ref<const std::string&>();
+            return RelayToServerInfo{plaintext, host, target};
+
+        } else {
+            // We fall back to forwarding a request to the next node
+            const auto& dest =
+                inner_json.at("destination").get_ref<const std::string&>();
+            const auto& ekey =
+                inner_json.at("ephemeral_key").get_ref<const std::string&>();
+
+            return RelayToNodeInfo{parsed.ciphertext, ekey, dest};
+        }
+
+    } catch (std::exception& e) {
+        LOKI_LOG(debug, "Error parsing inner JSON in onion request: {}",
+                 e.what());
+        return ProcessCiphertextError::INVALID_JSON;
+    }
+}
+
+void RequestHandler::process_onion_req(const std::string& ciphertext,
+                                       const std::string& ephem_key,
+                                       std::function<void(loki::Response)> cb,
+                                       bool v2) {
+    if (!service_node_.snode_ready()) {
+        cb(loki::Response{Status::SERVICE_UNAVAILABLE, "Snode not ready"});
+        return;
+    }
+
+    LOKI_LOG(debug, "process_onion_req, v2: {}", v2);
+
+    static int counter = 0;
+
+    ParsedInfo res;
+
+    if (v2) {
+        res =
+            process_ciphertext_v2(this->channel_cipher_, ciphertext, ephem_key);
+    } else {
+        res =
+            process_ciphertext_v1(this->channel_cipher_, ciphertext, ephem_key);
+    }
+
+    if (const auto info = std::get_if<FinalDesitnationInfo>(&res)) {
+
+        LOKI_LOG(debug, "We are the final destination in the onion request!");
+
+        this->process_onion_exit(
+            ephem_key, info->body,
+            [this, ephem_key, cb = std::move(cb)](loki::Response res) {
+                auto wrapped_res = this->wrap_proxy_response(
+                    res, ephem_key, true /* use aes gcm */);
+                cb(std::move(wrapped_res));
+            });
+
+        return;
+
+    } else if (const auto info = std::get_if<RelayToNodeInfo>(&res)) {
+
+        const auto& dest = info->next_node;
+        const auto& payload = info->ciphertext;
+        const auto& ekey = info->ephemeral_key;
+
+        auto sn = service_node_.find_node_by_ed25519_pk(dest);
+
+        if (!sn) {
+            auto msg = fmt::format("Next node not found: {}", dest);
+            LOKI_LOG(warn, "{}", msg);
+            auto res = loki::Response{Status::BAD_GATEWAY, std::move(msg)};
+            auto wrapped_res = this->wrap_proxy_response(res, ephem_key, true);
+            cb(std::move(res));
+            return;
+        }
+
+        nlohmann::json req_body;
+
+        req_body["ciphertext"] = payload;
+        req_body["ephemeral_key"] = ekey;
+
+        auto on_response = [cb, counter_copy = counter](
+                               bool success, std::vector<std::string> data) {
+            // Processing the result we got from upstream
+
+            if (!success) {
+                LOKI_LOG(debug, "[Onion request] Request time out");
+                cb(loki::Response{Status::GATEWAY_TIMEOUT, "Request time out"});
+                return;
+            }
+
+            // We only expect a two-part message
+            if (data.size() != 2) {
+                LOKI_LOG(debug,
+                         "[Onion request] Incorrect number of messages: {}",
+                         data.size());
+                cb(loki::Response{Status::BAD_REQUEST,
+                                  "Incorrect number of messages"});
+                return;
+            }
+
+            /// We use http status codes (for now)
+            if (data[0] == "200") {
+                cb(loki::Response{Status::OK, std::move(data[1])});
+            } else {
+                LOKI_LOG(debug, "Onion request relay failed with: {}", data[1]);
+                // When do we ever get this??
+                cb(loki::Response{Status::SERVICE_UNAVAILABLE, ""});
+            }
+        };
+
+        LOKI_LOG(debug, "send_onion_to_sn, sn: {} reqidx: {}", *sn, counter++);
+
+        if (v2) {
+            service_node_.send_onion_to_sn_v2(*sn, payload, ekey, on_response);
+        } else {
+            service_node_.send_onion_to_sn_v1(*sn, payload, ekey, on_response);
+        }
+
+    } else if (const auto info = std::get_if<RelayToServerInfo>(&res)) {
+        LOKI_LOG(debug, "We are to forward the request to url: {}{}",
+                 info->host, info->target);
+
+        const auto& target = info->target;
+
+        // Forward the request to url but only if it ends in `/lsrpc`
+        if ((target.rfind("/lsrpc") == target.size() - 6) &&
+            (target.find('?') == std::string::npos)) {
+            this->process_onion_to_url(info->host, target, info->payload,
+                                       std::move(cb));
+
+        } else {
+
+            auto res = loki::Response{Status::BAD_REQUEST, "Invalid url"};
+            auto wrapped_res = this->wrap_proxy_response(res, ephem_key, true);
+            cb(std::move(wrapped_res));
+        }
+
+    } else if (const auto error = std::get_if<ProcessCiphertextError>(&res)) {
+        switch (*error) {
+        case ProcessCiphertextError::INVALID_CIPHERTEXT: {
+            // Should this error be propagated back to the client? (No, if we
+            // couldn't decrypt, we probably won't be able to encrypt either.)
+            cb(loki::Response{Status::BAD_REQUEST, "Invalid ciphertext"});
+            break;
+        }
+        case ProcessCiphertextError::INVALID_JSON: {
+            auto res = loki::Response{Status::BAD_REQUEST, "Invalid json"};
+
+            auto wrapped_res = this->wrap_proxy_response(res, ephem_key, true);
+
+            cb(std::move(wrapped_res));
+            break;
+        }
+        }
+    } else {
+        LOKI_LOG(error, "UNKNOWN VARIANT");
+    }
+}
+
+} // namespace loki

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -5,8 +5,8 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
-#include <unordered_map>
 #include <optional>
+#include <unordered_map>
 
 #include <boost/asio.hpp>
 #include <boost/beast/http.hpp>
@@ -15,12 +15,11 @@
 
 #include "loki_common.h"
 #include "lokid_key.h"
+#include "notifier.h"
 #include "pow.hpp"
 #include "reachability_testing.h"
 #include "stats.h"
 #include "swarm.h"
-#include "notifier.h"
-#include <lokimq/string_view.h>
 
 static constexpr size_t BLOCK_HASH_CACHE_SIZE = 30;
 static constexpr int STORAGE_SERVER_HARDFORK = 12;
@@ -33,7 +32,7 @@ namespace http = boost::beast::http;
 using request_t = http::request<http::string_body>;
 
 namespace lokimq {
-    struct ConnectionID;
+struct ConnectionID;
 }
 
 namespace loki {
@@ -88,10 +87,9 @@ class FailedRequestHandler
     void retry(std::shared_ptr<FailedRequestHandler>&& self);
 
   public:
-    FailedRequestHandler(
-        boost::asio::io_context& ioc, const sn_record_t& sn,
-        std::shared_ptr<request_t> req,
-        std::function<void()> give_up_cb = nullptr);
+    FailedRequestHandler(boost::asio::io_context& ioc, const sn_record_t& sn,
+                         std::shared_ptr<request_t> req,
+                         std::function<void()> give_up_cb = nullptr);
 
     ~FailedRequestHandler();
     /// Initiates the timer for retrying (which cannot be done directly in
@@ -182,7 +180,8 @@ class ServiceNode {
 
     void bootstrap_data();
 
-    void bootstrap_peers(const std::vector<sn_record_t>& peers) const; // mutex not needed
+    void bootstrap_peers(
+        const std::vector<sn_record_t>& peers) const; // mutex not needed
 
     void bootstrap_swarms(const std::vector<swarm_id_t>& swarms) const;
 
@@ -194,12 +193,14 @@ class ServiceNode {
                           const signature& sig) const; // mutex not needed
 
     /// Reliably push message/batch to a service node
-    void relay_data_reliable(const std::string& blob,
-                             const sn_record_t& address) const; // mutex not needed
+    void
+    relay_data_reliable(const std::string& blob,
+                        const sn_record_t& address) const; // mutex not needed
 
     template <typename Message>
-    void relay_messages(const std::vector<Message>& messages,
-                        const std::vector<sn_record_t>& snodes) const; // mutex not needed
+    void relay_messages(
+        const std::vector<Message>& messages,
+        const std::vector<sn_record_t>& snodes) const; // mutex not needed
 
     /// Request swarm structure from the deamon and reset the timer
     void swarm_timer_tick();
@@ -211,9 +212,10 @@ class ServiceNode {
     void relay_buffered_messages();
 
     /// Check the latest version from DNS text record
-    void check_version_timer_tick();  // mutex not needed
+    void check_version_timer_tick(); // mutex not needed
     /// Update PoW difficulty from DNS text record
-    void pow_difficulty_timer_tick(const pow_dns_callback_t cb); // mutex not needed
+    void
+    pow_difficulty_timer_tick(const pow_dns_callback_t cb); // mutex not needed
 
     /// Ping the storage server periodically as required for uptime proofs
     void lokid_ping_timer_tick();
@@ -238,7 +240,8 @@ class ServiceNode {
                                        uint64_t test_height,
                                        sn_response_t&& res);
 
-    void process_reach_test_result(const sn_pub_key_t& pk, ReachType type, bool success);
+    void process_reach_test_result(const sn_pub_key_t& pk, ReachType type,
+                                   bool success);
 
     /// From a peer
     void process_blockchain_test_response(sn_response_t&& res,
@@ -276,15 +279,21 @@ class ServiceNode {
     void record_onion_request();
 
     // Add `pubkey` to the list of pubkeys to notify
-    void add_notify_pubkey(const lokimq::ConnectionID& cid, std::string_view pubkey);
+    void add_notify_pubkey(const lokimq::ConnectionID& cid,
+                           std::string_view pubkey);
 
     size_t get_notify_subscriber_count() const;
 
     // This is new, so it does not need to support http, thus new (if temp)
     // method
-    void send_onion_to_sn(const sn_record_t& sn, const std::string& payload,
-                          const std::string& eph_key,
-                          ss_client::Callback cb) const;
+    void send_onion_to_sn_v1(const sn_record_t& sn, const std::string& payload,
+                             const std::string& eph_key,
+                             ss_client::Callback cb) const;
+
+    /// Same as v1, but using the new protocol (ciphertext as binary)
+    void send_onion_to_sn_v2(const sn_record_t& sn, const std::string& payload,
+                             const std::string& eph_key,
+                             ss_client::Callback cb) const;
 
     // TODO: move this eventually out of SN
     // Send by either http or lmq

--- a/utils/include/utils.hpp
+++ b/utils/include/utils.hpp
@@ -79,6 +79,7 @@ static size_t decode_size(size_t sz) {
     return b * d.quot;
 }
 
+[[maybe_unused]]
 static size_t base32_decode_size(size_t sz) { return decode_size<5, 8>(sz); }
 
 template <typename Stack, typename V>


### PR DESCRIPTION
Adds `onion_req/v2` endpoint, which expects payload to be encoded as `| <4 bytest Little-endian> N | <N bytes> ciphertext | <utf8 encoded json> |`