### PR TITLE
Fix missing jemalloc linking

### DIFF
--- a/oxenss/daemon/CMakeLists.txt
+++ b/oxenss/daemon/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(daemon
 target_link_libraries(daemon
     PRIVATE
     common crypto logging rpc server snode storage utils version
+    jemalloc::jemalloc
     CLI11::CLI11)
 
 if(NOT BUILD_STATIC_DEPS)


### PR DESCRIPTION
The 2.3.0 code refactor accidentally dropped linking against jemalloc, and as a result memory usage is much higher.

This restores it.