### PR TITLE
boost 1.73+ compatibility without deprecation warning

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -1095,7 +1095,7 @@ void connection_t::write_response() {
         this->response_modifier_(response_);
     }
 
-    response_.set(http::field::content_length, response_.body().size());
+    response_.set(http::field::content_length, std::to_string(response_.body().size()));
 
     /// This attempts to write all data to a stream
     /// TODO: handle the case when we are trying to send too much

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -24,7 +24,7 @@
 #include <fstream>
 #include <string_view>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 using json = nlohmann::json;
 using loki::storage::Item;


### PR DESCRIPTION
Boost 1.73 warns when including <boost/bind.hpp> (about dropping support for global namespace _1, _2, etc.).  SS doesn't use those anyway, so can just switch to the more specific header that doesn't give the deprecation warning.