### PR TITLE
Stats and logs require operator key

### DIFF
--- a/common/include/dev_sink.h
+++ b/common/include/dev_sink.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <mutex>
 #include <spdlog/sinks/base_sink.h>
 #include <vector>
 // A sink used to store most important logs for developers

--- a/httpserver/command_line.cpp
+++ b/httpserver/command_line.cpp
@@ -30,7 +30,7 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
         ("bind-ip", po::value(&options_.ip)->default_value("0.0.0.0"), "IP to which to bind the server")
         ("version,v", po::bool_switch(&options_.print_version), "Print the version of this binary")
         ("help", po::bool_switch(&options_.print_help),"Shows this help message")
-        ("stats-access-key", po::value(&options_.stats_access_key), "A public key (x25519) that will be given access to the `get_stats` lmq endpoint");
+        ("stats-access-key", po::value(&options_.stats_access_keys)->multitoken(), "A public key (x25519) that will be given access to the `get_stats` lmq endpoint");
         // Add hidden ip and port options.  You technically can use the `--ip=` and `--port=` with
         // these here, but they are meant to be positional.  More usefully, you can specify `ip=`
         // and `port=` in the config file to specify them.

--- a/httpserver/command_line.cpp
+++ b/httpserver/command_line.cpp
@@ -29,7 +29,8 @@ void command_line_parser::parse_args(int argc, char* argv[]) {
         ("force-start", po::bool_switch(&options_.force_start), "Ignore the initialisation ready check")
         ("bind-ip", po::value(&options_.ip)->default_value("0.0.0.0"), "IP to which to bind the server")
         ("version,v", po::bool_switch(&options_.print_version), "Print the version of this binary")
-        ("help", po::bool_switch(&options_.print_help),"Shows this help message");
+        ("help", po::bool_switch(&options_.print_help),"Shows this help message")
+        ("stats-access-key", po::value(&options_.stats_access_key), "A public key (x25519) that will be given access to the `get_stats` lmq endpoint");
         // Add hidden ip and port options.  You technically can use the `--ip=` and `--port=` with
         // these here, but they are meant to be positional.  More usefully, you can specify `ip=`
         // and `port=` in the config file to specify them.

--- a/httpserver/command_line.h
+++ b/httpserver/command_line.h
@@ -21,7 +21,7 @@ struct command_line_options {
     std::string lokid_x25519_key;  // test only
     std::string lokid_ed25519_key; // test only
     // x25519 key that will be given access to get_stats lmq endpoint
-    std::string stats_access_key;
+    std::vector<std::string> stats_access_keys;
 };
 
 class command_line_parser {

--- a/httpserver/command_line.h
+++ b/httpserver/command_line.h
@@ -20,6 +20,8 @@ struct command_line_options {
     std::string lokid_key; // test only (but needed for backwards compatibility)
     std::string lokid_x25519_key;  // test only
     std::string lokid_ed25519_key; // test only
+    // x25519 key that will be given access to get_stats lmq endpoint
+    std::string stats_access_key;
 };
 
 class command_line_parser {

--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -261,9 +261,6 @@ class connection_t : public std::enable_shared_from_this<connection_t> {
     /// process GET /get_stats/v1
     void on_get_stats();
 
-    /// process GET /get_logs/v1; only returns errors atm
-    void on_get_logs();
-
     /// Determine what needs to be done with the request message
     /// (synchronously).
     void process_request();

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -46,6 +46,11 @@ class LokimqServer {
 
     bool check_pn_server_pubkey(const std::string& pk) const;
 
+    // Check that stats key is valid
+    bool check_stats_key(const std::string& pk) const;
+
+    void handle_get_logs(lokimq::Message& message);
+
     void handle_get_stats(lokimq::Message& message);
 
     uint16_t port_ = 0;

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace lokimq {
 class LokiMQ;
@@ -46,9 +47,6 @@ class LokimqServer {
 
     bool check_pn_server_pubkey(const std::string& pk) const;
 
-    // Check that stats key is valid
-    bool check_stats_key(const std::string& pk) const;
-
     void handle_get_logs(lokimq::Message& message);
 
     void handle_get_stats(lokimq::Message& message);
@@ -58,8 +56,8 @@ class LokimqServer {
     // binary stored in a string
     std::string pn_server_key_;
 
-    // Access key for `get_stats` as binary
-    std::string stats_access_key;
+    // Access keys for the 'service' category as binary
+    std::vector<std::string> stats_access_keys;
 
   public:
     LokimqServer(uint16_t port);
@@ -68,7 +66,7 @@ class LokimqServer {
     // Initialize lokimq
     void init(ServiceNode* sn, RequestHandler* rh,
               const lokid_key_pair_t& keypair,
-              const std::string& stats_access_key);
+              const std::vector<std::string>& stats_access_key);
 
     uint16_t port() { return port_; }
 

--- a/httpserver/lmq_server.h
+++ b/httpserver/lmq_server.h
@@ -46,10 +46,15 @@ class LokimqServer {
 
     bool check_pn_server_pubkey(const std::string& pk) const;
 
+    void handle_get_stats(lokimq::Message& message);
+
     uint16_t port_ = 0;
 
     // binary stored in a string
     std::string pn_server_key_;
+
+    // Access key for `get_stats` as binary
+    std::string stats_access_key;
 
   public:
     LokimqServer(uint16_t port);
@@ -57,7 +62,8 @@ class LokimqServer {
 
     // Initialize lokimq
     void init(ServiceNode* sn, RequestHandler* rh,
-              const lokid_key_pair_t& keypair);
+              const lokid_key_pair_t& keypair,
+              const std::string& stats_access_key);
 
     uint16_t port() { return port_; }
 

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -211,6 +211,8 @@ int main(int argc, char* argv[]) {
         loki::lokid_key_pair_t lokid_key_pair_x25519{private_key_x25519,
                                                      public_key_x25519};
 
+        LOKI_LOG(info, "Stats access key: {}", options.stats_access_key);
+
         // We pass port early because we want to send it in the first ping to
         // Lokid (in ServiceNode's constructor), but don't want to initialize
         // the rest of lmq server before we have a reference to ServiceNode
@@ -226,7 +228,7 @@ int main(int argc, char* argv[]) {
                                              channel_encryption);
 
         lokimq_server.init(&service_node, &request_handler,
-                           lokid_key_pair_x25519);
+                           lokid_key_pair_x25519, options.stats_access_key);
 
         RateLimiter rate_limiter;
 

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -211,7 +211,9 @@ int main(int argc, char* argv[]) {
         loki::lokid_key_pair_t lokid_key_pair_x25519{private_key_x25519,
                                                      public_key_x25519};
 
-        LOKI_LOG(info, "Stats access key: {}", options.stats_access_key);
+        for (const auto& key : options.stats_access_keys) {
+            LOKI_LOG(info, "Stats access key: {}", key);
+        }
 
         // We pass port early because we want to send it in the first ping to
         // Lokid (in ServiceNode's constructor), but don't want to initialize
@@ -228,7 +230,7 @@ int main(int argc, char* argv[]) {
                                              channel_encryption);
 
         lokimq_server.init(&service_node, &request_handler,
-                           lokid_key_pair_x25519, options.stats_access_key);
+                           lokid_key_pair_x25519, options.stats_access_keys);
 
         RateLimiter rate_limiter;
 

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -1746,6 +1746,9 @@ static nlohmann::json to_json(const all_stats_t& stats) {
     json["previous_period_retrieve_requests"] =
         stats.get_previous_period_retrieve_requests();
 
+    json["previous_period_onion_requests"] =
+        stats.get_previous_period_onion_requests();
+
     json["reset_time"] = std::chrono::duration_cast<std::chrono::seconds>(
                              stats.get_reset_time().time_since_epoch())
                              .count();
@@ -1763,6 +1766,16 @@ static nlohmann::json to_json(const all_stats_t& stats) {
 
     json["peers"] = peers;
     return json;
+}
+
+std::string ServiceNode::get_stats_for_session_client() const {
+
+    nlohmann::json res;
+    res["version"] = STORAGE_SERVER_VERSION_STRING;
+
+    constexpr bool PRETTY = true;
+    constexpr int indent = PRETTY ? 4 : 0;
+    return res.dump(indent);
 }
 
 std::string ServiceNode::get_stats() const {
@@ -1783,7 +1796,6 @@ std::string ServiceNode::get_stats() const {
     val["connections_in"] = get_net_stats().connections_in.load();
     val["http_connections_out"] = get_net_stats().http_connections_out.load();
     val["https_connections_out"] = get_net_stats().https_connections_out.load();
-    // val["open_socket_count"] = get_net_stats().open_fds.size();
 
     /// we want pretty (indented) json, but might change that in the future
     constexpr bool PRETTY = true;

--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -341,6 +341,9 @@ class ServiceNode {
     void
     set_difficulty_history(const std::vector<pow_difficulty_t>& new_history);
 
+    // Stats for session clients that want to know the version number
+    std::string get_stats_for_session_client() const;
+
     std::string get_stats() const;
 
     std::string get_status_line() const;


### PR DESCRIPTION
- Added two LMQ endpoints that require authentication with a key (set via `stats_access_key` as hex string): `service.get_stats` and `service.get_logs`
- `gets_stats` http endpoint now only returns the version number (session clienst might need it)