### PR TITLE
Static build fixes

### DIFF
--- a/contrib/drone-check-static-libs.sh
+++ b/contrib/drone-check-static-libs.sh
@@ -6,7 +6,7 @@
 set -o errexit
 
 anybad=
-for bin in httpserver/oxen-storage; do
+for bin in oxen-storage; do
     bad=
     if [ "$DRONE_STAGE_OS" == "darwin" ]; then
         if otool -L $bin | grep -Ev '^'$bin':|^\t(/usr/lib/libSystem\.|/usr/lib/libc\+\+\.|/usr/lib/libresolv\.|/System/Library/Frameworks/(CoreFoundation|IOKit|Security|SystemConfiguration))'; then

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -9,6 +9,8 @@ option(STATIC "Try to link external dependencies statically, where possible" ${D
 
 if(NOT STATIC AND NOT BUILD_STATIC_DEPS)
   find_package(PkgConfig REQUIRED)
+else()
+  set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "" FORCE)
 endif()
 
 if(NOT TARGET sodium)


### PR DESCRIPTION
The static build in the update broke and wasn't static (for embedded oxenmq/spdlog/SQLiteCpp); this fixes it.