### PR TITLE
Big retrieves

### DIFF
--- a/network-tests/conftest.py
+++ b/network-tests/conftest.py
@@ -11,6 +11,7 @@ def pytest_addoption(parser):
 @pytest.fixture(scope="module")
 def omq():
     omq = OxenMQ()
+    omq.max_message_size = 10*1024*1024
     omq.start()
     return omq
 
@@ -37,7 +38,7 @@ def sk():
     return SigningKey.generate()
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def exclude(pytestconfig):
     s = pytestconfig.getoption("exclude")
     return {s} if s and len(s) else {}

--- a/network-tests/test_big_retrieve.py
+++ b/network-tests/test_big_retrieve.py
@@ -1,0 +1,315 @@
+from util import sn_address
+import ss
+import time
+import base64
+import json
+from nacl.encoding import Base64Encoder
+from nacl.signing import SigningKey
+import nacl.utils
+import pytest
+
+# This test runs in a few seconds, a short ttl is fine.
+ttl = 600_000
+
+# Size of the msg we store for the tests
+msg_size = 70000
+
+@pytest.fixture(scope='module')
+def big_store(omq, random_sn, exclude):
+    sk = SigningKey.generate()
+    swarm = ss.get_swarm(omq, random_sn, sk)
+
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    pk = '03' + sk.verify_key.encode().hex()
+
+    hashes = []
+    for x in range(12):
+        s = []
+        for y in range(10):
+            ts = int(time.time() * 1000)
+            exp = ts + ttl
+            msg = nacl.utils.random(msg_size)
+            s.append(omq.request_future(conn, 'storage.store', [json.dumps({
+                "pubkey": pk,
+                "timestamp": ts,
+                "ttl": ttl,
+                "data": base64.b64encode(msg).decode()}).encode()]))
+        for si in s:
+            si = si.get()
+            assert len(si) == 1
+            si = json.loads(si[0])
+            assert 'hash' in si
+            hashes.append(si['hash'])
+
+    return {
+            'conn': conn,
+            'sk': sk,
+            'pk': pk,
+            'hashes': hashes
+            }
+
+
+def test_retrieve_count(omq, big_store):
+
+    conn = big_store['conn']
+    sk = big_store['sk']
+    pk = big_store['pk']
+    hashes = big_store['hashes']
+
+    ts = int(time.time() * 1000)
+    to_sign = "retrieve{}".format(ts).encode()
+    sig = sk.sign(to_sign, encoder=Base64Encoder).signature.decode()
+
+    s5 = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_count": 5
+        })])
+
+    s8 = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_count": 8,
+            "last_hash": hashes[-3]
+        })])
+
+    s20 = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_count": 20,
+            "last_hash": hashes[110]
+        })])
+
+    # This one is a little tricky: our last one is the limit, but we should still get more: false
+    s10 = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_count": 10,
+            "last_hash": hashes[-11]
+        })])
+
+    s5 = s5.get()
+    assert len(s5) == 1
+    s5 = json.loads(s5[0])
+    assert [x['hash'] for x in s5['messages']] == hashes[0:5]
+    assert s5['more']
+
+
+    s8 = s8.get()
+    assert len(s8) == 1
+    s8 = json.loads(s8[0])
+    assert [x['hash'] for x in s8['messages']] == hashes[-2:]
+    assert not s8['more']
+
+
+    s20 = s20.get()
+    assert len(s20) == 1
+    s20 = json.loads(s20[0])
+    assert [x['hash'] for x in s20['messages']] == hashes[111:]
+    assert not s20['more']
+
+    # We request 100, but should hit the implicit max size at 83
+    s100 = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_count": 100,
+            "last_hash": hashes[10]
+        })])
+
+    
+
+    s100 = s100.get()
+    assert len(s100) == 1
+    s100 = json.loads(s100[0])
+    assert [x['hash'] for x in s100['messages']] == hashes[11:94]
+    assert s100['more']
+
+
+    s10 = s10.get()
+    assert len(s10) == 1
+    s10 = json.loads(s10[0])
+    assert [x['hash'] for x in s10['messages']] == hashes[-10:]
+    assert not s10['more']
+
+
+
+
+def test_retrieve_size(omq, big_store):
+
+    conn = big_store['conn']
+    sk = big_store['sk']
+    pk = big_store['pk']
+    hashes = big_store['hashes']
+
+    ts = int(time.time() * 1000)
+    to_sign = "retrieve{}".format(ts).encode()
+    sig = sk.sign(to_sign, encoder=Base64Encoder).signature.decode()
+
+    s500k = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_size": 500_000,
+            "last_hash": hashes[2]
+        })])
+
+    s600k = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_size": 600_000,
+            "last_hash": hashes[-8]
+        })])
+
+    smax = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_size": -1,
+            "last_hash": hashes[2]
+        })])
+
+    smax_nomore = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_size": -1,
+            "last_hash": hashes[110]
+        })])
+
+    sthird = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_size": -3,
+            "last_hash": hashes[49]
+        })])
+
+    sdefault = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "last_hash": hashes[89]
+        })])
+
+    sdefault_nomore = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "last_hash": hashes[103]
+        })])
+
+    s500k = s500k.get()
+    assert len(s500k) == 1
+    s500k = json.loads(s500k[0])
+    assert [x['hash'] for x in s500k['messages']] == hashes[3:8]
+    assert s500k['more']
+
+
+    s600k = s600k.get()
+    assert len(s600k) == 1
+    s600k = json.loads(s600k[0])
+    assert [x['hash'] for x in s600k['messages']] == hashes[-7:-1]
+    assert s600k['more']
+
+
+    # Max retrieve size (-1) is 7.8MB, so with 70000*4/3=93333 bytes (plus a bit) per message
+    # retrieved, we should get 83 messages back.
+    smax = smax.get()
+    assert len(smax) == 1
+    smax = json.loads(smax[0])
+    assert [x['hash'] for x in smax['messages']] == hashes[3:86]
+    assert smax['more']
+
+
+    # 1/3 max retrieve should fit 27:
+    sthird = sthird.get()
+    assert len(sthird) == 1
+    sthird = json.loads(sthird[0])
+    assert [x['hash'] for x in sthird['messages']] == hashes[50:77]
+    assert sthird['more']
+
+
+    # Default is 1/5, should fit 16:
+    sdefault = sdefault.get()
+    assert len(sdefault) == 1
+    sdefault = json.loads(sdefault[0])
+    assert [x['hash'] for x in sdefault['messages']] == hashes[90:106]
+    assert sdefault['more']
+
+
+    smax_nomore = smax_nomore.get()
+    assert len(smax_nomore) == 1
+    smax_nomore = json.loads(smax_nomore[0])
+    assert [x['hash'] for x in smax_nomore['messages']] == hashes[111:]
+    assert not smax_nomore['more']
+
+    
+    sdefault_nomore = sdefault_nomore.get()
+    assert len(sdefault_nomore) == 1
+    sdefault_nomore = json.loads(sdefault_nomore[0])
+    assert [x['hash'] for x in sdefault_nomore['messages']] == hashes[-16:]
+    assert not sdefault_nomore['more']
+
+
+def test_retrieve_size_and_count(omq, big_store):
+
+    conn = big_store['conn']
+    sk = big_store['sk']
+    pk = big_store['pk']
+    hashes = big_store['hashes']
+
+    ts = int(time.time() * 1000)
+    to_sign = "retrieve{}".format(ts).encode()
+    sig = sk.sign(to_sign, encoder=Base64Encoder).signature.decode()
+
+    s5_or_1M = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_count": 5,
+            "max_size": 1_000_000,
+            "last_hash": hashes[19]
+        })])
+
+    s10_or_700k = omq.request_future(conn, 'storage.retrieve', [
+        json.dumps({
+            "pubkey": pk,
+            "timestamp": ts,
+            "signature": sig,
+            "max_count": 10,
+            "max_size": 700_000,
+            "last_hash": hashes[29]
+        })])
+
+    s5_or_1M = s5_or_1M.get()
+    assert len(s5_or_1M) == 1
+    s5_or_1M = json.loads(s5_or_1M[0])
+    assert [x['hash'] for x in s5_or_1M['messages']] == hashes[20:25]
+    assert s5_or_1M['more']
+    
+    s10_or_700k = s10_or_700k.get()
+    assert len(s10_or_700k) == 1
+    s10_or_700k = json.loads(s10_or_700k[0])
+    assert [x['hash'] for x in s10_or_700k['messages']] == hashes[30:37]
+    assert s10_or_700k['more']

