### PR TITLE
Only warn about missing pubkeys if above threshold

### DIFF
--- a/httpserver/service_node.cpp
+++ b/httpserver/service_node.cpp
@@ -40,6 +40,11 @@ constexpr std::array<std::chrono::seconds, 8> RETRY_INTERVALS = {
 
 constexpr std::chrono::milliseconds RELAY_INTERVAL = 350ms;
 
+// Threshold of missing data records at which we start warning and consult bootstrap nodes (mainly
+// so that we don't bother producing warning spam or going to the bootstrap just for a few new nodes
+// that will often have missing info for a few minutes).
+using MISSING_PUBKEY_THRESHOLD = std::ratio<3, 100>;
+
 static void make_sn_request(boost::asio::io_context& ioc, const sn_record_t& sn,
                             std::shared_ptr<request_t> req,
                             http_callback_t&& cb) {
@@ -130,6 +135,8 @@ parse_swarm_update(const std::string& response_body, bool from_json_rpc = false)
 
         const json service_node_states = result.at("service_node_states");
 
+        int missing_aux_pks = 0, total = 0;
+
         for (const auto& sn_json : service_node_states) {
             /// We want to include (test) decommissioned nodes, but not
             /// partially funded ones.
@@ -137,14 +144,19 @@ parse_swarm_update(const std::string& response_body, bool from_json_rpc = false)
                 continue;
             }
 
+            total++;
+            const auto& pk_hex = sn_json.at("service_node_pubkey").get_ref<const std::string&>();
             const auto& pk_x25519_hex =
                 sn_json.at("pubkey_x25519").get_ref<const std::string&>();
             const auto& pk_ed25519_hex =
                 sn_json.at("pubkey_ed25519").get_ref<const std::string&>();
 
             if (pk_x25519_hex.empty() || pk_ed25519_hex.empty()) {
-                // These will always either both be present or neither present
-                OXEN_LOG(warn, "ed25519/x25519 pubkeys are missing from service node info");
+                // These will always either both be present or neither present.  If they are missing
+                // there isn't much we can do: it means the remote hasn't transmitted them yet (or
+                // our local oxend hasn't received them yet).
+                missing_aux_pks++;
+                OXEN_LOG(debug, "ed25519/x25519 pubkeys are missing from service node info {}", pk_hex);
                 continue;
             }
 
@@ -152,8 +164,7 @@ parse_swarm_update(const std::string& response_body, bool from_json_rpc = false)
                 sn_json.at("public_ip").get_ref<const std::string&>(),
                 sn_json.at("storage_port").get<uint16_t>(),
                 sn_json.at("storage_lmq_port").get<uint16_t>(),
-                legacy_pubkey::from_hex(
-                        sn_json.at("service_node_pubkey").get_ref<const std::string&>()),
+                legacy_pubkey::from_hex(pk_hex),
                 ed25519_pubkey::from_hex(pk_ed25519_hex),
                 x25519_pubkey::from_hex(pk_x25519_hex)};
 
@@ -169,6 +180,12 @@ parse_swarm_update(const std::string& response_body, bool from_json_rpc = false)
 
                 swarm_map[swarm_id].push_back(std::move(sn));
             }
+        }
+
+        if (missing_aux_pks >
+                MISSING_PUBKEY_THRESHOLD::num*total/MISSING_PUBKEY_THRESHOLD::den) {
+            OXEN_LOG(warn, "Missing ed25519/x25519 pubkeys for {}/{} service nodes; "
+                    "oxend may be out of sync with the network", missing_aux_pks, total);
         }
 
     } catch (const std::exception& e) {
@@ -629,7 +646,8 @@ void ServiceNode::update_swarms() {
 
                     auto [missing, total] = count_missing_data(bu);
                     if (total >= (oxen::is_mainnet ? 100 : 10)
-                            && missing < 3*total/100) {
+                            && missing <
+                                MISSING_PUBKEY_THRESHOLD::num*total/MISSING_PUBKEY_THRESHOLD::den) {
                         OXEN_LOG(info, "Initialized from oxend with {}/{} SN records",
                                 total-missing, total);
                         syncing_ = false;


### PR DESCRIPTION
Uses the same 3% threshold we use for going to the bootstrap node (also move the threshold ratio into a constant).