### PR TITLE
Switch aes-gcm implementation from sodium to openssl

### DIFF
--- a/httpserver/http_connection.cpp
+++ b/httpserver/http_connection.cpp
@@ -794,8 +794,6 @@ bool connection_t::parse_header(const char* first, Args... args) {
     return parse_header(first) && parse_header(args...);
 }
 
-constexpr auto LONG_POLL_TIMEOUT = std::chrono::milliseconds(20000);
-
 /// Move this out of `connection_t` Process client request
 /// Decouple responding from http
 

--- a/httpserver/ip_utils.cpp
+++ b/httpserver/ip_utils.cpp
@@ -47,10 +47,10 @@ std::array bogonRanges = { FromIPv4(0, 0, 0, 0, 8),
 
 static bool is_ip_public_inner(const uint32_t ip)
 {
-  for(const auto ipRange: bogonRanges) {
-    uint32_t netstart = (std::get<0>(ipRange) & std::get<1>(ipRange)); // first ip in subnet
-    uint32_t netend = (netstart | ~std::get<1>(ipRange)); // last ip in subnet
-    if ((ip >= netstart) && (ip <= netend))
+  for(const auto& [block, netmask]: bogonRanges) {
+    uint32_t netstart = block & netmask; // first ip in subnet
+    uint32_t netend = netstart | ~netmask; // last ip in subnet
+    if (ip >= netstart && ip <= netend)
       return false;
   }
   return true;

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -14,7 +14,7 @@
 #include "lmq_server.h"
 #include "request_handler.h"
 
-#include <sodium.h>
+#include <sodium/core.h>
 #include <oxenmq/oxenmq.h>
 #include <oxenmq/hex.h>
 
@@ -116,11 +116,6 @@ int main(int argc, char* argv[]) {
 
     if (sodium_init() != 0) {
         OXEN_LOG(error, "Could not initialize libsodium");
-        return EXIT_FAILURE;
-    }
-
-    if (crypto_aead_aes256gcm_is_available() == 0) {
-        OXEN_LOG(error, "AES-256-GCM is not available on this CPU");
         return EXIT_FAILURE;
     }
 

--- a/httpserver/main.cpp
+++ b/httpserver/main.cpp
@@ -34,8 +34,6 @@ extern "C" {
 
 namespace fs = std::filesystem;
 
-constexpr int EXIT_INVALID_PORT = 2;
-
 int main(int argc, char* argv[]) {
 
     oxen::command_line_parser parser;

--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -35,9 +35,6 @@ namespace oxen {
 
 using storage::Item;
 
-constexpr std::array<std::chrono::seconds, 8> RETRY_INTERVALS = {
-    1s, 5s, 10s, 20s, 40s, 80s, 160s, 320s};
-
 constexpr std::chrono::milliseconds RELAY_INTERVAL = 350ms;
 
 static void make_sn_request(boost::asio::io_context& ioc, const sn_record_t& sn,


### PR DESCRIPTION
sodium's aes_gcm implementation is only available on amd64 chips with AESNI instructions; openssl's is more broadly supported.