### PR TITLE
Increase max ttl to 14 days

### DIFF
--- a/utils/src/utils.cpp
+++ b/utils/src/utils.cpp
@@ -116,8 +116,8 @@ bool parseTimestamp(const std::string& timestampString, const uint64_t ttl,
 }
 
 bool validateTTL(uint64_t ttlInt) {
-    // Minimum time to live of 10 seconds, maximum of 4 days
-    return (ttlInt >= 10 * 1000 && ttlInt <= 96 * 60 * 60 * 1000);
+    // Minimum time to live of 10 seconds, maximum of 14 days
+    return (ttlInt >= 10 * 1000 && ttlInt <= 14 * 24 * 60 * 60 * 1000);
 }
 
 bool parseTTL(const std::string& ttlString, uint64_t& ttl) {


### PR DESCRIPTION
Some "control" messages in Session require longer ttl.