### PR TITLE
Subkey auth for expiry extension; failable delete_msgs

### DIFF
--- a/network-tests/ss.py
+++ b/network-tests/ss.py
@@ -58,7 +58,7 @@ def random_swarm_members(swarm, n, exclude={}):
     return random.sample([s for s in swarm['snodes'] if s['pubkey_ed25519'] not in exclude], n)
 
 
-def store_n(omq, conn, sk, basemsg, n, offset=0, netid=5):
+def store_n(omq, conn, sk, basemsg, n, *, offset=0, netid=5):
     msgs = []
     pubkey = chr(netid).encode() + (sk.verify_key if isinstance(sk, SigningKey) else sk.public_key).encode()
     for i in range(n):

--- a/network-tests/test_expire.py
+++ b/network-tests/test_expire.py
@@ -95,7 +95,11 @@ def test_expire(omq, random_sn, sk, exclude):
 
     ts = msgs[6]['req']['expiry']
     hashes = [msgs[i]['hash'] for i in (0, 1, 5, 6, 7, 9)] + ['bepQtTaYrzcuCXO3fZkmk/h3xkMQ3vCh94i5HzLmj3I']
-    actual_update_msgs = sorted(msgs[i]['hash'] for i in (0, 1, 5))
+    # Make sure `hashes` input isn't provided in sorted order:
+    if hashes[0] < hashes[1]:
+        hashes[0], hashes[1] = hashes[1], hashes[0]
+    actual_update_msgs = sorted(msgs[i]['hash'] for i in (0, 1, 5, 6, 7, 9))
+    assert hashes != actual_update_msgs
 
     hashes = sorted(hashes, reverse=True)
     to_sign = ("expire" + str(ts) + "".join(hashes)).encode()

--- a/network-tests/test_expire.py
+++ b/network-tests/test_expire.py
@@ -99,7 +99,7 @@ def test_expire(omq, random_sn, sk, exclude):
     if hashes[0] < hashes[1]:
         hashes[0], hashes[1] = hashes[1], hashes[0]
     actual_update_msgs = sorted(msgs[i]['hash'] for i in (0, 1, 5, 6, 7, 9))
-    assert hashes != actual_update_msgs
+    assert hashes[0:2] != actual_update_msgs[0:2]
 
     hashes = sorted(hashes, reverse=True)
     to_sign = ("expire" + str(ts) + "".join(hashes)).encode()

--- a/network-tests/test_ifelse.py
+++ b/network-tests/test_ifelse.py
@@ -10,7 +10,7 @@ b64_m_yes = 'Yes='
 m_no = b'\x36\x8a\x5e'
 b64_m_no = 'Nope'
 
-def test_expire_all(omq, random_sn, sk, exclude):
+def test_ifelse(omq, random_sn, sk, exclude):
     swarm = ss.get_swarm(omq, random_sn, sk)
 
     sn = ss.random_swarm_members(swarm, 1, exclude)[0]
@@ -42,7 +42,7 @@ def test_expire_all(omq, random_sn, sk, exclude):
 
     r.append(omq.request_future(conn, 'storage.ifelse',
             [json.dumps({
-                'if': { 'hf_at_least': [19], 'height_before': 123456 },
+                'if': { 'hf_at_least': [19], 'height_before': 1234 },
                 'then': store_action(b64_m_yes, ts+1),
                 'else': store_action(b64_m_no, ts+1),
             })]))

