### PR TITLE
authenticated message subscription endpoints

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -60,7 +60,7 @@ macro(system_or_submodule BIGNAME smallname pkgconf subdir)
   endif()
 endmacro()
 
-system_or_submodule(OXENC oxenc liboxenc>=1.0.3 oxenc)
+system_or_submodule(OXENC oxenc liboxenc>=1.0.4 oxenc)
 system_or_submodule(OXENMQ oxenmq liboxenmq>=1.2.12 oxen-mq)
 set(JSON_MultipleHeaders ON CACHE BOOL "") # Allows multi-header nlohmann use
 system_or_submodule(NLOHMANN nlohmann_json nlohmann_json>=3.7.0 nlohmann_json)

--- a/network-tests/subkey.py
+++ b/network-tests/subkey.py
@@ -1,0 +1,59 @@
+from nacl.encoding import RawEncoder
+from nacl.hash import blake2b
+from hashlib import sha512
+from nacl.signing import SigningKey, VerifyKey
+import nacl.bindings as sodium
+from typing import Union
+
+
+def make_subkey(sk, subuser_or_raw: Union[VerifyKey, bytes]):
+    """
+    For a subkey signature, given subkey value c, we sign with d=a(c+H(c‖A)), which has
+    verification key D = (c+H(c‖A))A.
+
+    You can pass in either a raw subkey (32 bytes) or a VerifyKey to make one from it.
+
+    Returns length-32 bytes of each of: subkey, privkey, pubkey
+    """
+    if isinstance(subuser_or_raw, bytes):
+        assert(len(subuser_or_raw) == 32)
+        c = subuser_or_raw
+    else:
+        c = blake2b(sk.verify_key.encode() + subuser_or_raw.encode(), digest_size=32, encoder=RawEncoder)
+
+    a = sodium.crypto_sign_ed25519_sk_to_curve25519(sk.encode() + sk.verify_key.encode())
+    d = sodium.crypto_core_ed25519_scalar_mul(
+        a,
+        sodium.crypto_core_ed25519_scalar_add(
+            c,
+            blake2b(
+                c + sk.verify_key.encode(), key=b'OxenSSSubkey', digest_size=32, encoder=RawEncoder
+            ),
+        ),
+    )
+    D = sodium.crypto_scalarmult_ed25519_base_noclamp(d)
+    return c, d, D
+
+
+def sha512_multipart(*message_parts):
+    """Given any number of arguments, returns the SHA512 hash of them concatenated together.  This
+    also does one level of flatting if any of the given parts are a list or tuple."""
+    hasher = sha512()
+    for m in message_parts:
+        if isinstance(m, list) or isinstance(m, tuple):
+            for mi in m:
+                hasher.update(mi)
+        else:
+            hasher.update(m)
+    return hasher.digest()
+
+
+# Mostly copied from SOGS auth example; the signature math here is identical (just using d/D instead
+# of ka/kA):
+def sign(message_parts, s: SigningKey, d: bytes, D: bytes):
+    H_rh = sha512(s.encode()).digest()[32:]
+    r = sodium.crypto_core_ed25519_scalar_reduce(sha512_multipart(H_rh, D, message_parts))
+    sig_R = sodium.crypto_scalarmult_ed25519_base_noclamp(r)
+    HRAM = sodium.crypto_core_ed25519_scalar_reduce(sha512_multipart(sig_R, D, message_parts))
+    sig_s = sodium.crypto_core_ed25519_scalar_add(r, sodium.crypto_core_ed25519_scalar_mul(HRAM, d))
+    return sig_R + sig_s

