### PR TITLE
Batching; subkey auth; more namespace work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,4 +109,9 @@ if (BUILD_TESTS)
     add_subdirectory(unit_test)
 endif ()
 
+add_executable(onion-request EXCLUDE_FROM_ALL contrib/onion-request.cpp)
+set_target_properties(onion-request PROPERTIES RUNTIME_OUTPUT_DIRECTORY contrib)
+target_link_libraries(onion-request common crypto cpr::cpr oxenmq::oxenmq)
+target_include_directories(onion-request PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 include(cmake/archive.cmake)

--- a/contrib/drone-format-verify.sh
+++ b/contrib/drone-format-verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 test "x$IGNORE" != "x" && exit 0
 repo=$(readlink -e $(dirname $0)/../)
-clang-format-11 -i $(find $repo/{httpserver,crypto,storage,utils,unit_test,common} | grep -E '\.[hc](pp)?$' | grep -v 'Catch2')
+clang-format-11 -i $(find $repo/{oxenss,unit_test} | grep -E '\.[hc](pp)?$' | grep -v 'Catch2')
 jsonnetfmt -i $repo/.drone.jsonnet
 git --no-pager diff --exit-code --color || (echo -ne '\n\n\e[31;1mLint check failed; please run ./contrib/format.sh\e[0m\n\n' ; exit 1)

--- a/contrib/onion-request.cpp
+++ b/contrib/onion-request.cpp
@@ -10,8 +10,9 @@
 //          -I../../oxen-core/external/cpr/include ../build/crypto/libcrypto.a -loxenmq -lsodium -lcurl -lcrypto
 //
 
-#include "../crypto/include/channel_encryption.hpp"
-#include "cpr/cpr.h"
+#include <oxenss/crypto/channel_encryption.hpp>
+#include <oxenss/crypto/keys.h>
+#include <cpr/cpr.h>
 #include <chrono>
 #include <exception>
 #include <iostream>
@@ -26,7 +27,10 @@ extern "C" {
 #include <sys/param.h>
 }
 
+using namespace std::literals;
+
 using namespace oxen;
+using namespace oxen::crypto;
 
 int usage(std::string_view argv0, std::string_view err = "") {
     if (!err.empty())
@@ -262,7 +266,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     auto it = keys.rbegin();
     {
         crypto_box_keypair(A.data(), a.data());
-        oxen::ChannelEncryption e{a, A, false};
+        ChannelEncryption e{a, A, false};
 
         auto data = encode_size(payload.size());
         data += payload;
@@ -290,7 +294,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
 
         // Generate eph key for *this* request and encrypt it:
         crypto_box_keypair(A.data(), a.data());
-        oxen::ChannelEncryption e{a, A, false};
+        ChannelEncryption e{a, A, false};
         last_etype = enc_type.value_or(random_etype());
 
 #ifndef NDEBUG
@@ -325,7 +329,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     // Nothing in the response tells us how it is encoded so we have to guess; the client normally
     // *does* know because it specifies `"base64": false` if it wants binary, but I don't want to
     // parse and guess what we should do, so we'll just guess.
-    oxen::ChannelEncryption d{final_seckey, final_pubkey, false};
+    ChannelEncryption d{final_seckey, final_pubkey, false};
     bool decrypted = false;
     auto body = std::move(res.text);
     auto orig_size = body.size();

--- a/network-tests/ss.py
+++ b/network-tests/ss.py
@@ -62,7 +62,7 @@ def store_n(omq, conn, sk, basemsg, n, offset=0, netid=5):
     msgs = []
     pubkey = chr(netid).encode() + (sk.verify_key if isinstance(sk, SigningKey) else sk.public_key).encode()
     for i in range(n):
-        data = basemsg + "{}".format(i).encode()
+        data = basemsg + f"{i}".encode()
         ts = int((time.time() - i) * 1000)
         exp = int((time.time() - i + 30) * 1000)
         msgs.append({

--- a/network-tests/test_batch.py
+++ b/network-tests/test_batch.py
@@ -1,0 +1,249 @@
+from util import sn_address
+import ss
+import time
+import base64
+import json
+from nacl.encoding import HexEncoder, Base64Encoder, RawEncoder
+from nacl.hash import blake2b
+from hashlib import sha512
+from nacl.signing import SigningKey, VerifyKey
+import nacl.bindings as sodium
+from oxenc import bt_serialize, bt_deserialize
+
+
+def test_batch_json(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk, 3)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    ts = int(time.time() * 1000)
+    ttl = 86400000
+    exp = ts + ttl
+
+    # Store two messages for myself
+    s = omq.request_future(conn, 'storage.batch', [json.dumps({
+        "requests": [
+            {
+                "method": "store",
+                "params": {
+                    "pubkey": '03' + sk.verify_key.encode().hex(),
+                    'namespace': 42,
+                    "timestamp": ts,
+                    "ttl": ttl,
+                    "data": base64.b64encode(b"abc 123").decode(),
+                    "signature": sk.sign(f"store42{ts}".encode(), encoder=Base64Encoder).signature.decode(),
+                },
+            },
+            {
+                "method": "store",
+                "params": {
+                    "pubkey": '03' + sk.verify_key.encode().hex(),
+                    'namespace': 42,
+                    "timestamp": ts,
+                    "ttl": ttl,
+                    "data": base64.b64encode(b"xyz 123").decode(),
+                    "signature": sk.sign(f"store42{ts}".encode(), encoder=Base64Encoder).signature.decode(),
+                },
+            },
+        ],
+        }).encode()]).get()
+    assert len(s) == 1
+    s = json.loads(s[0])
+    assert "results" in s
+    assert len(s["results"]) == 2
+    assert s["results"][0]["code"] == 200
+    assert s["results"][1]["code"] == 200
+
+    hash0 = blake2b("{}{}".format(ts, exp).encode() + b'\x03' + sk.verify_key.encode() + b'42' + b'abc 123',
+            encoder=Base64Encoder).decode().rstrip('=')
+    hash1 = blake2b("{}{}".format(ts, exp).encode() + b'\x03' + sk.verify_key.encode() + b'42' + b'xyz 123',
+            encoder=Base64Encoder).decode().rstrip('=')
+    assert s["results"][0]["body"]["hash"] == hash0
+    assert s["results"][1]["body"]["hash"] == hash1
+
+
+def test_batch_bt(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk, 3)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    ts = int(time.time() * 1000)
+    ttl = 86400000
+    exp = ts + ttl
+
+    # Store two messages for myself
+    s = omq.request_future(conn, 'storage.batch', [bt_serialize({
+        "requests": [
+            {
+                "method": "store",
+                "params": {
+                    "pubkey": '03' + sk.verify_key.encode().hex(),
+                    'namespace': 42,
+                    "timestamp": ts,
+                    "ttl": ttl,
+                    "data": b"abc 123",
+                    "signature": sk.sign(f"store42{ts}".encode()).signature,
+                },
+            },
+            {
+                "method": "store",
+                "params": {
+                    "pubkey": '03' + sk.verify_key.encode().hex(),
+                    'namespace': 42,
+                    "timestamp": ts,
+                    "ttl": ttl,
+                    "data": b"xyz 123",
+                    "signature": sk.sign(f"store42{ts}".encode()).signature,
+                },
+            },
+        ],
+        })]).get()
+    assert len(s) == 1
+    s = bt_deserialize(s[0])
+    assert b"results" in s
+    assert len(s[b"results"]) == 2
+    assert s[b"results"][0][b"code"] == 200
+    assert s[b"results"][1][b"code"] == 200
+
+    hash0 = blake2b("{}{}".format(ts, exp).encode() + b'\x03' + sk.verify_key.encode() + b'42' + b'abc 123',
+            encoder=Base64Encoder).rstrip(b'=')
+    hash1 = blake2b("{}{}".format(ts, exp).encode() + b'\x03' + sk.verify_key.encode() + b'42' + b'xyz 123',
+            encoder=Base64Encoder).rstrip(b'=')
+    assert s[b"results"][0][b"body"][b"hash"] == hash0
+    assert s[b"results"][1][b"body"][b"hash"] == hash1
+
+
+def test_sequence(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk, 3)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    ts = int(time.time() * 1000)
+    ttl = 86400000
+    exp = ts + ttl
+
+    # Sequence some commands:
+    s = omq.request_future(conn, 'storage.sequence', [json.dumps({
+        "requests": [
+            {
+                "method": "store",
+                "params": {
+                    "pubkey": '05' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "ttl": ttl,
+                    "data": base64.b64encode(b"abc 123").decode(),
+                },
+            },
+            {
+                "method": "retrieve",
+                "params": {
+                    "pubkey": '05' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "signature": sk.sign(f"retrieve{ts}".encode(), encoder=Base64Encoder).signature.decode(),
+                },
+            },
+            {
+                "method": "store",
+                "params": {
+                    "pubkey": '05' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "ttl": ttl,
+                    "data": base64.b64encode(b"xyz 123").decode(),
+                },
+            },
+            {
+                "method": "delete_all",
+                "params": {
+                    "pubkey": '05' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "signature": sk.sign(f"delete_all{ts}".encode(), encoder=Base64Encoder).signature.decode(),
+                },
+            },
+            {
+                "method": "retrieve",
+                "params": {
+                    "pubkey": '05' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "signature": sk.sign(f"retrieve{ts}".encode(), encoder=Base64Encoder).signature.decode(),
+                },
+            },
+        ],
+        }).encode()]).get()
+
+    assert len(s) == 1
+    s = json.loads(s[0])
+    assert "results" in s
+    assert len(s["results"]) == 5
+    h0 = blake2b("{}{}".format(ts, exp).encode() + b'\x05' + sk.verify_key.encode() + b'abc 123',
+            encoder=Base64Encoder).decode().rstrip('=')
+    h1 = blake2b("{}{}".format(ts, exp).encode() + b'\x05' + sk.verify_key.encode() + b'xyz 123',
+            encoder=Base64Encoder).decode().rstrip('=')
+    assert s["results"][0]["body"]["hash"] == h0
+    assert s["results"][1]["body"]["messages"] == [{"data": "YWJjIDEyMw==", "expiration": ts + ttl, "hash": h0, "timestamp": ts}]
+    assert s["results"][2]["body"]["hash"] == h1
+    assert len(s["results"][3]["body"]["swarm"]) > 0
+    for sw in s["results"][3]["body"]["swarm"].values():
+        assert set(sw["deleted"]) == {h0, h1}
+    assert s["results"][4]["body"]["messages"] == []
+
+
+def test_failing_sequence(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk, 3)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    ts = int(time.time() * 1000)
+    ttl = 86400000
+    exp = ts + ttl
+
+    commands = {
+        "requests": [
+            {
+                "method": "store",
+                "params": {
+                    "pubkey": '05' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "namespace": 33, # will fail because no auth
+                    "ttl": ttl,
+                    "data": base64.b64encode(b"abc 123").decode(),
+                },
+            },
+            {
+                "method": "retrieve",
+                "params": {
+                    "pubkey": '05' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "signature": sk.sign(f"retrieve{ts}".encode(), encoder=Base64Encoder).signature.decode(),
+                },
+            },
+        ],
+    }
+
+    # Sequence some commands:
+    s_s = omq.request_future(conn, 'storage.sequence', [json.dumps(commands).encode()])
+    s_b = omq.request_future(conn, 'storage.batch', [json.dumps(commands).encode()])
+
+    s_s = s_s.get()
+    s_b = s_b.get()
+
+    # The sequence should fail the store, and thus not attempt the retrieve:
+    assert len(s_s) == 1
+    s_s = json.loads(s_s[0])
+    assert "results" in s_s
+    assert len(s_s["results"]) == 1
+    assert s_s["results"][0]["code"] == 401
+    assert s_s["results"][0]["body"] == "store: signature required to store to namespace 33"
+
+    # The same thing as a batch should fail but also do the retrieve:
+    assert len(s_b) == 1
+    s_b = json.loads(s_b[0])
+    assert "results" in s_b
+    assert len(s_b["results"]) == 2
+    assert s_b["results"][0]["code"] == 401
+    assert s_b["results"][0]["body"] == "store: signature required to store to namespace 33"
+    assert s_b["results"][1]["code"] == 200
+    assert s_b["results"][1]["body"]["messages"] == []

--- a/network-tests/test_expire.py
+++ b/network-tests/test_expire.py
@@ -4,7 +4,6 @@ import time
 import base64
 import json
 from nacl.encoding import HexEncoder, Base64Encoder
-from nacl.hash import blake2b
 from nacl.signing import VerifyKey
 import nacl.exceptions
 
@@ -33,7 +32,7 @@ def test_expire_all(omq, random_sn, sk, exclude):
 
     assert set(r['swarm'].keys()) == {x['pubkey_ed25519'] for x in swarm['snodes']}
 
-    
+
     # 0 and 1 have later expiries than 2, so they should get updated; 2's expiry is already the
     # given value, and 3/4 are <= so shouldn't get updated.
     msg_hashes = sorted(msgs[i]['hash'] for i in (0, 1))
@@ -140,3 +139,81 @@ def test_expire(omq, random_sn, sk, exclude):
     for i in range(10):
         assert r['messages'][i]['expiration'] == ts if i in (0, 1, 5, 6) else msgs[i]['req']['expiry']
 
+
+def test_expire_extend(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    msgs = ss.store_n(omq, conn, sk, b"omg123", 10)
+
+    now = int(time.time() * 1000)
+
+    my_ss_id = '05' + sk.verify_key.encode().hex()
+
+    for m in msgs:
+        assert m["req"]["expiry"] < now + 60_000
+
+    exp_5min = now + 5*60*1000
+    exp_long = now + 15*24*60*60*1000  # Beyond max TTL, should get shortened to now + max TTL
+    e = omq.request_future(conn, 'storage.sequence',
+            [json.dumps({
+                'requests': [
+                    {
+                        'method': 'expire',
+                        'params': {
+                            "pubkey": my_ss_id,
+                            "messages": [m["hash"] for m in msgs[0:8]],
+                            "expiry": exp_5min,
+                            "signature": sk.sign(f"expire{exp_5min}{''.join(m['hash'] for m in msgs[0:8])}".encode(),
+                                encoder=Base64Encoder).signature.decode(),
+                        }
+                    },
+                    {
+                        'method': 'expire',
+                        'params': {
+                            "pubkey": my_ss_id,
+                            "messages": [m["hash"] for m in msgs[8:]],
+                            "expiry": exp_long,
+                            "signature": sk.sign(f"expire{exp_long}{''.join(m['hash'] for m in msgs[8:])}".encode(),
+                                encoder=Base64Encoder).signature.decode(),
+                        }
+                    },
+                    {
+                        'method': 'retrieve',
+                        'params': {
+                            'pubkey': my_ss_id,
+                            'timestamp': now,
+                            'signature': sk.sign(f"retrieve{now}".encode(), encoder=Base64Encoder).signature.decode(),
+                        }
+                    }
+                ]
+            })]).get()
+
+    assert len(e) == 1
+    e = json.loads(e[0])
+    assert [x['code'] for x in e['results']] == [200, 200, 200]
+    e = [x['body'] for x in e['results']]
+
+    assert 5 <= len(e[0]['swarm']) <= 10
+    for s in e[0]['swarm'].values():
+        assert s['expiry'] == exp_5min
+        assert s['updated'] == sorted([m["hash"] for m in msgs[0:8]])
+
+    assert 5 <= len(e[1]['swarm']) <= 10
+    for s in e[1]['swarm'].values():
+        # expiry should have been shortened to now + max TTL:
+        assert s['expiry'] < exp_long
+        assert abs(s['expiry'] - 1000*(time.time() + 14*24*60*60)) <= 5000
+        assert s['updated'] == sorted([m["hash"] for m in msgs[8:]])
+
+    assert set(m['hash'] for m in e[2]['messages']) == set(m['hash'] for m in msgs)
+    exps = { m['hash']: m['expiration'] for m in e[2]['messages'] }
+    ts = { m['hash']: m['timestamp'] for m in e[2]['messages'] }
+    for m in msgs:
+        assert ts[m['hash']] == m['req']['timestamp']
+    for m in msgs[0:8]:
+        assert exps[m['hash']] == exp_5min
+    for m in msgs[8:]:
+        assert abs(exps[m['hash']] - 1000*(time.time() + 14*24*60*60)) <= 5000

--- a/network-tests/test_ifelse.py
+++ b/network-tests/test_ifelse.py
@@ -1,0 +1,187 @@
+from util import sn_address
+import json
+import ss
+import time
+from nacl.encoding import Base64Encoder
+from nacl.hash import blake2b
+
+m_yes = b'\x61\xeb'
+b64_m_yes = 'Yes='
+m_no = b'\x36\x8a\x5e'
+b64_m_no = 'Nope'
+
+def test_expire_all(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    ts = int(time.time() * 1000)
+    ttl = 86_400_000
+
+    my_ss_id = '05' + sk.verify_key.encode().hex()
+
+    def store_action(msg, ts):
+        return {
+                'method': 'store',
+                'params': {
+                    'pubkey': my_ss_id,
+                    'timestamp': ts,
+                    'ttl': ttl,
+                    'data': msg
+                    }
+                }
+
+    r = []
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_at_least': [2000000] },
+                'then': store_action(b64_m_yes, ts),
+                'else': store_action(b64_m_no, ts),
+            })]))
+
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_at_least': [19], 'height_before': 123456 },
+                'then': store_action(b64_m_yes, ts+1),
+                'else': store_action(b64_m_no, ts+1),
+            })]))
+
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_at_least': [19], 'height_before': 123456789 },
+                'then': store_action(b64_m_yes, ts+2),
+                'else': store_action(b64_m_no, ts+2),
+            })]))
+
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_at_least': [19] },
+                'then': store_action(b64_m_yes, ts+3),
+                'else': store_action(b64_m_no, ts+3),
+            })]))
+
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_at_least': [19, 1] },
+                'then': store_action(b64_m_yes, ts+4),
+            })]))
+
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_before': [19] },
+                'then': store_action(b64_m_yes, ts+5),
+            })]))
+
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_at_least': [19] },
+                'else': store_action(b64_m_yes, ts+6),
+            })]))
+
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_before': [19] },
+                'else': store_action(b64_m_no, ts+7),
+            })]))
+
+    r.append(omq.request_future(conn, 'storage.ifelse',
+            [json.dumps({
+                'if': { 'hf_at_least': [19] },
+                'then': {
+                    'method': 'ifelse',
+                    'params': { 'if': { 'hf_at_least': [19] }, 'then': {
+                        'method': 'ifelse',
+                        'params': { 'if': { 'height_at_least': 100 }, 'then': {
+                            'method': 'ifelse',
+                            'params': { 'if': { 'v_at_least': [2, 2] }, 'then': {
+                                'method': 'ifelse',
+                                'params': {
+                                    'if': { 'hf_before': [99999, 99] },
+                                    'then': {
+                                        'method': 'batch',
+                                        'params': {
+                                            'requests': [
+                                                store_action(b64_m_yes, ts+8),
+                                                store_action(b64_m_yes, ts+9),
+                                                store_action(b64_m_yes, ts+10)
+                                            ]
+                                        }
+                                    }
+                                }
+                            }}
+                        }}
+                    }}
+                }
+            })]))
+
+    bad = omq.request_future(conn, 'storage.batch',
+            [json.dumps({
+                'requests': [{
+                    'method': 'ifelse',
+                    'params': {
+                        'if': { 'hf_at_least': [19] },
+                        'then': { 'method': 'info', 'params': {} },
+                        'else': { 'method': 'info', 'params': {} }
+                    }
+                }]
+            })])
+
+    def hash(body, ts):
+        return blake2b(f"{ts}{ts+ttl}".encode() + b'\x05' + sk.verify_key.encode() + body,
+            encoder=Base64Encoder).decode().rstrip('=')
+
+    for i in range(len(r)):
+        r[i] = r[i].get()
+        print(r[i])
+        assert len(r[i]) == 1
+        r[i] = json.loads(r[i][0])
+        if i not in (5, 6):
+            assert 'result' in r[i] and r[i]['result']['code'] == 200 and 'body' in r[i]['result']
+
+    assert not r[0]['condition']
+    assert r[0]['result']['body']['hash'] == hash(m_no, ts)
+
+    assert not r[1]['condition']
+    assert r[1]['result']['body']['hash'] == hash(m_no, ts+1)
+
+    assert r[2]['condition']
+    assert r[2]['result']['body']['hash'] == hash(m_yes, ts+2)
+
+    assert r[3]['condition']
+    assert r[3]['result']['body']['hash'] == hash(m_yes, ts+3)
+
+    assert r[4]['condition']
+    assert r[4]['result']['body']['hash'] == hash(m_yes, ts+4)
+
+    assert not r[5]['condition']
+    assert 'result' not in r[5]
+
+    assert r[6]['condition']
+    assert 'result' not in r[6]
+
+    assert not r[7]['condition']
+    assert r[7]['result']['body']['hash'] == hash(m_no, ts+7)
+
+    x = r[8]
+    assert x['condition']  # hf >= 19
+    assert x['result']['code'] == 200
+    x = x['result']['body']
+    assert x['condition']  # hf >= 19
+    assert x['result']['code'] == 200
+    x = x['result']['body']
+    assert x['condition']  # height >= 100
+    assert x['result']['code'] == 200
+    x = x['result']['body']
+    assert x['condition']  # v >= 2.2
+    assert x['result']['code'] == 200
+    x = x['result']['body']
+    assert x['condition']  # hf < 99999.99
+    assert x['result']['code'] == 200
+    x = x['result']['body']
+    x = x['results']
+    assert len(x) == 3
+    assert [y['code'] for y in x] == [200, 200, 200]
+    assert x[0]['body']['hash'] == hash(m_yes, ts+8)
+    assert x[1]['body']['hash'] == hash(m_yes, ts+9)
+    assert x[2]['body']['hash'] == hash(m_yes, ts+10)