--- a/oxenss/rpc/client_rpc_endpoints.cpp
+++ b/oxenss/rpc/client_rpc_endpoints.cpp
@@ -610,11 +610,12 @@ bt_value expire_all::to_bt() const {
 
 template <typename Dict>
 static void load(expire_msgs& e, Dict& d) {
-    auto [expiry, messages, pubkey, pubkey_ed25519, signature] =
-            load_fields<TP, Vec<Str>, Str, SV, SV>(
-                    d, "expiry", "messages", "pubkey", "pubkey_ed25519", "signature");
+    auto [expiry, messages, pubkey, pubkey_ed25519, signature, subkey] =
+            load_fields<TP, Vec<Str>, Str, SV, SV, SV>(
+                    d, "expiry", "messages", "pubkey", "pubkey_ed25519", "signature", "subkey");
 
     load_pk_signature(e, d, pubkey, pubkey_ed25519, signature);
+    load_subkey(e, d, subkey);
     require("expiry", expiry);
     e.expiry = std::move(*expiry);
     require("messages", messages);
@@ -644,6 +645,9 @@ bt_value expire_msgs::to_bt() const {
     if (pubkey_ed25519)
         ret["pubkey_ed25519"] = std::string_view{
                 reinterpret_cast<const char*>(pubkey_ed25519->data()), pubkey_ed25519->size()};
+    if (subkey)
+        ret["subkey"] =
+                std::string_view{reinterpret_cast<const char*>(subkey->data()), subkey->size()};
     return ret;
 }
 

--- a/oxenss/rpc/client_rpc_endpoints.cpp
+++ b/oxenss/rpc/client_rpc_endpoints.cpp
@@ -498,15 +498,16 @@ static bool is_valid_message_hash(std::string_view hash) {
 
 template <typename Dict>
 static void load(delete_msgs& dm, Dict& d) {
-    auto [messages, pubkey, pubkey_ed25519, signature] =
-            load_fields<std::vector<std::string>, std::string, std::string_view, std::string_view>(
-                    d, "messages", "pubkey", "pubkey_ed25519", "signature");
+    auto [messages, pubkey, pubkey_ed25519, required, signature] =
+            load_fields<std::vector<std::string>, std::string, std::string_view, bool, std::string_view>(
+                    d, "messages", "pubkey", "pubkey_ed25519", "required", "signature");
 
     load_pk_signature(dm, d, pubkey, pubkey_ed25519, signature);
     require("messages", messages);
     dm.messages = std::move(*messages);
     if (dm.messages.empty())
         throw parse_error{"messages does not contain any message hashes"};
+    dm.required = required.value_or(false);
     for (const auto& m : dm.messages)
         if (!is_valid_message_hash(m))
             throw parse_error{"invalid message hash: " + m};

--- a/oxenss/rpc/client_rpc_endpoints.cpp
+++ b/oxenss/rpc/client_rpc_endpoints.cpp
@@ -314,28 +314,27 @@ namespace {
 
 }  // namespace
 
+// Aliases used in `load_fields<...>` to make formatting less obtuse
+using Str = std::string;
+using SV = std::string_view;
+using TP = system_clock::time_point;
+template <typename T>
+using Vec = std::vector<T>;
+
 template <typename Dict>
 static void load(store& s, Dict& d) {
-    auto [data, expiry, msg_ns, pubkey_alt, pubkey, pk_ed25519, sig_ts, sig, subkey] = load_fields<
-            std::string_view,
-            system_clock::time_point,
-            namespace_id,
-            std::string,
-            std::string,
-            std::string_view,
-            system_clock::time_point,
-            std::string_view,
-            std::string_view>(
-            d,
-            "data",
-            "expiry",
-            "namespace",
-            "pubKey",
-            "pubkey",
-            "pubkey_ed25519",
-            "sig_timestamp",
-            "signature",
-            "subkey");
+    auto [data, expiry, msg_ns, pubkey_alt, pubkey, pk_ed25519, sig_ts, sig, subkey] =
+            load_fields<SV, TP, namespace_id, Str, Str, SV, TP, SV, SV>(
+                    d,
+                    "data",
+                    "expiry",
+                    "namespace",
+                    "pubKey",
+                    "pubkey",
+                    "pubkey_ed25519",
+                    "sig_timestamp",
+                    "signature",
+                    "subkey");
 
     // timestamp and ttl are special snowflakes: for backwards compat reasons, they can
     // be passed as strings when loading from json.
@@ -428,18 +427,7 @@ static void load(retrieve& r, Dict& d) {
           sig,
           subkey,
           ts] =
-            load_fields<
-                    std::string,
-                    std::string,
-                    int,
-                    int,
-                    namespace_id,
-                    std::string,
-                    std::string,
-                    std::string_view,
-                    std::string_view,
-                    std::string_view,
-                    system_clock::time_point>(
+            load_fields<Str, Str, int, int, namespace_id, Str, Str, SV, SV, SV, TP>(
                     d,
                     "lastHash",
                     "last_hash",
@@ -499,7 +487,7 @@ static bool is_valid_message_hash(std::string_view hash) {
 template <typename Dict>
 static void load(delete_msgs& dm, Dict& d) {
     auto [messages, pubkey, pubkey_ed25519, required, signature] =
-            load_fields<std::vector<std::string>, std::string, std::string_view, bool, std::string_view>(
+            load_fields<Vec<Str>, Str, SV, bool, SV>(
                     d, "messages", "pubkey", "pubkey_ed25519", "required", "signature");
 
     load_pk_signature(dm, d, pubkey, pubkey_ed25519, signature);
@@ -535,13 +523,9 @@ bt_value delete_msgs::to_bt() const {
 
 template <typename Dict>
 static void load(delete_all& da, Dict& d) {
-    auto [msgs_ns, pubkey, pubkey_ed25519, signature, timestamp] = load_fields<
-            namespace_var,
-            std::string,
-            std::string_view,
-            std::string_view,
-            system_clock::time_point>(
-            d, "namespace", "pubkey", "pubkey_ed25519", "signature", "timestamp");
+    auto [msgs_ns, pubkey, pubkey_ed25519, signature, timestamp] =
+            load_fields<namespace_var, Str, SV, SV, TP>(
+                    d, "namespace", "pubkey", "pubkey_ed25519", "signature", "timestamp");
 
     load_pk_signature(da, d, pubkey, pubkey_ed25519, signature);
     require("timestamp", timestamp);
@@ -568,12 +552,9 @@ bt_value delete_all::to_bt() const {
 
 template <typename Dict>
 static void load(delete_before& db, Dict& d) {
-    auto [before, msgs_ns, pubkey, pubkey_ed25519, signature] = load_fields<
-            system_clock::time_point,
-            namespace_var,
-            std::string,
-            std::string_view,
-            std::string_view>(d, "before", "namespace", "pubkey", "pubkey_ed25519", "signature");
+    auto [before, msgs_ns, pubkey, pubkey_ed25519, signature] =
+            load_fields<TP, namespace_var, Str, SV, SV>(
+                    d, "before", "namespace", "pubkey", "pubkey_ed25519", "signature");
 
     load_pk_signature(db, d, pubkey, pubkey_ed25519, signature);
     require("before", before);
@@ -600,12 +581,9 @@ bt_value delete_before::to_bt() const {
 
 template <typename Dict>
 static void load(expire_all& e, Dict& d) {
-    auto [expiry, msgs_ns, pubkey, pubkey_ed25519, signature] = load_fields<
-            system_clock::time_point,
-            namespace_var,
-            std::string,
-            std::string_view,
-            std::string_view>(d, "expiry", "namespace", "pubkey", "pubkey_ed25519", "signature");
+    auto [expiry, msgs_ns, pubkey, pubkey_ed25519, signature] =
+            load_fields<TP, namespace_var, Str, SV, SV>(
+                    d, "expiry", "namespace", "pubkey", "pubkey_ed25519", "signature");
 
     load_pk_signature(e, d, pubkey, pubkey_ed25519, signature);
     require("expiry", expiry);
@@ -632,12 +610,9 @@ bt_value expire_all::to_bt() const {
 
 template <typename Dict>
 static void load(expire_msgs& e, Dict& d) {
-    auto [expiry, messages, pubkey, pubkey_ed25519, signature] = load_fields<
-            system_clock::time_point,
-            std::vector<std::string>,
-            std::string,
-            std::string_view,
-            std::string_view>(d, "expiry", "messages", "pubkey", "pubkey_ed25519", "signature");
+    auto [expiry, messages, pubkey, pubkey_ed25519, signature] =
+            load_fields<TP, Vec<Str>, Str, SV, SV>(
+                    d, "expiry", "messages", "pubkey", "pubkey_ed25519", "signature");
 
     load_pk_signature(e, d, pubkey, pubkey_ed25519, signature);
     require("expiry", expiry);
@@ -674,7 +649,7 @@ bt_value expire_msgs::to_bt() const {
 
 template <typename Dict>
 static void load(get_swarm& g, Dict& d) {
-    auto [pubKey, pubkey] = load_fields<std::string, std::string>(d, "pubKey", "pubkey");
+    auto [pubKey, pubkey] = load_fields<Str, Str>(d, "pubKey", "pubkey");
 
     require_exactly_one_of("pubkey", pubkey, "pubKey", pubKey, true);
     if (!g.pubkey.load(std::move(pubkey ? *pubkey : *pubKey)))
@@ -798,20 +773,15 @@ static std::optional<std::array<T, N>> to_fixed_array(const std::optional<std::v
 
 template <typename Dict>
 static void load_condition(ifelse& i, Dict if_) {
-    auto [height_ge_, height_lt_, hf_ge_, hf_lt_, v_ge_, v_lt_] = load_fields<
-            int,
-            int,
-            std::vector<int>,
-            std::vector<int>,
-            std::vector<int>,
-            std::vector<int>>(
-            if_,
-            "height_at_least",
-            "height_before",
-            "hf_at_least",
-            "hf_before",
-            "v_at_least",
-            "v_before");
+    auto [height_ge_, height_lt_, hf_ge_, hf_lt_, v_ge_, v_lt_] =
+            load_fields<int, int, Vec<int>, Vec<int>, Vec<int>, Vec<int>>(
+                    if_,
+                    "height_at_least",
+                    "height_before",
+                    "hf_at_least",
+                    "hf_before",
+                    "v_at_least",
+                    "v_before");
 
     auto hf_ge = to_fixed_array<2>(hf_ge_);
     auto hf_lt = to_fixed_array<2>(hf_lt_);

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -142,7 +142,7 @@ namespace {
 ///   possible.
 ///
 /// Returns dict of:
-/// - "swarms" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
+/// - "swarm" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
 ///     - "failed" and other failure keys -- see `recursive`.
 ///     - "hash": the hash of the stored message; will be an unpadded base64-encode blake2b hash of
 ///       (TIMESTAMP || EXPIRY || PUBKEY || NAMESPACE || DATA), where PUBKEY is in bytes (not hex!);
@@ -287,7 +287,7 @@ struct info final : no_args {
 ///   encoded for json requests; binary for OMQ requests.
 ///
 /// Returns dict of:
-/// - "swarms" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
+/// - "swarm" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
 ///     - "failed" and other failure keys -- see `recursive`.
 ///     - "deleted": list of hashes of messages that were found and deleted, sorted by ascii value
 ///     - "signature": signature of:
@@ -355,7 +355,7 @@ inline std::string signature_value(const namespace_var& ns) {
 ///   prefix).  Must be base64 encoded for json requests; binary for OMQ requests.
 ///
 /// Returns dict of:
-/// - "swarms" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
+/// - "swarm" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
 ///     - "failed" and other failure keys -- see `recursive`.
 ///     - "deleted": if deleting from a single namespace this is a list of hashes of deleted
 ///       messages from the namespace, sorted by ascii value.  If deleting from all namespaces this
@@ -400,7 +400,7 @@ struct delete_all final : recursive {
 ///   string for the default namespace (whether explicitly given or not).
 ///
 /// Returns dict of:
-/// - "swarms" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
+/// - "swarm" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
 ///     - "failed" and other failure keys -- see `recursive`.
 ///     - "deleted": if deleting from a single namespace this is a list of hashes of deleted
 ///       messages from the namespace, sorted by ascii value.  If deleting from all namespaces this
@@ -447,7 +447,7 @@ struct delete_before final : recursive {
 ///   namespace (whether or not explicitly provided).
 ///
 /// Returns dict of:
-/// - "swarms" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
+/// - "swarm" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
 ///     - "failed" and other failure keys -- see `recursive`.
 ///     - "updated":
 ///         - if expiring from a single namespace then this is a list of (ascii-sorted) hashes that
@@ -497,7 +497,7 @@ struct expire_all final : recursive {
 ///
 ///
 /// Returns dict of:
-/// - "swarms" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
+/// - "swarm" dict mapping ed25519 pubkeys (in hex) of swarm members to dict values of:
 ///     - "failed" and other failure keys -- see `recursive`.
 ///     - "updated": ascii-sorted list of hashes of messages that had their expiries updated.
 ///     - "expiry": the expiry timestamp that was applied (which might be different from the request

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -278,6 +278,10 @@ struct info final : no_args {
 ///   to the given `pubkey` value (without the `05` prefix).
 /// - messages -- array of message hash strings (as provided by the storage server) to delete.
 ///   Message IDs can be from any message namespace(s).
+/// - required -- if provided and set to true then require that at least one given message is
+///   deleted from at least one swarm member for a 200 response; otherwise return a 404.  When this
+///   field is omitted (or false) the response will be a 200 OK even if none of the messages
+///   existed.
 /// - signature -- Ed25519 signature of ("delete" || messages...); this signs the value constructed
 ///   by concatenating "delete" and all `messages` values, using `pubkey` to sign.  Must be base64
 ///   encoded for json requests; binary for OMQ requests.
@@ -298,6 +302,7 @@ struct delete_msgs final : recursive {
     std::optional<std::array<unsigned char, 32>> pubkey_ed25519;
     std::vector<std::string> messages;
     std::array<unsigned char, 64> signature;
+    bool required = false;
 
     void load_from(nlohmann::json params) override;
     void load_from(oxenc::bt_dict_consumer params) override;

--- a/oxenss/storage/database.hpp
+++ b/oxenss/storage/database.hpp
@@ -120,14 +120,16 @@ class Database {
             namespace_id ns,
             std::chrono::system_clock::time_point timestamp);
 
-    // Shortens the expiry time of the given messages owned by the given pubkey.  Expiries can only
-    // be shortened (i.e. brought closer to now), not extended into the future.  Returns a vector of
-    // hashes of messages that had their expiries updates.  (Missing messages and messages that
-    // already had an expiry <= the given expiry value are not returned).
+    // Updates the expiry time of the given messages owned by the given pubkey.  Returns a vector of
+    // hashes of found messages (i.e. hashes that don't exist are not returned).
+    //
+    // If extend_only is given as true, then only messages that have a current expiry less than the
+    // new expiry are updated (i.e. it will only extend expiries).
     std::vector<std::string> update_expiry(
             const user_pubkey_t& pubkey,
             const std::vector<std::string>& msg_hashes,
-            std::chrono::system_clock::time_point new_exp);
+            std::chrono::system_clock::time_point new_exp,
+            bool extend_only = false);
 
     // Shortens the expiry time of all messages owned by the given pubkey.  Expiries can only be
     // shortened (i.e. brought closer to now), not extended into the future.  Returns a vector of


### PR DESCRIPTION
- Enables subkey authentication for `expire` endpoint: if using subkey auth, then expiries can be extended (but not reduced).
- Adds a `"required"` parameter to the `delete` endpoint: if provided and true then deletions that have no effect (i.e. no deletions on any swarm member) return a 404 status, rather than a 200 (which can be useful when building a sequence).