--- a/network-tests/test_monitor.py
+++ b/network-tests/test_monitor.py
@@ -1,0 +1,270 @@
+from util import sn_address
+import ss
+import subkey
+import time
+import datetime
+from nacl.hash import blake2b
+from nacl.encoding import RawEncoder, Base64Encoder
+from nacl.signing import SigningKey, VerifyKey
+import nacl.bindings as sodium
+import json
+import base64
+
+import oxenmq
+from oxenc import bt_serialize, bt_deserialize
+
+
+def notify_request(
+    sk: SigningKey,
+    ts: int,
+    data: bool,
+    namespaces: list,
+    *,
+    netid=0x05,
+    sessionid: bool = False,
+    subk: bytes = None,
+):
+
+    req = {'n': sorted(namespaces), 'd': int(data), 't': ts}
+
+    if sessionid:
+        assert netid == 0x05
+        req['P'] = sk.verify_key.encode()
+        account = b'\x05' + sk.verify_key.to_curve25519_public_key().encode()
+    else:
+        account = chr(netid).encode() + sk.verify_key.encode()
+        req['p'] = account
+
+    # ( "MONITOR" || ACCOUNT || TS || D || NS[0] || ... || NS[n] )
+    message = (
+        f'MONITOR{account.hex()}{ts:d}{data:d}' + ','.join(f'{n}' for n in req['n'])
+    ).encode()
+
+    if not subk:
+        req['s'] = sk.sign(message).signature
+    else:
+        assert len(subk) == 32
+        req['S'] = subk
+        _, d, D = subkey.make_subkey(sk, subk)
+        sig = subkey.sign(message, sk, d, D)
+        assert len(sig) == 64
+        req['s'] = sig
+
+    return req
+
+
+def test_monitor_reg_ed(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk)
+
+    o = oxenmq.OxenMQ()
+    o.start()
+    ts = int(time.time())
+    registered = []
+    for snode in swarm['snodes']:
+        snode['addr'] = oxenmq.Address(
+            f"curve://{snode['ip']}:{snode['port_omq']}/{snode['pubkey_x25519']}"
+        )
+        c = o.connect_remote(
+            snode['addr'],
+            on_success=lambda conn: None,
+            on_failure=lambda _, msg: print(f"Connection failed: {msg}"),
+            timeout=datetime.timedelta(seconds=3),
+        )
+        req = notify_request(sk, ts, True, [-5, 0, 23], netid=3)
+        registered.append(
+            o.request_future(
+                c,
+                "monitor.messages",
+                bt_serialize(req),
+                request_timeout=datetime.timedelta(seconds=7),
+            )
+        )
+
+    registered = [r.get() for r in registered]
+    assert registered == [[b'd7:successi1ee']] * len(registered)
+
+
+def test_monitor_reg_session(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk)
+
+    o = oxenmq.OxenMQ()
+    o.start()
+    ts = int(time.time())
+    registered = []
+    for snode in swarm['snodes']:
+        snode['addr'] = oxenmq.Address(
+            f"curve://{snode['ip']}:{snode['port_omq']}/{snode['pubkey_x25519']}"
+        )
+        c = o.connect_remote(
+            snode['addr'],
+            on_success=lambda conn: None,
+            on_failure=lambda _, msg: print(f"Connection failed: {msg}"),
+            timeout=datetime.timedelta(seconds=3),
+        )
+        req = notify_request(sk, ts, True, [-5, 0, 23], netid=5, sessionid=True)
+        registered.append(
+            o.request_future(
+                c,
+                "monitor.messages",
+                bt_serialize(req),
+                request_timeout=datetime.timedelta(seconds=7),
+            )
+        )
+
+    registered = [r.get() for r in registered]
+    assert registered == [[b'd7:successi1ee']] * len(registered)
+
+
+def test_monitor_reg_subkey(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk)
+
+    # Highly random subkey value:
+    subk = b'abcdefghijklmnopqrstuvwxyzomg123'
+    o = oxenmq.OxenMQ()
+    o.start()
+    ts = int(time.time())
+    registered = []
+    for snode in swarm['snodes']:
+        snode['addr'] = oxenmq.Address(
+            f"curve://{snode['ip']}:{snode['port_omq']}/{snode['pubkey_x25519']}"
+        )
+        c = o.connect_remote(
+            snode['addr'],
+            on_success=lambda conn: None,
+            on_failure=lambda _, msg: print(f"Connection failed: {msg}"),
+            timeout=datetime.timedelta(seconds=3),
+        )
+        req = notify_request(sk, ts, True, [-5, 0, 23], netid=2, subk=subk)
+        registered.append(
+            o.request_future(
+                c,
+                "monitor.messages",
+                bt_serialize(req),
+                request_timeout=datetime.timedelta(seconds=7),
+            )
+        )
+
+    registered = [r.get() for r in registered]
+    assert registered == [[b'd7:successi1ee']] * len(registered)
+
+
+def test_monitor_push(omq, random_sn, sk, exclude):
+    swarm = ss.get_swarm(omq, random_sn, sk)
+
+    conns = {}
+
+    n_notifies = 0
+
+    def handle_notify_message(m):
+        nonlocal conns, n_notifies
+        snode = conns[m.conn]
+        print(f"got notify from {snode['pubkey_legacy']} at {time.time()}")
+        conns[m.conn]['response'].append(bt_deserialize(m.data()[0]))
+        n_notifies += 1
+
+    # We need to make our own OMQ because we need to add the cat/command for notifies
+    o = oxenmq.OxenMQ()
+    o.max_message_size = 10 * 1024 * 1024
+    notify = o.add_category('notify', oxenmq.AuthLevel.none)
+    notify.add_command("message", handle_notify_message)
+    o.start()
+
+    ts = int(time.time())
+    registered = []
+    for snode in swarm['snodes']:
+        snode['response'] = []
+        c = o.connect_remote(
+            oxenmq.Address(f"curve://{snode['ip']}:{snode['port_omq']}/{snode['pubkey_x25519']}"),
+            on_success=lambda conn: connected.add(conn),
+            on_failure=lambda _, msg: print(f"Connection failed: {msg}"),
+        )
+        snode['conn'] = c
+        conns[c] = snode
+
+        registered.append(
+            o.request_future(
+                c,
+                "monitor.messages",
+                bt_serialize(notify_request(sk, ts, True, [-5, 0, 23], netid=3)),
+                request_timeout=datetime.timedelta(seconds=5),
+            )
+        )
+
+    registered = [r.get() for r in registered]
+    assert registered == [[b'd7:successi1ee']] * len(registered)
+
+    # Now go send a message:
+    sn = ss.random_swarm_members(swarm, 1, exclude)[0]
+    conn = omq.connect_remote(sn_address(sn))
+
+    print(f"starting store at {time.time()}")
+    ts = int(time.time() * 1000)
+    ttl = 86400000
+    exp = ts + ttl
+    # Store a message for myself
+    s = omq.request_future(
+        conn,
+        'storage.store',
+        [
+            json.dumps(
+                {
+                    "pubkey": '03' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "ttl": ttl,
+                    "data": base64.b64encode("abc 123".encode()).decode(),
+                }
+            ).encode()
+        ],
+    )
+
+    # And another, but this one in a non-monitored namespace:
+    s2 = omq.request_future(
+        conn,
+        'storage.store',
+        [
+            json.dumps(
+                {
+                    "pubkey": '03' + sk.verify_key.encode().hex(),
+                    "timestamp": ts,
+                    "namespace": 123,
+                    "ttl": ttl,
+                    "data": base64.b64encode("abc 123".encode()).decode(),
+                }
+            ).encode()
+        ],
+    )
+
+
+    # It's pretty rare that we don't get all the responses before the store responses (since they
+    # don't have to be onion-routed back to us), but give it a couple seconds anyway.
+    s = s.get()
+    print(f"got store response at {time.time()}")
+    assert len(s) == 1
+    s = json.loads(s[0])
+    hash = (
+        blake2b(
+            "{}{}".format(ts, exp).encode() + b'\x03' + sk.verify_key.encode() + b'abc 123',
+            encoder=Base64Encoder,
+        )
+        .decode()
+        .rstrip('=')
+    )
+    assert [v['hash'] for v in s['swarm'].values()] == [hash] * len(s['swarm'])
+
+    s2 = s2.get()
+
+    tries = 0
+    while n_notifies < len(swarm['snodes']) and tries < 8:
+        time.sleep(0.25)
+        tries += 1
+
+    expected_notify = {
+        b'@': b'\x03' + sk.verify_key.encode(),
+        b'h': hash.encode(),
+        b'n': 0,
+        b't': ts,
+        b'z': exp,
+        b'~': b'abc 123',
+    }
+
+    assert [s['response'] for s in swarm['snodes']] == [[expected_notify]] * len(swarm['snodes'])

--- a/network-tests/test_monitor.py
+++ b/network-tests/test_monitor.py
@@ -118,7 +118,7 @@ def test_monitor_reg_session(omq, random_sn, sk, exclude):
 def test_monitor_reg_subkey(omq, random_sn, sk, exclude):
     swarm = ss.get_swarm(omq, random_sn, sk)
 
-    # Highly random subkey value:
+    # Highly random subkey tag:
     subk = b'abcdefghijklmnopqrstuvwxyzomg123'
     o = oxenmq.OxenMQ()
     o.start()

--- a/oxenss/common/namespace.h
+++ b/oxenss/common/namespace.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <type_traits>
+#include "formattable.h"
 
 namespace oxen {
 
@@ -27,5 +28,7 @@ std::string to_string(namespace_id ns);
 
 constexpr auto NAMESPACE_MIN = to_int(namespace_id::Min);
 constexpr auto NAMESPACE_MAX = to_int(namespace_id::Max);
+
+template <> inline constexpr bool to_string_formattable<namespace_id> = true;
 
 }  // namespace oxen

--- a/oxenss/common/namespace.h
+++ b/oxenss/common/namespace.h
@@ -29,6 +29,7 @@ std::string to_string(namespace_id ns);
 constexpr auto NAMESPACE_MIN = to_int(namespace_id::Min);
 constexpr auto NAMESPACE_MAX = to_int(namespace_id::Max);
 
-template <> inline constexpr bool to_string_formattable<namespace_id> = true;
+template <>
+inline constexpr bool to_string_formattable<namespace_id> = true;
 
 }  // namespace oxen

