### PR TITLE
Fix mismatched struct/class forward declaration

### DIFF
--- a/httpserver/http_connection.h
+++ b/httpserver/http_connection.h
@@ -41,7 +41,7 @@ namespace loki {
 std::shared_ptr<request_t> build_post_request(const char* target,
                                               std::string&& data);
 
-struct Security;
+class Security;
 
 class RequestHandler;
 class Response;


### PR DESCRIPTION
This causes a (fatal, with the default `-Werror`) warning under clang.