### PR TITLE
Squelch duplicate swarm updates

### DIFF
--- a/httpserver/service_node.h
+++ b/httpserver/service_node.h
@@ -102,6 +102,11 @@ class ServiceNode {
 
     std::atomic<int> oxend_pings_ = 0; // Consecutive successful pings, used for batching logs about it
 
+    // Will be set to true while we have an outstanding update_swarms() call so that we squelch
+    // other update_swarms() until it finishes (or fails), to avoid spamming oxend (particularly
+    // when syncing when we get tons of block notifications quickly).
+    std::atomic<bool> updating_swarms_ = false;
+
     reachability_testing reach_records_;
 
     /// Container for recently received messages directly from


### PR DESCRIPTION
Don't fire another swarm update if we already have one in progress; this avoids, in particular, firing tons of unnecessary get_service_nodes at oxend when oxend is in the middle of syncing.

When syncing, oxend can block for several seconds at a time, so those requests end up filling up the oxenmq job request buffer and then spewing the log file with warnings about dropping the excess requests.