--- a/network-tests/test_subkey_auth.py
+++ b/network-tests/test_subkey_auth.py
@@ -1,0 +1,144 @@
+from util import sn_address
+import ss
+import time
+import base64
+import json
+from nacl.encoding import HexEncoder, Base64Encoder, RawEncoder
+from nacl.hash import blake2b
+from hashlib import sha512
+from nacl.signing import SigningKey, VerifyKey
+import nacl.bindings as sodium
+
+def make_subkey(sk, subuser_pk: VerifyKey):
+    # Typically we'll do this, though in theory we can generate any old 32-byte value for c:
+    a = sodium.crypto_sign_ed25519_sk_to_curve25519(sk.encode() + sk.verify_key.encode())
+    c = blake2b(sk.verify_key.encode() + subuser_pk.encode(), digest_size=32, encoder=RawEncoder)
+    d = sodium.crypto_core_ed25519_scalar_mul(
+            a,
+            sodium.crypto_core_ed25519_scalar_add(
+                c, blake2b(c + sk.verify_key.encode(), key=b'OxenSSSubkey', digest_size=32, encoder=RawEncoder))
+            )
+    D = sodium.crypto_scalarmult_ed25519_base_noclamp(d)
+    return c, d, D
+
+
+def sha512_multipart(*message_parts):
+    """Given any number of arguments, returns the SHA512 hash of them concatenated together.  This
+    also does one level of flatting if any of the given parts are a list or tuple."""
+    hasher = sha512()
+    for m in message_parts:
+        if isinstance(m, list) or isinstance(m, tuple):
+            for mi in m:
+                hasher.update(mi)
+        else:
+            hasher.update(m)
+    return hasher.digest()
+
+
+# Mostly copied from SOGS auth example; the signature math here is identical (just using d/D instead
+# of ka/kA):
+def blinded_ed25519_signature(message_parts, s: SigningKey, d: bytes, D: bytes):
+    H_rh = sha512(s.encode()).digest()[32:]
+    r = sodium.crypto_core_ed25519_scalar_reduce(sha512_multipart(H_rh, D, message_parts))
+    sig_R = sodium.crypto_scalarmult_ed25519_base_noclamp(r)
+    HRAM = sodium.crypto_core_ed25519_scalar_reduce(sha512_multipart(sig_R, D, message_parts))
+    sig_s = sodium.crypto_core_ed25519_scalar_add(
+        r, sodium.crypto_core_ed25519_scalar_mul(HRAM, d)
+    )
+    return sig_R + sig_s
+
+
+def test_retrieve_subkey(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk, 3)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    ts = int(time.time() * 1000)
+    ttl = 86400000
+    exp = ts + ttl
+
+    # Store a message for myself, using master key
+    s = omq.request_future(conn, 'storage.store', [json.dumps({
+        "pubkey": '03' + sk.verify_key.encode().hex(),
+        'namespace': 42,
+        "timestamp": ts,
+        "ttl": ttl,
+        "data": base64.b64encode(b"abc 123").decode(),
+        "signature": sk.sign(f"store42{ts}".encode(), encoder=Base64Encoder).signature.decode(),
+        }).encode()]).get()
+    assert len(s) == 1
+    s = json.loads(s[0])
+    hash = blake2b("{}{}".format(ts, exp).encode() + b'\x03' + sk.verify_key.encode() + b'42' + b'abc 123',
+            encoder=Base64Encoder).decode().rstrip('=')
+    for k, v in s['swarm'].items():
+        assert hash == v['hash']
+
+    # Retrieve it using a subkey
+    dude_sk = SigningKey.generate()
+    c, d, D = make_subkey(sk, dude_sk.verify_key)
+    to_sign = f"retrieve42{ts}".encode()
+    sig = blinded_ed25519_signature(to_sign, dude_sk, d, D)
+
+    r = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": '03' + sk.verify_key.encode().hex(),
+            "namespace": 42,
+            "timestamp": ts,
+            "signature": base64.b64encode(sig).decode(),
+            "subkey": base64.b64encode(c).decode(),
+        }).encode()]).get()
+
+    assert len(r) == 1
+    r = json.loads(r[0])
+    assert r["hf"] >= [19, 0]
+    assert len(r["messages"]) == 1
+    assert r["messages"][0]["hash"] == hash
+
+def test_store_subkey(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    ts = int(time.time() * 1000)
+    ttl = 86400000
+    exp = ts + ttl
+
+    dude_sk = SigningKey.generate()
+    c, d, D = make_subkey(sk, dude_sk.verify_key)
+
+    sig = blinded_ed25519_signature(f"store42{ts}".encode(), dude_sk, d, D)
+
+    # Store a message using the subkey
+    s = omq.request_future(conn, 'storage.store', [json.dumps({
+        "pubkey": '03' + sk.verify_key.encode().hex(),
+        'namespace': 42,
+        "timestamp": ts,
+        "ttl": ttl,
+        "data": base64.b64encode("abc 123".encode()).decode(),
+        "subkey": base64.b64encode(c).decode(),
+        "signature": base64.b64encode(sig).decode(),
+        }).encode()]).get()
+    assert len(s) == 1
+    s = json.loads(s[0])
+    assert s["hf"] >= [19, 0]
+
+    hash = blake2b(f"{ts}{exp}".encode() + b'\x03' + sk.verify_key.encode() + b'42' + b'abc 123',
+            encoder=Base64Encoder).decode().rstrip('=')
+    assert len(s["swarm"]) > 0
+    for k, v in s['swarm'].items():
+        assert hash == v['hash']
+
+    # Retrieve using master key:
+    s = omq.request_future(conn, 'storage.retrieve', [json.dumps({
+            "pubkey": '03' + sk.verify_key.encode().hex(),
+            "namespace": 42,
+            "timestamp": ts,
+            "signature": sk.sign(f"retrieve42{ts}".encode(), encoder=Base64Encoder).signature.decode(),
+            }).encode()]).get()
+    assert len(s) == 1
+    s = json.loads(s[0])
+    assert s["hf"] >= [19, 0]
+    assert len(s["messages"]) == 1
+    assert s["messages"][0]["hash"] == hash

--- a/oxenss/common/type_list.h
+++ b/oxenss/common/type_list.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <variant>
+
+namespace oxen {
+
+/// Helper types for storing/managing a compile-time list of types.
+template <typename...>
+struct type_list {};
+
+/// Helper struct that grows a type_list by tacking additional types on the end:
+template <typename...>
+struct type_list_append;
+
+template <typename... T, typename... S>
+struct type_list_append<type_list<T...>, S...> {
+    using type = type_list<T..., S...>;
+};
+
+template <typename... T>
+using type_list_append_t = typename type_list_append<T...>::type;
+
+/// Helper for converting a type_list<T...> into a std::variant<T...>.  (Note that std::variant
+/// requires at least one T).
+template <typename... T>
+struct type_list_variant;
+
+template <typename... T>
+struct type_list_variant<type_list<T...>> {
+    static_assert(sizeof...(T) > 0, "std::variant requires at least one type");
+    using type = std::variant<T...>;
+};
+template <typename... T>
+using type_list_variant_t = typename type_list_variant<T...>::type;
+
+}  // namespace oxen

--- a/oxenss/common/type_list.h
+++ b/oxenss/common/type_list.h
@@ -20,6 +20,12 @@ struct type_list_append<type_list<T...>, S...> {
 template <typename... T>
 using type_list_append_t = typename type_list_append<T...>::type;
 
+template <typename...>
+constexpr bool type_list_contains = false;
+
+template <typename... S, typename T>
+inline constexpr bool type_list_contains<T, type_list<S...>> = (std::is_same_v<T, S> || ...);
+
 /// Helper for converting a type_list<T...> into a std::variant<T...>.  (Note that std::variant
 /// requires at least one T).
 template <typename... T>

--- a/oxenss/rpc/client_rpc_endpoints.cpp
+++ b/oxenss/rpc/client_rpc_endpoints.cpp
@@ -691,7 +691,7 @@ void oxend_request::load_from(bt_dict_consumer params) {
 
 void batch::load_from(json params) {
     auto reqs_it = params.find("requests");
-    if (reqs_it == params.end() || !reqs_it->is_array())
+    if (reqs_it == params.end() || !reqs_it->is_array() || reqs_it->empty())
         throw parse_error{"Invalid batch request: no valid \"requests\" field"};
     if (reqs_it->size() > BATCH_REQUEST_MAX)
         throw parse_error{"Invalid batch request: subrequest limit exceeded"};
@@ -735,6 +735,8 @@ void batch::load_from(bt_dict_consumer params) {
             throw parse_error{"Invalid batch request: subrequests must have a params dict"};
         subreqs.push_back(rpc_it->second.load_subreq_bt(sr.consume_dict_consumer()));
     }
+    if (subreqs.empty())
+        throw parse_error{"Invalid batch request: empty \"requests\" list"};
 }
 
 }  // namespace oxen::rpc

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -405,8 +405,10 @@ struct delete_before final : recursive {
 ///   namespace (namespace 0).
 /// - expiry -- the new expiry timestamp (milliseconds since unix epoch).  Should be >= now, but
 ///   tolerance acceptance allows >= 60s ago.
-/// - signature -- signature of ("expire_all" || expiry), signed by `pubkey`.  Must be base64
-///   encoded (json) or bytes (OMQ).
+/// - signature -- signature of ("expire_all" || namespace || expiry), signed by `pubkey`.  Must be
+///   base64 encoded (json) or bytes (OMQ).  namespace should be the stringified namespace for
+///   non-default namespace expiries (i.e. "42", "-99", "all"), or an empty string for the default
+///   namespace (whether or not explicitly provided).
 ///
 /// Returns dict of:
 /// - "swarms" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -90,13 +90,18 @@ namespace {
 /// - `data` (required) the message data, encoded in base64 (for json requests).  Max data size is
 ///   76800 bytes (== 102400 in b64 encoding).  For OMQ RPC requests the value is bytes.
 /// - `namespace` (optional) a non-zero integer namespace (from -32768 to 32767) in which to store
-///   this message.  (Not accepted before the Oxen 10.x hard fork).  Messages in different
-///   namespaces are treated as separate storage boxes from untagged messages.  Different IDs have
-///   different storage properties:
+///   this message.  Messages in different namespaces are treated as separate storage boxes from
+///   untagged messages.  (Note that before the Oxen 10 hardfork (HF 19) this field will be ignored
+///   and the message will end up in the default namespace (i.e. namespace 0) regardless of what was
+///   specified here.)
+///
+///   Different IDs have different storage properties:
 ///   - namespaces divisible by 10 (e.g. 0, 60, -30) allow unauthenticated submission: that is,
 ///     anyone may deposit messages into them without authentication.  Authentication is required
 ///     for retrieval (and all other operations).
 ///   - namespaces -30 through 30 are reserved for current and future Session message storage.
+///     Currently in use or planned for use are 0 (DMs), -10 (legacy closed groups), 3 (future v2
+///     closed groups), 5 (Session account private metadata).
 ///   - non-divisible-by-10 namespaces require authentication for all operations, including storage.
 ///   Omitting the namespace is equivalent to specifying the 0 namespace.
 ///

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -537,8 +537,8 @@ using client_subrequest = type_list_variant_t<client_rpc_subrequests>;
 /// Note that requests may be performed in parallel or out of order; if you need sequential requests
 /// use "sequence" instead.
 ///
-/// This request takes an object containing a single key "requests" which contains a list of up to 6
-/// elements to invoke up to 6 subrequests.  Each element is a dict containing keys:
+/// This request takes an object containing a single key "requests" which contains a list of 1 to 5
+/// elements to invoke up to 5 subrequests.  Each element is a dict containing keys:
 ///
 /// - "method" -- the method name, e.g. "retrieve".
 /// - "params" -- the parameters to pass to the subrequest.

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -122,20 +122,22 @@ namespace {
 /// if the signature does not match.  Should not be provided when depositing a message in a public
 /// receiving (i.e. divisible by 10) namespace.
 ///
-/// - signature -- Ed25519 signature of ("store" || namespace || timestamp), where namespace and
-///   timestamp are the base10 expression of the namespace and timestamp values.  Must be base64
-///   encoded for json requests; binary for OMQ requests.  For non-05 type pubkeys (i.e. non session
-///   ids) the signature will be verified using `pubkey`.  For 05 pubkeys, see the following option.
+/// - signature -- Ed25519 signature of ("store" || namespace || sig_timestamp), where namespace and
+///   sig_timestamp are the base10 expression of the namespace and sig_timestamp values.  Must be
+///   base64 encoded for json requests; binary for OMQ requests.  For non-05 type pubkeys (i.e. non
+///   session ids) the signature will be verified using `pubkey`.  For 05 pubkeys, see the following
+///   option.
 /// - pubkey_ed25519 if provided *and* the pubkey has a type 05 (i.e. Session id) then `pubkey` will
 ///   be interpreted as an `x25519` pubkey derived from *this* given ed25519 pubkey (which must be
 ///   64 hex characters or 32 bytes).  *This* pubkey should be used for signing, but must also
 ///   convert to the given `pubkey` value (without the `05` prefix) for the signature to be
 ///   accepted.
 /// - sig_timestamp -- the timestamp at which this request was initiated, in milliseconds since unix
-///   epoch.  Must be within ±60s of the current time.  (For clients it is recommended to retrieve a
-///   timestamp via `info` first, to avoid client time sync issues).  If omitted, `timestamp` is
-///   used instead; it is recommended to include this value separately, particularly if a delay
-///   between message construction and message submission is possible.
+///   epoch, used in the authentication signature.  Must be within ±60s of the current time.  (For
+///   clients it is recommended to retrieve a timestamp via `info` first, to avoid client time sync
+///   issues).  If omitted, `timestamp` is used instead; it is recommended to include this value
+///   separately, particularly if a delay between message construction and message submission is
+///   possible.
 ///
 /// Returns dict of:
 /// - "swarms" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -199,6 +199,17 @@ struct store final : recursive {
 ///   be interpreted as an `x25519` pubkey derived from this given ed25519 pubkey (which must be 64
 ///   hex characters or 32 bytes).  *This* pubkey should be used for signing, but must also convert
 ///   to the given `pubkey` value (without the `05` prefix).
+///
+/// On success, returns a dict containing key "messages" with value of a list of message details;
+/// each message is a dict containing keys:
+///
+/// - "hash" -- the message hash
+/// - "timestamp" -- the timestamp when the message was deposited
+/// - "expiry" -- the timestamp when the message is currently scheduled to expire
+/// - "data" -- the message data; b64-encoded for json, bytes for bt-encoded requests.
+///
+/// Messages order is such that the hash of the last message is the appropriate value to provide as
+/// a future "last_hash" value, but otherwise no particular ordering is guaranteed.
 struct retrieve final : endpoint {
     static constexpr auto names() { return NAMES("retrieve"); }
 

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -968,6 +968,7 @@ void RequestHandler::process_client_req(rpc::expire_all&& req, std::function<voi
                 std::nullopt,  // no subkey allowed
                 req.signature,
                 "expire_all",
+                signature_value(req.msg_namespace),
                 req.expiry)) {
         OXEN_LOG(debug, "expire_all: signature verification failed");
         return cb(Response{http::UNAUTHORIZED, "expire_all signature verification failed"sv});

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -831,7 +831,8 @@ void RequestHandler::process_client_req(
         handle_action_one_ns(
                 mine,
                 "deleted",
-                service_node_.get_db().delete_all(req.pubkey, var::get<namespace_id>(req.msg_namespace)),
+                service_node_.get_db().delete_all(
+                        req.pubkey, var::get<namespace_id>(req.msg_namespace)),
                 req.b64,
                 ed25519_sk_,
                 req.pubkey.prefixed_hex(),

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -422,6 +422,11 @@ void RequestHandler::process_client_req(rpc::store&& req, std::function<void(Res
         return cb(Response{http::NOT_ACCEPTABLE, "Timestamp error: check your clock"sv});
     }
 
+    // TODO: remove after HF 19
+    if (!service_node_.hf_at_least(snode::HARDFORK_NAMESPACES) &&
+        req.msg_namespace != namespace_id::Default)
+        req.msg_namespace = namespace_id::Default;
+
     if (!is_public_namespace(req.msg_namespace)) {
         if (!req.signature) {
             auto err = fmt::format(

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -831,7 +831,7 @@ void RequestHandler::process_client_req(
         handle_action_one_ns(
                 mine,
                 "deleted",
-                service_node_.get_db().delete_all(req.pubkey, ns_or_default(req.msg_namespace)),
+                service_node_.get_db().delete_all(req.pubkey, var::get<namespace_id>(req.msg_namespace)),
                 req.b64,
                 ed25519_sk_,
                 req.pubkey.prefixed_hex(),
@@ -933,7 +933,7 @@ void RequestHandler::process_client_req(
                 mine,
                 "deleted",
                 service_node_.get_db().delete_by_timestamp(
-                        req.pubkey, ns_or_default(req.msg_namespace), req.before),
+                        req.pubkey, var::get<namespace_id>(req.msg_namespace), req.before),
                 req.b64,
                 ed25519_sk_,
                 req.pubkey.prefixed_hex(),
@@ -995,7 +995,7 @@ void RequestHandler::process_client_req(rpc::expire_all&& req, std::function<voi
                 mine,
                 "updated",
                 service_node_.get_db().update_all_expiries(
-                        req.pubkey, ns_or_default(req.msg_namespace), req.expiry),
+                        req.pubkey, var::get<namespace_id>(req.msg_namespace), req.expiry),
                 req.b64,
                 ed25519_sk_,
                 req.pubkey.prefixed_hex(),

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -590,7 +590,7 @@ void RequestHandler::process_client_req(
     if (service_node_.hf_at_least(snode::HARDFORK_RETRIEVE_AUTH) &&
         req.msg_namespace != namespace_id::LegacyClosed) {
         if (!req.check_signature) {
-            OXEN_LOG(debug, "retrieve: request signature required as of HF19");
+            OXEN_LOG(debug, "retrieve: request signature required as of HF19.1");
             return cb(Response{http::UNAUTHORIZED, "retrieve: request signature required"sv});
         }
     }

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -839,7 +839,7 @@ void RequestHandler::process_client_req(
     }
 
     if (req.recurse)
-        add_misc_response_fields(mine, service_node_, now);
+        add_misc_response_fields(res->result, service_node_, now);
 
     if (--res->pending == 0)
         reply_or_fail(std::move(res));
@@ -876,7 +876,7 @@ void RequestHandler::process_client_req(rpc::delete_msgs&& req, std::function<vo
     mine["deleted"] = std::move(deleted);
     mine["signature"] = req.b64 ? oxenc::to_base64(sig.begin(), sig.end()) : util::view_guts(sig);
     if (req.recurse)
-        add_misc_response_fields(mine, service_node_);
+        add_misc_response_fields(res->result, service_node_);
 
     if (--res->pending == 0)
         reply_or_fail(std::move(res));
@@ -940,7 +940,7 @@ void RequestHandler::process_client_req(
                 req.before);
     }
     if (req.recurse)
-        add_misc_response_fields(mine, service_node_, now);
+        add_misc_response_fields(res->result, service_node_, now);
 
     if (--res->pending == 0)
         reply_or_fail(std::move(res));
@@ -1002,7 +1002,7 @@ void RequestHandler::process_client_req(rpc::expire_all&& req, std::function<voi
                 req.expiry);
     }
     if (req.recurse)
-        add_misc_response_fields(mine, service_node_, now);
+        add_misc_response_fields(res->result, service_node_, now);
 
     if (--res->pending == 0)
         reply_or_fail(std::move(res));
@@ -1049,7 +1049,7 @@ void RequestHandler::process_client_req(rpc::expire_msgs&& req, std::function<vo
     mine["updated"] = std::move(updated);
     mine["signature"] = req.b64 ? oxenc::to_base64(sig.begin(), sig.end()) : util::view_guts(sig);
     if (req.recurse)
-        add_misc_response_fields(mine, service_node_, now);
+        add_misc_response_fields(res->result, service_node_, now);
 
     if (--res->pending == 0)
         reply_or_fail(std::move(res));

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -1058,6 +1058,8 @@ void RequestHandler::process_client_req(rpc::expire_msgs&& req, std::function<vo
 
 void RequestHandler::process_client_req(rpc::batch&& req, std::function<void(rpc::Response)> cb) {
 
+    assert(!req.subreqs.empty());
+
     auto subresults = std::make_shared<json>(json::array());
     for (size_t i = 0; i < req.subreqs.size(); i++)
         subresults->emplace_back();
@@ -1098,10 +1100,7 @@ namespace {
 void RequestHandler::process_client_req(
         rpc::sequence&& req, std::function<void(rpc::Response)> cb) {
 
-    if (req.subreqs.empty()) {
-        cb(Response{http::OK, json({{"results", json::array()}})});
-        return;
-    }
+    assert(!req.subreqs.empty());
 
     auto manager = std::make_shared<sequence_manager>();
     manager->subreqs = std::move(req.subreqs);

--- a/oxenss/rpc/request_handler.h
+++ b/oxenss/rpc/request_handler.h
@@ -193,10 +193,11 @@ class RequestHandler {
     void process_client_req(rpc::expire_msgs&&, std::function<void(Response)> cb);
     void process_client_req(rpc::batch&&, std::function<void(Response)> cb);
     void process_client_req(rpc::sequence&&, std::function<void(Response)> cb);
+    void process_client_req(rpc::ifelse&&, std::function<void(Response)> cb);
 
     struct rpc_handler {
-        std::function<client_subrequest(nlohmann::json params)> load_subreq_json;
-        std::function<client_subrequest(oxenc::bt_dict_consumer params)> load_subreq_bt;
+        std::function<client_request(std::variant<nlohmann::json, oxenc::bt_dict_consumer> params)>
+                load_req;
         std::function<void(RequestHandler&, nlohmann::json, std::function<void(Response)>)>
                 http_json;
         std::function<void(

--- a/oxenss/rpc/request_handler.h
+++ b/oxenss/rpc/request_handler.h
@@ -188,10 +188,19 @@ class RequestHandler {
     void process_client_req(rpc::expire_all&&, std::function<void(Response)> cb);
     void process_client_req(rpc::expire_msgs&&, std::function<void(Response)> cb);
 
-    using rpc_map = std::unordered_map<
-            std::string_view,
-            std::function<void(
-                    RequestHandler&, const nlohmann::json&, std::function<void(Response)>)>>;
+    struct rpc_handler {
+        std::function<void(RequestHandler&, const nlohmann::json&, std::function<void(Response)>)>
+                json;
+        std::function<void(
+                RequestHandler&,
+                std::string_view params,
+                bool recurse,
+                std::function<void(Response)>)>
+                omq;
+    };
+
+    using rpc_map = std::unordered_map<std::string_view, rpc_handler>;
+
     static const rpc_map client_rpc_endpoints;
 
     // Process a client request taking encoded json to be parsed containing something like

--- a/oxenss/server/omq.cpp
+++ b/oxenss/server/omq.cpp
@@ -324,7 +324,7 @@ void OMQ::handle_client_request(std::string_view method, oxenmq::Message& messag
         it->second.omq(
                 *request_handler_,
                 params,
-                !forwarded,
+                forwarded,
                 [send = message.send_later(),
                  bt_encoded = !params.empty() && params.front() == 'd'](rpc::Response res) {
                     std::string dump;

--- a/oxenss/server/omq.cpp
+++ b/oxenss/server/omq.cpp
@@ -219,44 +219,6 @@ void OMQ::handle_get_stats(oxenmq::Message& message) {
 
 namespace {
 
-    template <typename RPC>
-    void register_client_rpc_endpoint(OMQ::rpc_map& regs) {
-        auto call = [](rpc::RequestHandler& h,
-                       std::string_view params,
-                       [[maybe_unused]] bool recursive,
-                       std::function<void(rpc::Response)> cb) {
-            RPC req;
-            if (params.empty())
-                params = "{}"sv;
-            if (params.front() == 'd') {
-                req.load_from(oxenc::bt_dict_consumer{params});
-                req.b64 = false;
-            } else {
-                auto body = nlohmann::json::parse(params, nullptr, false);
-                if (body.is_discarded()) {
-                    OXEN_LOG(debug, "Bad OMQ client request: not valid json or bt_dict");
-                    return cb(rpc::Response{
-                            http::BAD_REQUEST, "invalid body: expected json or bt_dict"sv});
-                }
-                req.load_from(body);
-            }
-            if constexpr (std::is_base_of_v<rpc::recursive, RPC>)
-                req.recurse = recursive;
-            h.process_client_req(std::move(req), std::move(cb));
-        };
-        for (auto& name : RPC::names()) {
-            [[maybe_unused]] auto [it, ins] = regs.emplace(name, call);
-            assert(ins);
-        }
-    }
-
-    template <typename... RPC>
-    OMQ::rpc_map register_client_rpc_endpoints(rpc::type_list<RPC...>) {
-        OMQ::rpc_map regs;
-        (register_client_rpc_endpoint<RPC>(regs), ...);
-        return regs;
-    }
-
 }  // namespace
 
 oxenc::bt_value json_to_bt(nlohmann::json j) {
@@ -325,14 +287,12 @@ nlohmann::json bt_to_json(oxenc::bt_list_consumer l) {
     return j;
 }
 
-const OMQ::rpc_map OMQ::client_rpc_endpoints =
-        register_client_rpc_endpoints(rpc::client_rpc_types{});
-
 void OMQ::handle_client_request(std::string_view method, oxenmq::Message& message, bool forwarded) {
     OXEN_LOG(debug, "Handling OMQ RPC request for {}", method);
-    auto it = client_rpc_endpoints.find(method);
-    assert(it != client_rpc_endpoints.end());  // This endpoint shouldn't have been registered
-                                               // if it isn't in here
+    auto it = rpc::RequestHandler::client_rpc_endpoints.find(method);
+
+    // This endpoint shouldn't have been registered if it isn't in here:
+    assert(it != rpc::RequestHandler::client_rpc_endpoints.end());
 
     const size_t full_size = forwarded ? 2 : 1;
     const size_t empty_body = full_size - 1;
@@ -361,7 +321,7 @@ void OMQ::handle_client_request(std::string_view method, oxenmq::Message& messag
 
     try {
         std::string_view params = message.data.size() == full_size ? message.data.back() : ""sv;
-        it->second(
+        it->second.omq(
                 *request_handler_,
                 params,
                 !forwarded,

--- a/oxenss/server/omq.h
+++ b/oxenss/server/omq.h
@@ -138,14 +138,6 @@ class OMQ {
     static std::pair<std::string_view, rpc::OnionRequestMetadata> decode_onion_data(
             std::string_view data);
 
-    using rpc_map = std::unordered_map<
-            std::string_view,
-            std::function<void(
-                    rpc::RequestHandler&,
-                    std::string_view params,
-                    bool recurse,
-                    std::function<void(rpc::Response)>)>>;
-    static const rpc_map client_rpc_endpoints;
 };
 
 }  // namespace oxen::server

--- a/oxenss/server/omq.h
+++ b/oxenss/server/omq.h
@@ -137,7 +137,6 @@ class OMQ {
     // Decodes onion request data; throws if invalid formatted or missing required fields.
     static std::pair<std::string_view, rpc::OnionRequestMetadata> decode_onion_data(
             std::string_view data);
-
 };
 
 }  // namespace oxen::server

--- a/oxenss/snode/service_node.cpp
+++ b/oxenss/snode/service_node.cpp
@@ -1333,7 +1333,7 @@ bool ServiceNode::is_pubkey_for_us(const user_pubkey_t& pk) const {
     return swarm_->is_pubkey_for_us(pk);
 }
 
-SwarmInfo ServiceNode::get_swarm(const user_pubkey_t& pk) {
+SwarmInfo ServiceNode::get_swarm(const user_pubkey_t& pk) const {
     std::lock_guard guard(sn_mutex_);
 
     if (!swarm_) {
@@ -1344,7 +1344,7 @@ SwarmInfo ServiceNode::get_swarm(const user_pubkey_t& pk) {
     return get_swarm_by_pk(swarm_->all_valid_swarms(), pk);
 }
 
-std::vector<sn_record> ServiceNode::get_swarm_peers() {
+std::vector<sn_record> ServiceNode::get_swarm_peers() const {
     std::lock_guard guard{sn_mutex_};
 
     return swarm_->other_nodes();

--- a/oxenss/snode/service_node.h
+++ b/oxenss/snode/service_node.h
@@ -199,6 +199,8 @@ class ServiceNode {
 
     const hf_revision& hf() const { return hardfork_; }
 
+    const uint64_t& blockheight() const { return block_height_; }
+
     bool hf_at_least(hf_revision version) const { return hardfork_ >= version; }
 
     // Return true if the service node is ready to handle requests, which means the storage

--- a/oxenss/snode/service_node.h
+++ b/oxenss/snode/service_node.h
@@ -192,6 +192,8 @@ class ServiceNode {
             rpc::OnionRequestMetadata&& data,
             std::function<void(bool success, std::vector<std::string> data)> cb) const;
 
+    const hf_revision& hf() const { return hardfork_; }
+
     bool hf_at_least(hf_revision version) const { return hardfork_ >= version; }
 
     // Return true if the service node is ready to handle requests, which means the storage
@@ -228,9 +230,9 @@ class ServiceNode {
 
     bool is_pubkey_for_us(const user_pubkey_t& pk) const;
 
-    SwarmInfo get_swarm(const user_pubkey_t& pk);
+    SwarmInfo get_swarm(const user_pubkey_t& pk) const;
 
-    std::vector<sn_record> get_swarm_peers();
+    std::vector<sn_record> get_swarm_peers() const;
 
     // Stats for session clients that want to know the version number
     std::string get_stats_for_session_client() const;

--- a/oxenss/snode/service_node.h
+++ b/oxenss/snode/service_node.h
@@ -55,7 +55,7 @@ inline constexpr hf_revision HARDFORK_NAMESPACES = {19, 0};
 
 // The hardfork at which we require authentication for (almost) all retrieval.  (Message namespace
 // -10 is temporarily exempt for closed group backwards support).
-inline constexpr hf_revision HARDFORK_RETRIEVE_AUTH = {19, 0};
+inline constexpr hf_revision HARDFORK_RETRIEVE_AUTH = {19, 1};
 
 class Swarm;
 

--- a/oxenss/snode/service_node.h
+++ b/oxenss/snode/service_node.h
@@ -48,6 +48,11 @@ using hf_revision = std::pair<int, int>;
 // The earliest hardfork *this* version of storage server will work on:
 inline constexpr hf_revision STORAGE_SERVER_HARDFORK = {18, 1};
 
+// The hardfork at which msg namespaces become available for storing messages.  (Prior to this we
+// ignore any specified namespace value and just store in namespace 0, even if another namespace was
+// given).
+inline constexpr hf_revision HARDFORK_NAMESPACES = {19, 0};
+
 // The hardfork at which we require authentication for (almost) all retrieval.  (Message namespace
 // -10 is temporarily exempt for closed group backwards support).
 inline constexpr hf_revision HARDFORK_RETRIEVE_AUTH = {19, 0};

--- a/oxenss/storage/database.cpp
+++ b/oxenss/storage/database.cpp
@@ -643,13 +643,15 @@ std::vector<message> Database::retrieve(
 
     auto st = impl->prepared_st(
             last_id ? "SELECT hash, namespace, timestamp, expiry, data FROM messages "
-                      "WHERE owner = ? AND id > ? ORDER BY id LIMIT ?"
+                      "WHERE owner = ? AND namespace = ? AND id > ? ORDER BY id LIMIT ?"
                     : "SELECT hash, namespace, timestamp, expiry, data FROM messages "
-                      "WHERE owner = ? ORDER BY id LIMIT ?");
-    st->bind(1, *ownerid);
+                      "WHERE owner = ? AND namespace = ? ORDER BY id LIMIT ?");
+    int pos = 1;
+    st->bind(pos++, *ownerid);
+    st->bind(pos++, to_int(ns));
     if (last_id)
-        st->bind(2, *last_id);
-    st->bind(last_id ? 3 : 2, num_results.value_or(-1));
+        st->bind(pos++, *last_id);
+    st->bind(pos++, num_results.value_or(-1));
 
     while (st->executeStep()) {
         auto [hash, ns, ts, exp, data] =

--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -89,7 +89,7 @@ TEST_CASE("storage - data persistence, namespace", "[storage][namespace]") {
         CHECK(storage.get_owner_count() == 1);
         CHECK(storage.get_message_count() == 1);
 
-        auto items = storage.retrieve(pubkey, namespace_id::Default, "");
+        auto items = storage.retrieve(pubkey, ns, "");
 
         REQUIRE(items.size() == 1);
         CHECK_FALSE(items[0].pubkey);  // pubkey is left unset when we retrieve for pubkey


### PR DESCRIPTION
- adds "hf" tags to most responses (basically everywhere we have a "t" response).  Also fixes some places that were putting "t" inside the swarm member response instead of the outer request.
- disable namespace storing before HF19
- Delay retrieving requiring authentication until HF19.1
- Add subkey authentication for store/retrieve (this is draft support and may change, but if it doesn't this avoids needing a future SS update).
- Add batch/sequence requests; these are similar to SOGS in that "batch" does all the things, while "sequence" does them in order and aborts if anything in the sequence fails.
- Update/fix some documentation
- Change namespace signatures in various methods so that the namespace value in the signature is always "" for the default namespace; previously *some* namespace signatures required a "0" if the default namespace was explicitly given, "" if implicit, but this wasn't consistent and is potentially confusing.
- Fixed `expire_all` not having the namespace in the auth signature.