### PR TITLE
Set "t" in the outer part of the request

### DIFF
--- a/httpserver/request_handler.cpp
+++ b/httpserver/request_handler.cpp
@@ -449,8 +449,12 @@ void RequestHandler::process_client_req(
         mine["failed"] = true;
         mine["query_failure"] = true;
     }
-    if (entry_router)
+    if (entry_router) {
+        // Deprecated: we accidentally set this inside the entry router's "swarm" instead of in the
+        // outer response, so keep it here for now in case something is relying on that.
         mine["t"] = to_epoch_ms(now);
+        res->result["t"] = to_epoch_ms(now);
+    }
 
     OXEN_LOG(trace, "Successfully stored message {} for {}", message_hash, obfuscate_pubkey(req.pubkey));
 

--- a/network-tests/test_store_retrieve.py
+++ b/network-tests/test_store_retrieve.py
@@ -35,6 +35,9 @@ def test_store(omq, random_sn, sk, exclude):
         edpk = VerifyKey(k, encoder=HexEncoder)
         edpk.verify(v['hash'].encode(), base64.b64decode(v['signature']))
 
+    # NB: assumes the test machine is reasonably time synced
+    assert(ts - 30000 <= s['t'] <= ts + 30000)
+
 
 def test_store_retrieve_unauthenticated(omq, random_sn, sk, exclude):
     """Retrieves messages without authentication.  This test will break in the future when we turn


### PR DESCRIPTION
It was accidentally being set on the entry server's "swarm" entry.  (This also keeps it there, for now, to eventually be removed).