### PR TITLE
Adds ed25519 pubkey to oxend pings

### DIFF
--- a/oxenss/snode/service_node.cpp
+++ b/oxenss/snode/service_node.cpp
@@ -836,6 +836,8 @@ void ServiceNode::oxend_ping() {
 
     json oxend_params{
             {"version", STORAGE_SERVER_VERSION},
+            {"pubkey_ed25519",
+             oxenc::to_hex(our_address_.pubkey_ed25519.begin(), our_address_.pubkey_ed25519.end())},
             {"https_port", our_address_.port},
             {"omq_port", our_address_.omq_port}};
 


### PR DESCRIPTION
This will allow the oxend to verify the pubkey when pings are received
and reject the ping if they are wrong.

The reason this causes issues is that storage server only receives the
snode keys on startup and if oxend is restarted without restarting
storage server then it could end up running with the wrong keys.

If oxend instead rejects the pings and stops sending uptime proofs then
the operator will know that something needs attention and can restart
the storage server.