--- a/oxenss/crypto/keys.cpp
+++ b/oxenss/crypto/keys.cpp
@@ -114,7 +114,8 @@ std::array<unsigned char, 32> subkey_verify_key(
         const unsigned char* pubkey, const unsigned char* subkey) {
 
     std::array<unsigned char, 32> subkey_pub;
-    // Need to compute: (c + H("OxenSSSubkey" || c || A)) A and use that instead of A for verification:
+    // Need to compute: (c + H("OxenSSSubkey" || c || A)) A and use that instead of A for
+    // verification:
 
     // H("OxenSSSubkey" || c || A):
     crypto_generichash_state h_state;

--- a/oxenss/crypto/keys.h
+++ b/oxenss/crypto/keys.h
@@ -14,6 +14,8 @@ namespace oxen::crypto {
 
 using namespace std::literals;
 
+constexpr std::string_view SUBKEY_HASH_KEY = "OxenSSSubkey"sv;
+
 namespace detail {
     template <size_t Length>
     inline constexpr std::array<unsigned char, Length> null_bytes = {0};
@@ -90,6 +92,12 @@ using x25519_keypair = std::pair<x25519_pubkey, x25519_seckey>;
 legacy_pubkey parse_legacy_pubkey(std::string_view pubkey_in);
 ed25519_pubkey parse_ed25519_pubkey(std::string_view pubkey_in);
 x25519_pubkey parse_x25519_pubkey(std::string_view pubkey_in);
+
+/// Computes the signature verification derived pubkey for a pubkey+subkey string.  Throws
+/// std::invalid_argument if the pubkey/subkey aren't valid.
+std::array<unsigned char, 32> subkey_verify_key(std::string_view pubkey, std::string_view subkey);
+std::array<unsigned char, 32> subkey_verify_key(
+        const unsigned char* pubkey, const unsigned char* subkey);
 
 }  // namespace oxen::crypto
 

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -24,8 +24,6 @@ namespace oxen::rpc {
 
 using namespace std::literals;
 
-constexpr std::string_view SUBKEY_HASH_KEY = "OxenSSSubkey"sv;
-
 // Client rpc endpoints, accessible via the HTTPS storage_rpc endpoint, the OMQ
 // "storage.whatever" endpoints, and as the final target of an onion request.
 

--- a/oxenss/server/CMakeLists.txt
+++ b/oxenss/server/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(server STATIC
     https.cpp
     omq.cpp
     omq_logger.cpp
+    omq_monitor.cpp
     server_certificates.cpp)
 
 find_package(Threads)

--- a/oxenss/server/omq.h
+++ b/oxenss/server/omq.h
@@ -2,15 +2,18 @@
 
 #include <cstdint>
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include <nlohmann/json_fwd.hpp>
 #include <oxenc/bt_serialize.h>
 #include <oxenmq/oxenmq.h>
 
-#include <oxenss/snode/sn_record.h>
+#include "../common/message.h"
+#include "../snode/sn_record.h"
 
 namespace oxen::rpc {
 class RequestHandler;
@@ -25,10 +28,35 @@ class ServiceNode;
 
 namespace oxen::server {
 
+using namespace std::literals;
+
 oxenc::bt_value json_to_bt(nlohmann::json j);
 
 nlohmann::json bt_to_json(oxenc::bt_dict_consumer d);
 nlohmann::json bt_to_json(oxenc::bt_list_consumer l);
+
+struct MonitorData {
+    static constexpr auto MONITOR_EXPIRY_TIME = 65min;
+
+    std::chrono::steady_clock::time_point expiry;  // When this notify reg expires
+    std::vector<namespace_id> namespaces;          // sorted namespace_ids
+    oxenmq::ConnectionID push_conn;                // ConnectionID to push notifications to
+    bool want_data;                                // true if the subscriber wants msg data
+
+    MonitorData(
+            std::vector<namespace_id> namespaces,
+            oxenmq::ConnectionID conn,
+            bool data,
+            std::chrono::seconds ttl = MONITOR_EXPIRY_TIME) :
+            expiry{std::chrono::steady_clock::now() + ttl},
+            namespaces{std::move(namespaces)},
+            push_conn{std::move(conn)},
+            want_data{data} {}
+
+    void reset_expiry(std::chrono::seconds ttl = MONITOR_EXPIRY_TIME) {
+        expiry = std::chrono::steady_clock::now() + ttl;
+    }
+};
 
 class OMQ {
     oxenmq::OxenMQ omq_;
@@ -40,6 +68,10 @@ class OMQ {
     rpc::RequestHandler* request_handler_ = nullptr;
 
     rpc::RateLimiter* rate_limiter_ = nullptr;
+
+    // Tracks accounts we are monitoring for OMQ push notification messages
+    std::unordered_multimap<std::string, MonitorData> monitoring_;
+    mutable std::shared_mutex monitoring_mutex_;
 
     // Get node's address
     std::string peer_lookup(std::string_view pubkey_bin) const;
@@ -82,6 +114,72 @@ class OMQ {
     /// argument list.
     void handle_client_request(
             std::string_view method, oxenmq::Message& message, bool forwarded = false);
+
+    /// Handles a subscription request to monitor new messages (OMQ endpoint monitor.messages).  The
+    /// message body must be bt-encoded, and contains the following keys.  Note that keys are
+    /// case-sensitive and, for proper bt-encoding, must be in ascii-sorted order (rather than the
+    /// order described here).  Keys are:
+    /// - exactly one of:
+    ///   - p -- the account public key, prefixed with the netid, in bytes (33 bytes).  This should
+    ///     be used for pubkeys that are ed keys (but not 05 session ids, see the next entry)
+    ///   - P -- an ed25519 pubkey underlying a session ID, in bytes (32 bytes).  The account
+    ///     will be derived by converting to an x25519 pubkey and prepending the 0x05 byte.  The
+    ///     signature uses *this* key, not the derived x25519 key.
+    /// - S -- (optional) a 32-byte authentication subkey to use for authentication.  The
+    ///   signature with such a subkey uses a derived key (as described in the RPC endpoint
+    ///   documentation).
+    /// - n -- list of namespace ids to monitor for new messages; the ids must be valid (i.e. -32768
+    ///   through 32767), must be sorted in numeric order, and must contain no duplicates.
+    /// - d -- set to 1 if the caller wants the full message data, 0 (or omitted) will omit the data
+    ///   from notifications.
+    /// - t -- signature timestamp, in integer unix seconds (*not* milliseconds), associated with
+    ///   the signature.  This timestamp must be within the last 2 weeks (and no more than 1 day in
+    ///   the future) for this request to be valid.
+    /// - s -- the signature associated with this message.  This is an Ed25519 signature of the
+    ///   value:
+    ///       ( "MONITOR" || ACCOUNT || TS || D || NS[0] || "," || ... || "," || NS[n] )
+    ///   signed by the account Ed25519 key or derived subkey (if using subkey):
+    ///   - ACCOUNT is the full account ID, expressed in hex (e.g. "0512345...").
+    ///   - TS is the signature timestamp value, expressed as a base-10 string
+    ///   - D is "0" or "1" depending on whether data is wanted (i.e. the "d" request parameter)
+    ///   - NS[i] are the namespace values from the request expressed as base-10 strings
+    ///
+    /// If the request validates then the connection is subscribed (for 65 minutes) to new incoming
+    /// messages in the given namespace(s).  A caller should renew subscriptions periodically by
+    /// re-submitting the subscription request (with at most 1h between re-subscriptions).
+    ///
+    /// The reply to the subscription request is a bencoded dict containing keys:
+    /// - success -- included on successful subscription and set to the integer 1
+    /// - errcode -- a numeric error value indicating the failure.  Currently implemented are:
+    ///   - 1 -- invalid arguments -- called for invalid data (e.g. wrong encoding, wrong value
+    ///     type, or a missing required parameter)
+    ///   - 2 -- invalid pubkey -- the given pubkey/session id is not a valid pubkey.
+    ///   - 3 -- invalid namespace -- the namespaces provided are invalid (e.g. invalid value, not
+    ///     sorted, or contains duplicates).
+    ///   - 4 -- invalid timestamp -- the timestamp is not a valid integral timestamp, is too old,
+    ///     or is in the future.
+    ///   - 5 -- signature failed -- the signature failed to validate.
+    ///   - 6 -- wrong swarm -- the given pubkey is not stored by this service node's swarm.
+    /// - error -- included whenever `errcode` is, this contains an English description of the
+    ///   error.
+    ///
+    /// Each time a message is received the service node sends a message to the connection with a
+    /// first part (i.e. endpoint) of "notify.message", and second part containing the bt-encoded
+    /// message details in a dict with keys:
+    ///
+    /// - @ -- the account pubkey, in bytes (33).  This is the actual account value, regardless of
+    ///   which of `p`/`P`/`S` was used in the request.  (Symbol so that it sorts very early).
+    /// - h -- the message hash
+    /// - n -- the message namespace (-32768 to 32767)
+    /// - t -- the message timestamp (milliseconds since unix epoch), as provided by the client who
+    ///   deposited the message.
+    /// - z -- the expiry (milliseconds since unix epoch) of the message.
+    /// - ~d -- the message data.  Note that this is only included if it was requested by specifying
+    ///   `d` as 1 in the subscription request.  (This is `~d` rather than `d` to put it at the end
+    ///   of the dict, which makes construction here a little easier).
+    ///
+    /// Note that the client should accept (and ignore) unknown keys, to allow for future expansion.
+    void handle_monitor_messages(oxenmq::Message& message);
 
     void handle_get_logs(oxenmq::Message& message);
 
@@ -137,6 +235,9 @@ class OMQ {
     // Decodes onion request data; throws if invalid formatted or missing required fields.
     static std::pair<std::string_view, rpc::OnionRequestMetadata> decode_onion_data(
             std::string_view data);
+
+    // Called during message submission to send notifications to anyone subscribed to them.
+    void send_notifies(message msg);
 };
 
 }  // namespace oxen::server

--- a/oxenss/server/omq.h
+++ b/oxenss/server/omq.h
@@ -130,8 +130,8 @@ class OMQ {
     ///   - P -- an ed25519 pubkey underlying a session ID, in bytes (32 bytes).  The account
     ///     will be derived by converting to an x25519 pubkey and prepending the 0x05 byte.  The
     ///     signature uses *this* key, not the derived x25519 key.
-    /// - S -- (optional) a 32-byte authentication subkey to use for authentication.  The
-    ///   signature with such a subkey uses a derived key (as described in the RPC endpoint
+    /// - S -- (optional) a 32-byte authentication subkey tag to use for authentication.  The
+    ///   signature with such a subkey tag uses a derived subkey (as described in the RPC endpoint
     ///   documentation).
     /// - n -- list of namespace ids to monitor for new messages; the ids must be valid (i.e. -32768
     ///   through 32767), must be sorted in numeric order, and must contain no duplicates.
@@ -143,7 +143,7 @@ class OMQ {
     /// - s -- the signature associated with this message.  This is an Ed25519 signature of the
     ///   value:
     ///       ( "MONITOR" || ACCOUNT || TS || D || NS[0] || "," || ... || "," || NS[n] )
-    ///   signed by the account Ed25519 key or derived subkey (if using subkey):
+    ///   signed by the account Ed25519 key or derived subkey (if using a subkey tag):
     ///   - ACCOUNT is the full account ID, expressed in hex (e.g. "0512345...").
     ///   - TS is the signature timestamp value, expressed as a base-10 string
     ///   - D is "0" or "1" depending on whether data is wanted (i.e. the "d" request parameter)

--- a/oxenss/server/omq.h
+++ b/oxenss/server/omq.h
@@ -116,9 +116,14 @@ class OMQ {
             std::string_view method, oxenmq::Message& message, bool forwarded = false);
 
     /// Handles a subscription request to monitor new messages (OMQ endpoint monitor.messages).  The
-    /// message body must be bt-encoded, and contains the following keys.  Note that keys are
-    /// case-sensitive and, for proper bt-encoding, must be in ascii-sorted order (rather than the
-    /// order described here).  Keys are:
+    /// message body must be bt-encoded, and can be either a dict, or a list of dicts, containing
+    /// the following keys.  Note that keys are case-sensitive and, for proper bt-encoding, must be
+    /// in ascii-sorted order (rather than the order described here).
+    ///
+    /// The list of dicts mode is primarily intended to batch multiple subscription requests
+    /// together
+    ///
+    /// Keys are:
     /// - exactly one of:
     ///   - p -- the account public key, prefixed with the netid, in bytes (33 bytes).  This should
     ///     be used for pubkeys that are ed keys (but not 05 session ids, see the next entry)
@@ -148,7 +153,10 @@ class OMQ {
     /// messages in the given namespace(s).  A caller should renew subscriptions periodically by
     /// re-submitting the subscription request (with at most 1h between re-subscriptions).
     ///
-    /// The reply to the subscription request is a bencoded dict containing keys:
+    /// The reply to the subscription request is either a bencoded dict or list of dicts containing
+    /// the following keys.  In the case of a list of subscriptions in the request, the returned
+    /// list will be the same length with the ith element corresponding to the ith element of the
+    /// input.
     /// - success -- included on successful subscription and set to the integer 1
     /// - errcode -- a numeric error value indicating the failure.  Currently implemented are:
     ///   - 1 -- invalid arguments -- called for invalid data (e.g. wrong encoding, wrong value

--- a/oxenss/server/omq_monitor.cpp
+++ b/oxenss/server/omq_monitor.cpp
@@ -30,208 +30,241 @@ namespace {
         WRONG_SWARM = 6,
     };
 
-    void monitor_error(oxenmq::Message& m, MonitorResponse r, std::string_view message) {
-        std::string buf;
-        buf.resize(message.size() + 30);
-        oxenc::bt_dict_producer d{buf.data(), buf.size()};
-        d.append("errcode", static_cast<std::underlying_type_t<MonitorResponse>>(r));
-        d.append("error", message);
-        buf.resize(d.view().size());
-        m.send_reply(buf);
+    void monitor_error(oxenc::bt_dict_producer& out, MonitorResponse r, std::string message) {
+        out.append("errcode", static_cast<std::underlying_type_t<MonitorResponse>>(r));
+        out.append("error", std::move(message));
+    }
+
+    // {pubkey (bytes), pubkey (hex), namespaces, want_data}
+    using sub_info = std::tuple<std::string, std::string, std::vector<namespace_id>, bool>;
+
+    void handle_monitor_message_single(
+            oxenc::bt_dict_consumer d, oxenc::bt_dict_producer& out, std::vector<sub_info>& subs) {
+
+        // Values we receive, in bt-dict order:
+        std::string_view ed_pk;   // P
+        std::string_view subkey;  // S
+        bool want_data = false;   // d
+        using namespace_int = std::underlying_type_t<namespace_id>;
+        std::vector<namespace_id> namespaces;  // n
+        std::string pubkey;                    // p
+        std::string_view signature;            // s
+        std::chrono::seconds timestamp;        // t
+
+        try {
+            // Ed25519 pubkey for a Session ID (required if `p` is not present)
+            if (d.skip_until("P")) {
+                ed_pk = d.consume_string_view();
+                if (ed_pk.size() != 32)
+                    return monitor_error(
+                            out,
+                            MonitorResponse::BAD_PUBKEY,
+                            "Provided P= Session Ed25519 pubkey must be 32 bytes");
+            }
+
+            // Subkey for subkey auth (optional)
+            if (d.skip_until("S")) {
+                subkey = d.consume_string_view();
+                if (subkey.size() != 32)
+                    return monitor_error(
+                            out,
+                            MonitorResponse::BAD_PUBKEY,
+                            "Provided S= subkey must be 32 bytes");
+            }
+
+            // Send full data (optional)
+            if (d.skip_until("d"))
+                want_data = d.consume_integer<bool>();
+
+            // List of namespaces to monitor (required)
+            if (d.skip_until("n")) {
+                auto ns = d.consume_list_consumer();
+                namespaces.push_back(
+                        static_cast<namespace_id>(ns.consume_integer<namespace_int>()));
+                while (!ns.is_finished()) {
+                    auto nsi = static_cast<namespace_id>(ns.consume_integer<namespace_int>());
+                    if (nsi > namespaces.back())
+                        namespaces.push_back(nsi);
+                    else
+                        return monitor_error(
+                                out,
+                                MonitorResponse::BAD_NS,
+                                "Invalid n= namespace list: namespaces must be ascending");
+                }
+            } else {
+                throw std::runtime_error{"required namespace list is missing"};
+            }
+
+            if (d.skip_until("p")) {
+                if (!ed_pk.empty())
+                    throw std::runtime_error{"Cannot provide both p= and P= pubkey values"};
+                pubkey = d.consume_string();
+                if (pubkey.size() != 33)
+                    monitor_error(
+                            out,
+                            MonitorResponse::BAD_PUBKEY,
+                            "Provided p= pubkey must be 33 bytes");
+            } else if (ed_pk.empty()) {
+                throw std::runtime_error{"Either p= or P= must be given"};
+            }
+
+            if (!d.skip_until("s"))
+                throw std::runtime_error{"required signature is missing"};
+            signature = d.consume_string_view();
+            if (signature.size() != 64)
+                return monitor_error(
+                        out, MonitorResponse::BAD_SIG, "Provided s= signature must be 64 bytes");
+
+            if (!d.skip_until("t"))
+                throw std::runtime_error{"required signature timestamp is missing"};
+            timestamp = std::chrono::seconds{d.consume_integer<int64_t>()};
+
+        } catch (const std::exception& ex) {
+            return monitor_error(
+                    out,
+                    MonitorResponse::BAD_ARGS,
+                    fmt::format("Invalid arguments: invalid {}= value: {}", d.key(), ex.what()));
+        }
+
+        // Make sure the sig timestamp isn't too old or too new
+        auto now = std::chrono::system_clock::now();
+        auto ts = std::chrono::system_clock::time_point(timestamp);
+        if (bool too_old = ts < now - 14 * 24h; too_old || ts > now + 24h) {
+            return monitor_error(
+                    out,
+                    MonitorResponse::BAD_TS,
+                    "Invalid t= signature timestamp: timestamp is "s +
+                            (too_old ? "too old" : "in the future"));
+        }
+
+        // If given an Ed25519 pubkey for a Session ID, derive the Session ID
+        if (!ed_pk.empty()) {
+            pubkey.resize(33);
+            pubkey[0] = 0x05;
+            if (auto rc = crypto_sign_ed25519_pk_to_curve25519(
+                        reinterpret_cast<unsigned char*>(pubkey.data() + 1),
+                        reinterpret_cast<const unsigned char*>(ed_pk.data()));
+                rc != 0)
+                return monitor_error(
+                        out, MonitorResponse::BAD_PUBKEY, "Invalid P= ed25519 public key");
+        } else {
+            // No Session Ed25519, so assume the pubkey (without prefix byte) is Ed25519
+            ed_pk = pubkey;
+            ed_pk.remove_prefix(1);
+        }
+
+        std::string_view verify_key = ed_pk;
+        std::array<unsigned char, 32> subkey_pub;
+        if (!subkey.empty()) {
+            try {
+                subkey_pub = crypto::subkey_verify_key(ed_pk, subkey);
+            } catch (const std::invalid_argument& ex) {
+                auto m = fmt::format("Signature verification failed: {}", ex.what());
+                log::warning(logcat, "{}", m);
+                return monitor_error(out, MonitorResponse::BAD_SIG, m);
+            }
+            verify_key = std::string_view{
+                    reinterpret_cast<const char*>(subkey_pub.data()), subkey_pub.size()};
+        }
+        assert(verify_key.size() == 32);
+
+        auto pubkey_hex = oxenc::to_hex(pubkey);
+
+        auto sig_msg = fmt::format(
+                "MONITOR{:s}{:d}{:d}{}",
+                pubkey_hex,
+                timestamp.count(),
+                want_data,
+                fmt::join(namespaces, ","));
+
+        if (0 != crypto_sign_verify_detached(
+                         reinterpret_cast<const unsigned char*>(signature.data()),
+                         reinterpret_cast<const unsigned char*>(sig_msg.data()),
+                         sig_msg.size(),
+                         reinterpret_cast<const unsigned char*>(verify_key.data()))) {
+            log::debug(logcat, "monitor.messages signature verification failed");
+            return monitor_error(out, MonitorResponse::BAD_SIG, "Signature verification failed");
+        }
+
+        subs.emplace_back(
+                std::move(pubkey), std::move(pubkey_hex), std::move(namespaces), want_data);
+        out.append("success", 1);
     }
 
 }  // namespace
 
 void OMQ::handle_monitor_messages(oxenmq::Message& message) {
-    if (message.data.size() != 1)
-        return monitor_error(
-                message,
-                MonitorResponse::BAD_ARGS,
-                "Invalid arguments: monitor.messages takes a single bencoded dict parameter");
+    if (message.data.size() != 1 || message.data[0].size() < 2 ||
+        !(message.data[0].front() == 'd' || message.data[0].front() == 'l') ||
+        message.data[0].back() != 'e') {
+        message.send_reply(oxenc::bt_serialize(oxenc::bt_dict{
+                {"errcode", static_cast<int>(MonitorResponse::BAD_ARGS)},
+                {"error",
+                 "Invalid arguments: monitor.messages takes a single bencoded dict/list "
+                 "parameter"}}));
+        return;
+    }
     const auto& m = message.data[0];
-    if (m.size() < 2 || m.front() != 'd')
-        return monitor_error(
-                message,
-                MonitorResponse::BAD_ARGS,
-                "Invalid arguments: monitor.messages parameter must be a bencoded dict");
-    oxenc::bt_dict_consumer d{m};
 
-    // Values we receive, in bt-dict order:
-    std::string_view ed_pk;   // P
-    std::string_view subkey;  // S
-    bool want_data = false;   // d
-    using namespace_int = std::underlying_type_t<namespace_id>;
-    std::vector<namespace_id> namespaces;  // n
-    std::string pubkey;                    // p
-    std::string_view signature;            // s
-    std::chrono::seconds timestamp;        // t
-
+    std::string result;
+    std::vector<sub_info> subs;
     try {
-        // Ed25519 pubkey for a Session ID (required if `p` is not present)
-        if (d.skip_until("P")) {
-            ed_pk = d.consume_string_view();
-            if (ed_pk.size() != 32)
-                return monitor_error(
-                        message,
-                        MonitorResponse::BAD_PUBKEY,
-                        "Provided P= Session Ed25519 pubkey must be 32 bytes");
-        }
-
-        // Subkey for subkey auth (optional)
-        if (d.skip_until("S")) {
-            subkey = d.consume_string_view();
-            if (subkey.size() != 32)
-                return monitor_error(
-                        message,
-                        MonitorResponse::BAD_PUBKEY,
-                        "Provided S= subkey must be 32 bytes");
-        }
-
-        // Send full data (optional)
-        if (d.skip_until("d"))
-            want_data = d.consume_integer<bool>();
-
-        // List of namespaces to monitor (required)
-        if (d.skip_until("n")) {
-            auto ns = d.consume_list_consumer();
-            namespaces.push_back(static_cast<namespace_id>(ns.consume_integer<namespace_int>()));
-            while (!ns.is_finished()) {
-                auto nsi = static_cast<namespace_id>(ns.consume_integer<namespace_int>());
-                if (nsi > namespaces.back())
-                    namespaces.push_back(nsi);
-                else
-                    return monitor_error(
-                            message,
-                            MonitorResponse::BAD_NS,
-                            "Invalid n= namespace list: namespaces must be ascending");
-            }
+        if (m.front() == 'd') {
+            result.resize(256);
+            oxenc::bt_dict_producer out{result.data(), result.size()};
+            handle_monitor_message_single(oxenc::bt_dict_consumer{m}, out, subs);
+            result.resize(out.view().size());
         } else {
-            throw std::runtime_error{"required namespace list is missing"};
+            result += 'l';
+            oxenc::bt_list_consumer l{m};
+            std::array<char, 256> buf;
+            while (!l.is_finished()) {
+                oxenc::bt_dict_producer out{buf.data(), buf.size()};
+                handle_monitor_message_single(l.consume_dict_consumer(), out, subs);
+                result.append(out.view());
+            }
+            result += 'e';
         }
-
-        if (d.skip_until("p")) {
-            if (!ed_pk.empty())
-                throw std::runtime_error{"Cannot provide both p= and P= pubkey values"};
-            pubkey = d.consume_string();
-            if (pubkey.size() != 33)
-                monitor_error(
-                        message,
-                        MonitorResponse::BAD_PUBKEY,
-                        "Provided p= pubkey must be 33 bytes");
-        } else if (ed_pk.empty()) {
-            throw std::runtime_error{"Either p= or P= must be given"};
-        }
-
-        if (!d.skip_until("s"))
-            throw std::runtime_error{"required signature is missing"};
-        signature = d.consume_string_view();
-        if (signature.size() != 64)
-            return monitor_error(
-                    message, MonitorResponse::BAD_SIG, "Provided s= signature must be 64 bytes");
-
-        if (!d.skip_until("t"))
-            throw std::runtime_error{"required signature timestamp is missing"};
-        timestamp = std::chrono::seconds{d.consume_integer<int64_t>()};
-
-    } catch (const std::exception& ex) {
-        return monitor_error(
-                message,
-                MonitorResponse::BAD_ARGS,
-                fmt::format("Invalid arguments: invalid {}= value: {}", d.key(), ex.what()));
+    } catch (const std::exception& e) {
+        message.send_reply(oxenc::bt_serialize(oxenc::bt_dict{
+                {"errcode", static_cast<int>(MonitorResponse::BAD_ARGS)},
+                {"error", "Invalid arguments: Failed to parse monitor.messages data value"}}));
+        return;
     }
 
-    // Make sure the sig timestamp isn't too old or too new
-    auto now = std::chrono::system_clock::now();
-    auto ts = std::chrono::system_clock::time_point(timestamp);
-    if (bool too_old = ts < now - 14 * 24h; too_old || ts > now + 24h) {
-        return monitor_error(
-                message,
-                MonitorResponse::BAD_TS,
-                "Invalid t= signature timestamp: timestamp is "s +
-                        (too_old ? "too old" : "in the future"));
-    }
-
-    // If given an Ed25519 pubkey for a Session ID, derive the Session ID
-    if (!ed_pk.empty()) {
-        pubkey.resize(33);
-        pubkey[0] = 0x05;
-        if (auto rc = crypto_sign_ed25519_pk_to_curve25519(
-                    reinterpret_cast<unsigned char*>(pubkey.data() + 1),
-                    reinterpret_cast<const unsigned char*>(ed_pk.data()));
-            rc != 0)
-            return monitor_error(
-                    message, MonitorResponse::BAD_PUBKEY, "Invalid P= ed25519 public key");
-    } else {
-        // No Session Ed25519, so assume the pubkey (without prefix byte) is Ed25519
-        ed_pk = pubkey;
-        ed_pk.remove_prefix(1);
-    }
-
-    std::string_view verify_key = ed_pk;
-    std::array<unsigned char, 32> subkey_pub;
-    if (!subkey.empty()) {
-        try {
-            subkey_pub = crypto::subkey_verify_key(ed_pk, subkey);
-        } catch (const std::invalid_argument& ex) {
-            auto m = fmt::format("Signature verification failed: {}", ex.what());
-            log::warning(logcat, "{}", m);
-            return monitor_error(message, MonitorResponse::BAD_SIG, m);
-        }
-        verify_key = std::string_view{
-                reinterpret_cast<const char*>(subkey_pub.data()), subkey_pub.size()};
-    }
-    assert(verify_key.size() == 32);
-
-    auto pubkey_hex = oxenc::to_hex(pubkey);
-
-    auto sig_msg = fmt::format(
-            "MONITOR{:s}{:d}{:d}{}",
-            pubkey_hex,
-            timestamp.count(),
-            want_data,
-            fmt::join(namespaces, ","));
-
-    if (0 != crypto_sign_verify_detached(
-                     reinterpret_cast<const unsigned char*>(signature.data()),
-                     reinterpret_cast<const unsigned char*>(sig_msg.data()),
-                     sig_msg.size(),
-                     reinterpret_cast<const unsigned char*>(verify_key.data()))) {
-        log::debug(logcat, "monitor.messages signature verification failed");
-        return monitor_error(message, MonitorResponse::BAD_SIG, "Signature verification failed");
-    }
-
-    {
+    if (!subs.empty()) {
         std::unique_lock lock{monitoring_mutex_};
-        bool found = false;
-        for (auto [it, end] = monitoring_.equal_range(pubkey); it != end; ++it) {
-            auto& mon_data = it->second;
-            if (mon_data.push_conn == message.conn) {
+        for (auto& [pubkey, pubkey_hex, namespaces, want_data] : subs) {
+            bool found = false;
+            for (auto [it, end] = monitoring_.equal_range(pubkey); it != end; ++it) {
+                auto& mon_data = it->second;
+                if (mon_data.push_conn == message.conn) {
+                    log::debug(
+                            logcat,
+                            "monitor.messages sub renewed for {} monitoring namespace(s) {}",
+                            pubkey_hex,
+                            fmt::join(namespaces, ", "));
+                    mon_data.reset_expiry();
+                    mon_data.namespaces = std::move(namespaces);
+                    mon_data.want_data = want_data;
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
                 log::debug(
                         logcat,
-                        "monitor.messages subscription renewed for {} monitoring namespace(s) {}",
+                        "monitor.messages new subscription for {} monitoring namespace(s) {}",
                         pubkey_hex,
                         fmt::join(namespaces, ", "));
-                mon_data.reset_expiry();
-                mon_data.namespaces = std::move(namespaces);
-                mon_data.want_data = want_data;
-                found = true;
-                break;
+                monitoring_.emplace(
+                        std::piecewise_construct,
+                        std::forward_as_tuple(std::move(pubkey)),
+                        std::forward_as_tuple(std::move(namespaces), message.conn, want_data));
             }
         }
-        if (!found) {
-            log::debug(
-                    logcat,
-                    "monitor.messages new subscription for {} monitoring namespace(s) {}",
-                    pubkey_hex,
-                    fmt::join(namespaces, ", "));
-            monitoring_.emplace(
-                    std::piecewise_construct,
-                    std::forward_as_tuple(pubkey),
-                    std::forward_as_tuple(std::move(namespaces), message.conn, want_data));
-        }
     }
-
-    message.send_reply("d7:successi1ee");
+    message.send_reply(result);
 }
 
 static void write_metadata(

--- a/oxenss/server/omq_monitor.cpp
+++ b/oxenss/server/omq_monitor.cpp
@@ -1,0 +1,307 @@
+#include "omq.h"
+#include "../common/namespace.h"
+#include "../rpc/client_rpc_endpoints.h"
+#include "../utils/time.hpp"
+
+#include <chrono>
+#include <oxen/log.hpp>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <oxenc/bt_producer.h>
+#include <oxenc/hex.h>
+#include <sodium/crypto_sign.h>
+#include <sodium/crypto_sign_ed25519.h>
+
+namespace oxen::server {
+
+using namespace std::literals;
+
+static auto logcat = log::Cat("monitor");
+
+namespace {
+
+    enum class MonitorResponse {
+        BAD_ARGS = 1,
+        BAD_PUBKEY = 2,
+        BAD_NS = 3,
+        BAD_TS = 4,
+        BAD_SIG = 5,
+        WRONG_SWARM = 6,
+    };
+
+    void monitor_error(oxenmq::Message& m, MonitorResponse r, std::string_view message) {
+        std::string buf;
+        buf.resize(message.size() + 30);
+        oxenc::bt_dict_producer d{buf.data(), buf.size()};
+        d.append("errcode", static_cast<std::underlying_type_t<MonitorResponse>>(r));
+        d.append("error", message);
+        buf.resize(d.view().size());
+        m.send_reply(buf);
+    }
+
+}  // namespace
+
+void OMQ::handle_monitor_messages(oxenmq::Message& message) {
+    if (message.data.size() != 1)
+        return monitor_error(
+                message,
+                MonitorResponse::BAD_ARGS,
+                "Invalid arguments: monitor.messages takes a single bencoded dict parameter");
+    const auto& m = message.data[0];
+    if (m.size() < 2 || m.front() != 'd')
+        return monitor_error(
+                message,
+                MonitorResponse::BAD_ARGS,
+                "Invalid arguments: monitor.messages parameter must be a bencoded dict");
+    oxenc::bt_dict_consumer d{m};
+
+    // Values we receive, in bt-dict order:
+    std::string_view ed_pk;   // P
+    std::string_view subkey;  // S
+    bool want_data = false;   // d
+    using namespace_int = std::underlying_type_t<namespace_id>;
+    std::vector<namespace_id> namespaces;  // n
+    std::string pubkey;                    // p
+    std::string_view signature;            // s
+    std::chrono::seconds timestamp;        // t
+
+    try {
+        // Ed25519 pubkey for a Session ID (required if `p` is not present)
+        if (d.skip_until("P")) {
+            ed_pk = d.consume_string_view();
+            if (ed_pk.size() != 32)
+                return monitor_error(
+                        message,
+                        MonitorResponse::BAD_PUBKEY,
+                        "Provided P= Session Ed25519 pubkey must be 32 bytes");
+        }
+
+        // Subkey for subkey auth (optional)
+        if (d.skip_until("S")) {
+            subkey = d.consume_string_view();
+            if (subkey.size() != 32)
+                return monitor_error(
+                        message,
+                        MonitorResponse::BAD_PUBKEY,
+                        "Provided S= subkey must be 32 bytes");
+        }
+
+        // Send full data (optional)
+        if (d.skip_until("d"))
+            want_data = d.consume_integer<bool>();
+
+        // List of namespaces to monitor (required)
+        if (d.skip_until("n")) {
+            auto ns = d.consume_list_consumer();
+            namespaces.push_back(static_cast<namespace_id>(ns.consume_integer<namespace_int>()));
+            while (!ns.is_finished()) {
+                auto nsi = static_cast<namespace_id>(ns.consume_integer<namespace_int>());
+                if (nsi > namespaces.back())
+                    namespaces.push_back(nsi);
+                else
+                    return monitor_error(
+                            message,
+                            MonitorResponse::BAD_NS,
+                            "Invalid n= namespace list: namespaces must be ascending");
+            }
+        } else {
+            throw std::runtime_error{"required namespace list is missing"};
+        }
+
+        if (d.skip_until("p")) {
+            if (!ed_pk.empty())
+                throw std::runtime_error{"Cannot provide both p= and P= pubkey values"};
+            pubkey = d.consume_string();
+            if (pubkey.size() != 33)
+                monitor_error(
+                        message,
+                        MonitorResponse::BAD_PUBKEY,
+                        "Provided p= pubkey must be 33 bytes");
+        } else if (ed_pk.empty()) {
+            throw std::runtime_error{"Either p= or P= must be given"};
+        }
+
+        if (!d.skip_until("s"))
+            throw std::runtime_error{"required signature is missing"};
+        signature = d.consume_string_view();
+        if (signature.size() != 64)
+            return monitor_error(
+                    message, MonitorResponse::BAD_SIG, "Provided s= signature must be 64 bytes");
+
+        if (!d.skip_until("t"))
+            throw std::runtime_error{"required signature timestamp is missing"};
+        timestamp = std::chrono::seconds{d.consume_integer<int64_t>()};
+
+    } catch (const std::exception& ex) {
+        return monitor_error(
+                message,
+                MonitorResponse::BAD_ARGS,
+                fmt::format("Invalid arguments: invalid {}= value: {}", d.key(), ex.what()));
+    }
+
+    // Make sure the sig timestamp isn't too old or too new
+    auto now = std::chrono::system_clock::now();
+    auto ts = std::chrono::system_clock::time_point(timestamp);
+    if (bool too_old = ts < now - 14 * 24h; too_old || ts > now + 24h) {
+        return monitor_error(
+                message,
+                MonitorResponse::BAD_TS,
+                "Invalid t= signature timestamp: timestamp is "s +
+                        (too_old ? "too old" : "in the future"));
+    }
+
+    // If given an Ed25519 pubkey for a Session ID, derive the Session ID
+    if (!ed_pk.empty()) {
+        pubkey.resize(33);
+        pubkey[0] = 0x05;
+        if (auto rc = crypto_sign_ed25519_pk_to_curve25519(
+                    reinterpret_cast<unsigned char*>(pubkey.data() + 1),
+                    reinterpret_cast<const unsigned char*>(ed_pk.data()));
+            rc != 0)
+            return monitor_error(
+                    message, MonitorResponse::BAD_PUBKEY, "Invalid P= ed25519 public key");
+    } else {
+        // No Session Ed25519, so assume the pubkey (without prefix byte) is Ed25519
+        ed_pk = pubkey;
+        ed_pk.remove_prefix(1);
+    }
+
+    std::string_view verify_key = ed_pk;
+    std::array<unsigned char, 32> subkey_pub;
+    if (!subkey.empty()) {
+        try {
+            subkey_pub = crypto::subkey_verify_key(ed_pk, subkey);
+        } catch (const std::invalid_argument& ex) {
+            auto m = fmt::format("Signature verification failed: {}", ex.what());
+            log::warning(logcat, "{}", m);
+            return monitor_error(message, MonitorResponse::BAD_SIG, m);
+        }
+        verify_key = std::string_view{
+                reinterpret_cast<const char*>(subkey_pub.data()), subkey_pub.size()};
+    }
+    assert(verify_key.size() == 32);
+
+    auto pubkey_hex = oxenc::to_hex(pubkey);
+
+    auto sig_msg = fmt::format(
+            "MONITOR{:s}{:d}{:d}{}",
+            pubkey_hex,
+            timestamp.count(),
+            want_data,
+            fmt::join(namespaces, ","));
+
+    if (0 != crypto_sign_verify_detached(
+                     reinterpret_cast<const unsigned char*>(signature.data()),
+                     reinterpret_cast<const unsigned char*>(sig_msg.data()),
+                     sig_msg.size(),
+                     reinterpret_cast<const unsigned char*>(verify_key.data()))) {
+        log::debug(logcat, "monitor.messages signature verification failed");
+        return monitor_error(message, MonitorResponse::BAD_SIG, "Signature verification failed");
+    }
+
+    {
+        std::unique_lock lock{monitoring_mutex_};
+        bool found = false;
+        for (auto [it, end] = monitoring_.equal_range(pubkey); it != end; ++it) {
+            auto& mon_data = it->second;
+            if (mon_data.push_conn == message.conn) {
+                log::debug(
+                        logcat,
+                        "monitor.messages subscription renewed for {} monitoring namespace(s) {}",
+                        pubkey_hex,
+                        fmt::join(namespaces, ", "));
+                mon_data.reset_expiry();
+                mon_data.namespaces = std::move(namespaces);
+                mon_data.want_data = want_data;
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            log::debug(
+                    logcat,
+                    "monitor.messages new subscription for {} monitoring namespace(s) {}",
+                    pubkey_hex,
+                    fmt::join(namespaces, ", "));
+            monitoring_.emplace(
+                    std::piecewise_construct,
+                    std::forward_as_tuple(pubkey),
+                    std::forward_as_tuple(std::move(namespaces), message.conn, want_data));
+        }
+    }
+
+    message.send_reply("d7:successi1ee");
+}
+
+static void write_metadata(
+        oxenc::bt_dict_producer& d, std::string_view pubkey, const message& msg) {
+    d.append("@", pubkey);
+    d.append("h", msg.hash);
+    d.append("n", to_int(msg.msg_namespace));
+    d.append("t", to_epoch_ms(msg.timestamp));
+    d.append("z", to_epoch_ms(msg.expiry));
+}
+
+void OMQ::send_notifies(message msg) {
+    auto pubkey = msg.pubkey.prefixed_raw();
+    auto now = std::chrono::steady_clock::now();
+    std::vector<oxenmq::ConnectionID> relay_to, relay_to_with_data;
+    {
+        std::shared_lock lock{monitoring_mutex_};
+        for (auto [it, end] = monitoring_.equal_range(pubkey); it != end; ++it) {
+            const auto& mon_data = it->second;
+            if (mon_data.expiry >= now &&
+                std::binary_search(
+                        mon_data.namespaces.begin(), mon_data.namespaces.end(), msg.msg_namespace))
+                (mon_data.want_data ? relay_to_with_data : relay_to).push_back(mon_data.push_conn);
+        }
+    }
+
+    if (relay_to.empty() && relay_to_with_data.empty())
+        return;
+
+    // We output a dict with keys (in order):
+    // - @ pubkey
+    // - h msg hash
+    // - n msg namespace
+    // - t msg timestamp
+    // - z msg expiry
+    // - ~d msg data (optional)
+    constexpr size_t metadata_size = 2       // d...e
+                                   + 3 + 36  // 1:@ and 33:[33-byte pubkey]
+                                   + 3 + 46  // 1:h and 43:[43-byte base64 unpadded hash]
+                                   + 3 + 8   // 1:n and i-32768e
+                                   + 3 + 16  // 1:t and i1658784776010e plus a byte to grow
+                                   + 3 + 16  // 1:z and i1658784776010e plus a byte to grow
+                                   + 10;     // safety margin
+
+    std::string data;
+    if (!relay_to_with_data.empty())
+        data.resize(
+                metadata_size  // all the metadata above
+                + 3            // 1:~
+                + 8            // 76800: plus a couple bytes to grow
+                + msg.data.size());
+    else
+        data.resize(metadata_size);
+
+    if (!relay_to.empty()) {
+        oxenc::bt_dict_producer d{data.data(), data.size()};
+        write_metadata(d, pubkey, msg);
+
+        for (const auto& conn : relay_to)
+            omq_.send(conn, "notify.message", data);
+    }
+
+    if (!relay_to_with_data.empty()) {
+        oxenc::bt_dict_producer d{data.data(), data.size()};
+        write_metadata(d, pubkey, msg);
+        d.append("~", msg.data);
+
+        for (const auto& conn : relay_to_with_data)
+            omq_.send(conn, "notify.message", data);
+    }
+}
+
+}  // namespace oxen::server

--- a/oxenss/server/omq_monitor.cpp
+++ b/oxenss/server/omq_monitor.cpp
@@ -289,6 +289,7 @@ void OMQ::send_notifies(message msg) {
     if (!relay_to.empty()) {
         oxenc::bt_dict_producer d{data.data(), data.size()};
         write_metadata(d, pubkey, msg);
+        data.resize(d.view().size());
 
         for (const auto& conn : relay_to)
             omq_.send(conn, "notify.message", data);
@@ -298,6 +299,7 @@ void OMQ::send_notifies(message msg) {
         oxenc::bt_dict_producer d{data.data(), data.size()};
         write_metadata(d, pubkey, msg);
         d.append("~", msg.data);
+        data.resize(d.view().size());
 
         for (const auto& conn : relay_to_with_data)
             omq_.send(conn, "notify.message", data);

--- a/oxenss/snode/service_node.cpp
+++ b/oxenss/snode/service_node.cpp
@@ -414,8 +414,11 @@ bool ServiceNode::process_store(message msg, bool* new_msg) {
 
     /// store in the database (if not already present)
     auto stored = db_->store(msg);
-    if (stored)
+    if (stored) {
         log::trace(logcat, *stored ? "saved message: {}" : "message already exists: {}", msg.data);
+        if (*stored)
+            omq_server_.send_notifies(std::move(msg));
+    }
     if (new_msg)
         *new_msg = stored.value_or(false);
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 100
+skip-string-normalization = true
+skip-magic-trailing-comma = true
+target-version = ['py38']
+include = 'network-tests/.*\.py$'


### PR DESCRIPTION
This PR adds endpoints to storage server that allows someone to maintain a oxenmq connection to one or more swarm members and receive pushed notifications through that connection when new messages are delivered.

This is authenticated: subscribing requires a signature from the mailbox owner signed within the past 14 days, and connections have to be refreshed at least once/hour to keep the push notifications alive.

The immediate use for this will be for more efficient push notifications for mobile clients using the push notification server, but this mechanism will eventually also allow clients (over lokinet) to get messages pushed to them rather than having to frequently poll.