--- a/oxenss/rpc/client_rpc_endpoints.cpp
+++ b/oxenss/rpc/client_rpc_endpoints.cpp
@@ -417,9 +417,11 @@ bt_value store::to_bt() const {
 
 template <typename Dict>
 static void load(retrieve& r, Dict& d) {
-    auto [lastHash, last_hash, msg_ns, pubKey, pubkey, pk_ed25519, sig, subkey, ts] = load_fields<
+    auto [lastHash, last_hash, max_count, max_size, msg_ns, pubKey, pubkey, pk_ed25519, sig, subkey, ts] = load_fields<
             std::string,
             std::string,
+            int,
+            int,
             namespace_id,
             std::string,
             std::string,
@@ -430,6 +432,8 @@ static void load(retrieve& r, Dict& d) {
             d,
             "lastHash",
             "last_hash",
+            "max_count",
+            "max_size",
             "namespace",
             "pubKey",
             "pubkey",
@@ -466,6 +470,9 @@ static void load(retrieve& r, Dict& d) {
             throw parse_error{"Invalid last_hash: expected base64 (43 chars)"};
     }
     r.last_hash = std::move(last_hash);
+
+    r.max_count = max_count;
+    r.max_size = max_size;
 }
 void retrieve::load_from(json params) {
     load(*this, params);

--- a/oxenss/rpc/client_rpc_endpoints.cpp
+++ b/oxenss/rpc/client_rpc_endpoints.cpp
@@ -417,30 +417,41 @@ bt_value store::to_bt() const {
 
 template <typename Dict>
 static void load(retrieve& r, Dict& d) {
-    auto [lastHash, last_hash, max_count, max_size, msg_ns, pubKey, pubkey, pk_ed25519, sig, subkey, ts] = load_fields<
-            std::string,
-            std::string,
-            int,
-            int,
-            namespace_id,
-            std::string,
-            std::string,
-            std::string_view,
-            std::string_view,
-            std::string_view,
-            system_clock::time_point>(
-            d,
-            "lastHash",
-            "last_hash",
-            "max_count",
-            "max_size",
-            "namespace",
-            "pubKey",
-            "pubkey",
-            "pubkey_ed25519",
-            "signature",
-            "subkey",
-            "timestamp");
+    auto [lastHash,
+          last_hash,
+          max_count,
+          max_size,
+          msg_ns,
+          pubKey,
+          pubkey,
+          pk_ed25519,
+          sig,
+          subkey,
+          ts] =
+            load_fields<
+                    std::string,
+                    std::string,
+                    int,
+                    int,
+                    namespace_id,
+                    std::string,
+                    std::string,
+                    std::string_view,
+                    std::string_view,
+                    std::string_view,
+                    system_clock::time_point>(
+                    d,
+                    "lastHash",
+                    "last_hash",
+                    "max_count",
+                    "max_size",
+                    "namespace",
+                    "pubKey",
+                    "pubkey",
+                    "pubkey_ed25519",
+                    "signature",
+                    "subkey",
+                    "timestamp");
 
     require_exactly_one_of("pubkey", pubkey, "pubKey", pubKey, true);
     auto& pk = pubkey ? pubkey : pubKey;

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -227,8 +227,10 @@ struct store final : recursive {
 ///   hex characters or 32 bytes).  *This* pubkey should be used for signing, but must also convert
 ///   to the given `pubkey` value (without the `05` prefix).
 ///
-/// On success, returns a dict containing key "messages" with value of a list of message details;
-/// each message is a dict containing keys:
+/// On success, returns a dict containing key "messages" with value of a list of message details,
+/// and key "more" with a boolean value indicating whether there were more messages (i.e. results
+/// were truncated because of the requested or default limits).  Each message details value is a
+/// dict containing keys:
 ///
 /// - "hash" -- the message hash
 /// - "timestamp" -- the timestamp when the message was deposited

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -707,8 +707,7 @@ void RequestHandler::process_client_req(
     // means 1/5 of the max:
     if (req.max_size && *req.max_size < 0) {
         req.max_size = RETRIEVE_MAX_SIZE / -*req.max_size;
-    }
-    else if (!req.max_size || *req.max_size > RETRIEVE_MAX_SIZE)
+    } else if (!req.max_size || *req.max_size > RETRIEVE_MAX_SIZE)
         req.max_size = RETRIEVE_MAX_SIZE;
 
     std::vector<message> msgs;
@@ -741,10 +740,7 @@ void RequestHandler::process_client_req(
         });
     }
 
-    json res{
-        {"messages", std::move(messages)},
-        {"more", more}
-    };
+    json res{{"messages", std::move(messages)}, {"more", more}};
     add_misc_response_fields(res, service_node_, now);
 
     return cb(Response{http::OK, std::move(res)});

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -693,13 +693,32 @@ void RequestHandler::process_client_req(
         }
     }
 
+    // Treat 0 count/size as unspecified:
+    if (req.max_count && *req.max_count == 0)
+        req.max_count.reset();
+    if (req.max_size && *req.max_size == 0)
+        req.max_size.reset();
+
+    // If neither are specified we default to 1/5 of max size:
+    if (!req.max_count && !req.max_size)
+        req.max_size = -5;
+
+    // For negative max sizes, we treat it as a fraction of the max size, e.g. -1 means max; -5
+    // means 1/5 of the max:
+    if (req.max_size && *req.max_size < 0) {
+        req.max_size = RETRIEVE_MAX_SIZE / -*req.max_size;
+    }
+    else if (!req.max_size || *req.max_size > RETRIEVE_MAX_SIZE)
+        req.max_size = RETRIEVE_MAX_SIZE;
+
     std::vector<message> msgs;
     try {
         msgs = service_node_.get_db().retrieve(
                 req.pubkey,
                 req.msg_namespace,
                 req.last_hash.value_or(""),
-                CLIENT_RETRIEVE_MESSAGE_LIMIT);
+                req.max_count,
+                req.max_size);
         service_node_.record_retrieve_request();
     } catch (const std::exception& e) {
         auto msg = fmt::format(

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -712,8 +712,9 @@ void RequestHandler::process_client_req(
         req.max_size = RETRIEVE_MAX_SIZE;
 
     std::vector<message> msgs;
+    bool more = false;
     try {
-        msgs = service_node_.get_db().retrieve(
+        std::tie(msgs, more) = service_node_.get_db().retrieve(
                 req.pubkey,
                 req.msg_namespace,
                 req.last_hash.value_or(""),
@@ -740,7 +741,10 @@ void RequestHandler::process_client_req(
         });
     }
 
-    json res{{"messages", std::move(messages)}};
+    json res{
+        {"messages", std::move(messages)},
+        {"more", more}
+    };
     add_misc_response_fields(res, service_node_, now);
 
     return cb(Response{http::OK, std::move(res)});

--- a/oxenss/rpc/request_handler.h
+++ b/oxenss/rpc/request_handler.h
@@ -43,11 +43,18 @@ inline constexpr auto STORE_TOLERANCE = 10s;
 inline constexpr auto SIGNATURE_TOLERANCE = 60s;
 inline constexpr auto SIGNATURE_TOLERANCE_FORWARDED = 70s;
 
-// The maximum messages that may be retrieved in a single request by a client:
-constexpr int CLIENT_RETRIEVE_MESSAGE_LIMIT = 100;
+// Maximum retrieve size (in bytes).  We have to be quite conversative here because there are
+// several ways with multiple layers of base64 encoding that can occur: first, for json, the body
+// gets base64 encoded, but then onion requests (by default) also b64 encode the encrypted payload,
+// so we might have double base64 encoding.  We include the first b64 encoding overhead in our size
+// calculation, but not the second, and so this value is reduced to accomodate it.
+//
+// The maximum network message size is 10MiB, which means the max before b64 encoding is 7.5MiB
+// (7864320).  We allow for some respoinse overhead, which lands us on this effective maximum:
+inline constexpr int RETRIEVE_MAX_SIZE = 7'800'000;
 
 // Maximum subrequests that can be stuffed into a single batch request
-constexpr size_t BATCH_REQUEST_MAX = 5;
+inline constexpr size_t BATCH_REQUEST_MAX = 5;
 
 // Simpler wrapper that works for most of our responses
 struct Response {

--- a/oxenss/storage/database.cpp
+++ b/oxenss/storage/database.cpp
@@ -622,7 +622,7 @@ void Database::bulk_store(const std::vector<message>& items) {
     t.commit();
 }
 
-std::vector<message> Database::retrieve(
+std::pair<std::vector<message>, bool> Database::retrieve(
         const user_pubkey_t& pubkey,
         namespace_id ns,
         const std::string& last_hash,
@@ -630,12 +630,11 @@ std::vector<message> Database::retrieve(
         std::optional<size_t> max_size,
         const bool size_b64,
         const size_t per_message_overhead) {
-    std::vector<message> results;
 
     auto owner_st = impl->prepared_st("SELECT id FROM owners WHERE pubkey = ? AND type = ?");
     auto ownerid = exec_and_maybe_get<int64_t>(owner_st, pubkey);
     if (!ownerid)
-        return results;
+        return {};
 
     if (max_results && *max_results < 1)
         max_results = 1;
@@ -657,24 +656,34 @@ std::vector<message> Database::retrieve(
     st->bind(pos++, to_int(ns));
     if (last_id)
         st->bind(pos++, *last_id);
-    st->bind(pos++, max_results ? static_cast<int>(*max_results) : -1);
+    st->bind(pos++, max_results ? static_cast<int>(*max_results) + 1 : -1);
+
+    std::pair<std::vector<message>, bool> result{};
+    auto& [results, more] = result;
 
     size_t agg_size = 0;
     while (st->executeStep()) {
         auto [hash, ns, ts, exp, data] =
                 get<std::string, namespace_id, int64_t, int64_t, std::string>(st);
+        if (max_results && results.size() >= *max_results) {
+            more = true;
+            break;
+        }
         if (max_size) {
             agg_size += per_message_overhead;
             agg_size += hash.size();
             agg_size += size_b64 ? data.size() * 4 / 3 : data.size();
-            if (!results.empty() && agg_size > *max_size)
+            if (!results.empty() && agg_size > *max_size) {
+                more = true;
                 break;
+            }
         }
+
         results.emplace_back(
                 std::move(hash), ns, from_epoch_ms(ts), from_epoch_ms(exp), std::move(data));
     }
 
-    return results;
+    return result;
 }
 
 std::vector<message> Database::retrieve_all() {

--- a/oxenss/storage/database.hpp
+++ b/oxenss/storage/database.hpp
@@ -53,11 +53,14 @@ class Database {
 
     // Retrieves messages owned by pubkey received since `last_hash` stored in namespace `ns`.  If
     // last_hash is empty or not found then returns all messages (up to the limit). Optionally takes
-    // a maximum number of messages to return.
+    // a maximum number of messages to return or a maximum aggregate size of messages to return.
     //
     // Note that the `pubkey` value of the returned message's will be left default constructed,
     // i.e. *not* filled with the given pubkey.
-    std::vector<message> retrieve(
+    //
+    // Returns a vector of messages, and a bool indicating whether there are more results to
+    // retrieve.
+    std::pair<std::vector<message>, bool> retrieve(
             const user_pubkey_t& pubkey,
             namespace_id ns,
             const std::string& last_hash,

--- a/oxenss/storage/database.hpp
+++ b/oxenss/storage/database.hpp
@@ -66,9 +66,11 @@ class Database {
             const std::string& last_hash,
             std::optional<size_t> num_results = std::nullopt,
             std::optional<size_t> max_size = std::nullopt,
-            bool size_b64 = true, // True if the data will get b64-encoded (and thus is 4/3 as large)
-            size_t per_message_overhead = DEFAULT_MSG_OVERHEAD // how much overhead per message to allow for
-            );
+            bool size_b64 =
+                    true,  // True if the data will get b64-encoded (and thus is 4/3 as large)
+            size_t per_message_overhead =
+                    DEFAULT_MSG_OVERHEAD  // how much overhead per message to allow for
+    );
 
     // Retrieves all messages.
     std::vector<message> retrieve_all();

--- a/oxenss/storage/database.hpp
+++ b/oxenss/storage/database.hpp
@@ -46,6 +46,11 @@ class Database {
 
     void bulk_store(const std::vector<message>& items);
 
+    // Default value for message overhead calculations in `retrieve`.  In practice, overhead for the
+    // message itself (i.e. the json keys, etc.) seems to be in the 75-80 character range (depending
+    // on whether json or bt-encoded), not including the hash + the data.
+    constexpr static size_t DEFAULT_MSG_OVERHEAD = 100;
+
     // Retrieves messages owned by pubkey received since `last_hash` stored in namespace `ns`.  If
     // last_hash is empty or not found then returns all messages (up to the limit). Optionally takes
     // a maximum number of messages to return.
@@ -56,7 +61,11 @@ class Database {
             const user_pubkey_t& pubkey,
             namespace_id ns,
             const std::string& last_hash,
-            std::optional<int> num_results = std::nullopt);
+            std::optional<size_t> num_results = std::nullopt,
+            std::optional<size_t> max_size = std::nullopt,
+            bool size_b64 = true, // True if the data will get b64-encoded (and thus is 4/3 as large)
+            size_t per_message_overhead = DEFAULT_MSG_OVERHEAD // how much overhead per message to allow for
+            );
 
     // Retrieves all messages.
     std::vector<message> retrieve_all();

--- a/unit_test/storage.cpp
+++ b/unit_test/storage.cpp
@@ -52,7 +52,7 @@ TEST_CASE("storage - data persistence", "[storage]") {
         CHECK(storage.get_owner_count() == 1);
         CHECK(storage.get_message_count() == 1);
 
-        auto items = storage.retrieve(pubkey, namespace_id::Default, "");
+        auto [items, more] = storage.retrieve(pubkey, namespace_id::Default, "");
 
         REQUIRE(items.size() == 1);
         CHECK_FALSE(items[0].pubkey);  // pubkey is left unset when we retrieve for pubkey
@@ -89,7 +89,7 @@ TEST_CASE("storage - data persistence, namespace", "[storage][namespace]") {
         CHECK(storage.get_owner_count() == 1);
         CHECK(storage.get_message_count() == 1);
 
-        auto items = storage.retrieve(pubkey, ns, "");
+        auto [items, more] = storage.retrieve(pubkey, ns, "");
 
         REQUIRE(items.size() == 1);
         CHECK_FALSE(items[0].pubkey);  // pubkey is left unset when we retrieve for pubkey
@@ -145,13 +145,13 @@ TEST_CASE("storage - only return entries for specified pubkey", "[storage]") {
 
     const auto lastHash = "";
     {
-        auto items = storage.retrieve(pubkey1, namespace_id::Default, lastHash);
+        auto [items, more] = storage.retrieve(pubkey1, namespace_id::Default, lastHash);
         REQUIRE(items.size() == 1);
         CHECK(items[0].hash == "hash0");
     }
 
     {
-        auto items = storage.retrieve(pubkey2, namespace_id::Default, lastHash);
+        auto [items, more] = storage.retrieve(pubkey2, namespace_id::Default, lastHash);
         REQUIRE(items.size() == 1);
         CHECK(items[0].hash == "hash1");
     }
@@ -177,14 +177,14 @@ TEST_CASE("storage - return entries older than lasthash", "[storage]") {
 
     {
         const auto lastHash = "hash0";
-        auto items = storage.retrieve(pubkey, namespace_id::Default, lastHash);
+        auto [items, more] = storage.retrieve(pubkey, namespace_id::Default, lastHash);
         REQUIRE(items.size() == num_entries - 1);
         CHECK(items[0].hash == "hash1");
     }
 
     {
         const auto lastHash = std::string("hash") + std::to_string(num_entries / 2 - 1);
-        auto items = storage.retrieve(pubkey, namespace_id::Default, lastHash);
+        auto [items, more] = storage.retrieve(pubkey, namespace_id::Default, lastHash);
         REQUIRE(items.size() == num_entries / 2);
         CHECK(items[0].hash == "hash" + std::to_string(num_entries / 2));
     }
@@ -215,14 +215,14 @@ TEST_CASE("storage - remove expired entries", "[storage]") {
 
     {
         const auto lastHash = "";
-        auto items = storage.retrieve(pubkey1, namespace_id::Default, lastHash);
+        auto [items, more] = storage.retrieve(pubkey1, namespace_id::Default, lastHash);
         REQUIRE(items.size() == 2);
     }
     std::this_thread::sleep_for(5ms);
     storage.clean_expired();
     {
         const auto lastHash = "";
-        auto items = storage.retrieve(pubkey1, namespace_id::Default, lastHash);
+        auto [items, more] = storage.retrieve(pubkey1, namespace_id::Default, lastHash);
         REQUIRE(items.size() == 1);
         CHECK(items[0].hash == "hash0");
     }
@@ -262,7 +262,7 @@ TEST_CASE("storage - bulk data storage", "[storage]") {
 
     // retrieve
     {
-        auto items = storage.retrieve(pubkey, namespace_id::Default, "");
+        auto [items, more] = storage.retrieve(pubkey, namespace_id::Default, "");
         CHECK(items.size() == num_items);
     }
 
@@ -311,7 +311,7 @@ TEST_CASE("storage - bulk storage with overlap", "[storage]") {
 
     // retrieve
     {
-        auto items = storage.retrieve(pubkey, namespace_id::Default, "");
+        auto [items, more] = storage.retrieve(pubkey, namespace_id::Default, "");
         CHECK(items.size() == num_items);
     }
 }
@@ -342,11 +342,11 @@ TEST_CASE("storage - retrieve limit", "[storage]") {
     CHECK(storage.get_owner_count() == 2);
     CHECK(storage.get_message_count() == num_entries + 5);
 
-    CHECK(storage.retrieve(pubkey, namespace_id::Default, "").size() == num_entries);
-    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 10).size() == 10);
-    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 88).size() == 88);
-    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 99).size() == 99);
-    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 100).size() == 100);
-    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 101).size() == 100);
-    CHECK(storage.retrieve(pubkey2, namespace_id::Default, "", 10).size() == 5);
+    CHECK(storage.retrieve(pubkey, namespace_id::Default, "").first.size() == num_entries);
+    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 10).first.size() == 10);
+    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 88).first.size() == 88);
+    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 99).first.size() == 99);
+    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 100).first.size() == 100);
+    CHECK(storage.retrieve(pubkey, namespace_id::Default, "", 101).first.size() == 100);
+    CHECK(storage.retrieve(pubkey2, namespace_id::Default, "", 10).first.size() == 5);
 }


### PR DESCRIPTION
- Adds parameters `max_count` and `max_size` to the `retrieve` request
  - `max_count` lets you set a maximum number of results to return
  - `max_size` lets you set a maximum aggregate size of results to return
  - `max_size` takes negative values to indicate a fraction of the maximum, e.g. -1 means max size, -4 means 1/4 of the max_size, etc.
  - Current max size is 7.8MB (because some requests still apply b64 encoding on top of the encrypted value, and with b64 encoding this brings us close to the 10MiB limit).
    - negative `max_size` values are particularly important for batched retrievals, e.g. if retrieving from 3 different namespaces use `"max_size": -3` to ensure that you won't overflow the inter-node network request size.
  - default retrieve (with neither specified) is now `max_size=-5`, i.e. 1/5 of the maximum network message size.
- Add a `"more": true`/`"more": false` to the retrieve endpoint that indicates whether the message list was truncated (true) or complete (false).  Previously you could (mostly) guess that there were more by noticing that you got exactly 100 responses, but that won't work anymore.