### PR TITLE
Nearest swarm fixes, ip update fixes & optimizations

### DIFF
--- a/oxenss/snode/service_node.cpp
+++ b/oxenss/snode/service_node.cpp
@@ -527,7 +527,8 @@ void ServiceNode::on_swarm_update(block_update&& bu) {
 
     if (std::string reason; !snode_ready(&reason)) {
         log::warning(logcat, "Storage server is still not ready: {}", reason);
-        swarm_->update_state(std::move(bu.swarms), std::move(bu.decommissioned_nodes), events, false);
+        swarm_->update_state(
+                std::move(bu.swarms), std::move(bu.decommissioned_nodes), events, false);
         return;
     } else {
         if (!active_) {

--- a/oxenss/snode/service_node.h
+++ b/oxenss/snode/service_node.h
@@ -243,7 +243,7 @@ class ServiceNode {
 
     bool is_pubkey_for_us(const user_pubkey_t& pk) const;
 
-    SwarmInfo get_swarm(const user_pubkey_t& pk) const;
+    std::optional<SwarmInfo> get_swarm(const user_pubkey_t& pk) const;
 
     std::vector<sn_record> get_swarm_peers() const;
 

--- a/oxenss/snode/swarm.cpp
+++ b/oxenss/snode/swarm.cpp
@@ -21,23 +21,6 @@ static bool swarm_exists(const std::vector<SwarmInfo>& all_swarms, const swarm_i
     return it != all_swarms.end();
 }
 
-void debug_print(std::ostream& os, const block_update& bu) {
-    os << "Block update: {\n";
-    os << "     height: " << bu.height << '\n';
-    os << "     block hash: " << bu.block_hash << '\n';
-    os << "     hardfork: " << bu.hardfork << '.' << bu.snode_revision << '\n';
-    os << "     swarms: [\n";
-
-    for (const SwarmInfo& swarm : bu.swarms) {
-        os << "         {\n";
-        os << "             id: " << swarm.swarm_id << '\n';
-        os << "         }\n";
-    }
-
-    os << "     ]\n";
-    os << "}\n";
-}
-
 Swarm::~Swarm() = default;
 
 bool Swarm::is_existing_swarm(swarm_id_t sid) const {

--- a/oxenss/snode/swarm.cpp
+++ b/oxenss/snode/swarm.cpp
@@ -346,14 +346,6 @@ std::pair<int, int> count_missing_data(const block_update& bu) {
             total++;
             if (snode.ip.empty() || snode.ip == "0.0.0.0" || !snode.port || !snode.omq_port ||
                 !snode.pubkey_ed25519 || !snode.pubkey_x25519) {
-                log::warning(
-                        logcat,
-                        "well wtf {} {} {} {} {}",
-                        snode.ip,
-                        snode.port,
-                        snode.omq_port,
-                        snode.pubkey_ed25519,
-                        snode.pubkey_x25519);
                 missing++;
             }
         }

--- a/oxenss/snode/swarm.h
+++ b/oxenss/snode/swarm.h
@@ -21,6 +21,8 @@ constexpr swarm_id_t INVALID_SWARM_ID = std::numeric_limits<uint64_t>::max();
 struct SwarmInfo {
     swarm_id_t swarm_id;
     std::vector<sn_record> snodes;
+
+    bool operator<(const SwarmInfo& other) const { return swarm_id < other.swarm_id; }
 };
 
 struct block_update {

--- a/oxenss/snode/swarm.h
+++ b/oxenss/snode/swarm.h
@@ -36,8 +36,6 @@ struct block_update {
     bool unchanged = false;
 };
 
-void debug_print(std::ostream& os, const block_update& bu);
-
 // Returns a pointer to the SwarmInfo member of `all_swarms` for the given user pub.  Returns a
 // nullptr on error (which will only happen if there are no swarms at all).  `all_swarms` must be
 // sorted by swarm id.

--- a/oxenss/snode/swarm.h
+++ b/oxenss/snode/swarm.h
@@ -43,7 +43,8 @@ void debug_print(std::ostream& os, const block_update& bu);
 // sorted by swarm id.
 const SwarmInfo* get_swarm_by_pk(const std::vector<SwarmInfo>& all_swarms, const user_pubkey_t& pk);
 // Not invokable with a temporary:
-const SwarmInfo* get_swarm_by_pk(std::vector<SwarmInfo>&& all_swarms, const user_pubkey_t& pk) = delete;
+const SwarmInfo* get_swarm_by_pk(std::vector<SwarmInfo>&& all_swarms, const user_pubkey_t& pk) =
+        delete;
 
 // Takes a swarm update, returns the number of active SN entries with missing
 // IP/port/ed25519/x25519 data and the total number of entries.  (We don't include

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(Test
     serialization.cpp
     service_node.cpp
     storage.cpp
+    swarm.cpp
 )
 
 target_link_libraries(Test

--- a/unit_test/service_node.cpp
+++ b/unit_test/service_node.cpp
@@ -11,7 +11,7 @@
 using namespace std::literals;
 using namespace oxen::crypto;
 
-static auto create_dummy_sn_record() -> oxen::snode::sn_record {
+static oxen::snode::sn_record create_dummy_sn_record() {
     const auto pk = legacy_pubkey::from_hex(
             "330e73449f6656cfe7816fa00d850af1f45884eab9e404026ca51f54b045e385");
     const auto pk_x25519 = x25519_pubkey::from_hex(
@@ -25,7 +25,7 @@ static auto create_dummy_sn_record() -> oxen::snode::sn_record {
 
 using ip_ports = std::tuple<const char*, uint16_t, uint16_t>;
 
-static auto test_ip_update(ip_ports old_addr, ip_ports new_addr, ip_ports expected) -> void {
+static void test_ip_update(ip_ports old_addr, ip_ports new_addr, ip_ports expected) {
     using oxen::snode::sn_record;
 
     auto sn = create_dummy_sn_record();
@@ -33,26 +33,26 @@ static auto test_ip_update(ip_ports old_addr, ip_ports new_addr, ip_ports expect
     std::tie(sn.ip, sn.port, sn.omq_port) = old_addr;
 
     oxen::snode::SwarmInfo si{0, std::vector<sn_record>{sn}};
-    auto current = std::vector<oxen::snode::SwarmInfo>{si};
+    std::vector<oxen::snode::SwarmInfo> current{{si}};
 
     std::tie(sn.ip, sn.port, sn.omq_port) = new_addr;
 
     oxen::snode::SwarmInfo si2{0, std::vector<sn_record>{sn}};
-    auto incoming = std::vector<oxen::snode::SwarmInfo>{si2};
+    std::vector<oxen::snode::SwarmInfo> incoming{{si2}};
 
-    auto new_records = apply_ips(current, incoming);
+    preserve_ips(incoming, current);
 
-    CHECK(new_records[0].snodes[0].ip == std::get<0>(expected));
-    CHECK(new_records[0].snodes[0].port == std::get<1>(expected));
-    CHECK(new_records[0].snodes[0].omq_port == std::get<2>(expected));
+    CHECK(incoming[0].snodes[0].ip == std::get<0>(expected));
+    CHECK(incoming[0].snodes[0].port == std::get<1>(expected));
+    CHECK(incoming[0].snodes[0].omq_port == std::get<2>(expected));
 }
 
 TEST_CASE("service nodes - updates IP address", "[service-nodes][updates]") {
     auto sn = create_dummy_sn_record();
 
-    const auto default_ip = ip_ports{"0.0.0.0", 0, 0};
-    const auto ip1 = ip_ports{"1.1.1.1", 123, 456};
-    const auto ip2 = ip_ports{"1.2.3.4", 123, 456};
+    const ip_ports default_ip{"0.0.0.0", 0, 0};
+    const ip_ports ip1{"1.1.1.1", 123, 456};
+    const ip_ports ip2{"1.2.3.4", 123, 456};
 
     // Should update
     test_ip_update(ip1, ip2, ip2);
@@ -66,7 +66,7 @@ TEST_CASE("service nodes - updates IP address", "[service-nodes][updates]") {
 
 /// Check that we don't inadvertently change how we compute message hashes
 TEST_CASE("service nodes - message hashing", "[service-nodes][messages]") {
-    const auto timestamp = std::chrono::system_clock::time_point{1616650862026ms};
+    const std::chrono::system_clock::time_point timestamp{1616650862026ms};
     const auto expiry = timestamp + 48h;
     oxen::user_pubkey_t pk;
     REQUIRE(pk.load("05ffba630924aa1224bb930dde21c0d11bf004608f2812217f8ac812d6c7e3ad48"));

--- a/unit_test/service_node.cpp
+++ b/unit_test/service_node.cpp
@@ -86,15 +86,3 @@ TEST_CASE("service nodes - message hashing", "[service-nodes][messages]") {
                    std::to_string(oxen::to_epoch_ms(expiry)) + pk.prefixed_raw() + data}) ==
           expected);
 }
-
-TEST_CASE("service nodes - pubkey to swarm id") {
-    oxen::user_pubkey_t pk;
-    REQUIRE(pk.load("05ffba630924aa1224bb930dde21c0d11bf004608f2812217f8ac812d6c7e3ad48"));
-    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 4532060000165252872ULL);
-
-    REQUIRE(pk.load("050123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"));
-    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 0);
-
-    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000123456789abcdef"));
-    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 0x0123456789abcdefULL);
-}

--- a/unit_test/swarm.cpp
+++ b/unit_test/swarm.cpp
@@ -1,0 +1,156 @@
+#include <catch2/catch.hpp>
+#include <iostream>
+
+#include <oxenss/crypto/keys.h>
+#include <oxenss/rpc/request_handler.h>
+#include <oxenss/snode/swarm.h>
+#include <oxenss/utils/time.hpp>
+
+#include <oxenc/base64.h>
+
+using namespace std::literals;
+
+using ip_ports = std::tuple<const char*, uint16_t, uint16_t>;
+
+TEST_CASE("swarm - pubkey to swarm space", "[swarm]") {
+    oxen::user_pubkey_t pk;
+    REQUIRE(pk.load("053506f4a71324b7dd114eddbf4e311f39dde243e1f2cb97c40db1961f70ebaae8"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 17589930838143112648ULL);
+    REQUIRE(pk.load("05cf27da303a50ac8c4b2d43d27259505c9bcd73fc21cf2a57902c3d050730b604"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 10370619079776428163ULL);
+    REQUIRE(pk.load("03d3511706b8b34f6e8411bf07bd22ba6b2435ca56846fbccf6eb1e166a6cd15cc"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 2144983569669512198ULL);
+    REQUIRE(pk.load("ff0f06693428fca9102a451e3f28d9cc743d8ea60a89ab6aa69eb119470c11cbd3"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 9690840703409570833ULL);
+    REQUIRE(pk.load("05ffba630924aa1224bb930dde21c0d11bf004608f2812217f8ac812d6c7e3ad48"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 4532060000165252872ULL);
+    REQUIRE(pk.load("05eeeeeeeeeeeeeeee777777777777777711111111111111118888888888888888"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 0);
+    REQUIRE(pk.load("050123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 0);
+    REQUIRE(pk.load("05fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 1);
+    REQUIRE(pk.load("05ffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffff"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 1ULL << 63);
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000ffffffffffffffff"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == (uint64_t)-1);
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000123456789abcdef"));
+    CHECK(oxen::snode::pubkey_to_swarm_space(pk) == 0x0123456789abcdefULL);
+}
+
+TEST_CASE("service nodes - pubkey to swarm id") {
+    std::vector<oxen::snode::SwarmInfo> swarms{
+        {100, {}}, {200, {}}, {300, {}}, {399, {}}, {498, {}}, {596, {}}, {694, {}}};
+
+    oxen::user_pubkey_t pk;
+
+    // Exact matches:
+    // 0x64 = 100, 0xc8 = 200, 0x1f2 = 498
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000064"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+    REQUIRE(pk.load("0500000000000000000000000000000000000000000000000000000000000000c8"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 200);
+    REQUIRE(pk.load("0500000000000000000000000000000000000000000000000000000000000001f2"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 498);
+
+    // Nearest
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000000"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000001"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+
+    // Nearest, with wraparound
+    // 0x8000... is closest to the top value
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000008000000000000000"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 694);
+
+    // 0xa000... is closest (via wraparound) to the smallest
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000a000000000000000"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+
+    // This is the invalid swarm id for swarms, but should still work for a client
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000ffffffffffffffff"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000fffffffffffffffe"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+
+
+    // Midpoint tests; we prefer the lower value when exactly in the middle between two swarms.
+    // 0x96 = 150
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000095"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000096"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000097"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 200);
+
+    // 0xfa = 250
+    REQUIRE(pk.load("0500000000000000000000000000000000000000000000000000000000000000f9"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 200);
+    REQUIRE(pk.load("0500000000000000000000000000000000000000000000000000000000000000fa"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 200);
+    REQUIRE(pk.load("0500000000000000000000000000000000000000000000000000000000000000fb"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 300);
+
+    // 0x15d = 349
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000000000000000015d"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 300);
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000000000000000015e"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 399);
+
+    // 0x1c0 = 448
+    REQUIRE(pk.load("0500000000000000000000000000000000000000000000000000000000000001c0"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 399);
+    REQUIRE(pk.load("0500000000000000000000000000000000000000000000000000000000000001c1"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 498);
+
+    // 0x223 = 547
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000222"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 498);
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000223"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 498);
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000224"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 596);
+
+    // 0x285 = 645
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000285"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 596);
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000286"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 694);
+
+    // 0x800....d is the midpoint between 694 and 100 (the long way).  We always round "down" (which
+    // in this case, means wrapping to the largest swarm).
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000800000000000018c"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 694);
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000800000000000018d"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 694);
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000800000000000018e"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
+
+
+    // With a swarm at -20 the midpoint is now 40 (=0x28).  When our value is the *low* value we
+    // prefer the *last* swarm in the case of a tie (while consistent with the general case of
+    // preferring the left edge, it means we're inconsistent with the other wraparound case, above.
+    // *sigh*).
+    swarms.push_back({(uint64_t)-20, {}});
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000027"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == swarms.back().swarm_id);
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000028"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == swarms.back().swarm_id);
+    REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000029"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == swarms.front().swarm_id);
+
+
+    // The code used to have a broken edge case if we have a swarm at zero and a client at max-u64
+    // because of an overflow in how the distance is calculated (the first swarm will be calculated
+    // as max-u64 away, rather than 1 away), and so the id always maps to the highest swarm (even
+    // though 0xfff...fe maps to the lowest swarm; the first check here, then, would fail.
+    swarms.insert(swarms.begin(), {0, {}});
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000ffffffffffffffff"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 0);
+    REQUIRE(pk.load("05000000000000000000000000000000000000000000000000fffffffffffffffe"));
+    CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 0);
+}
+

--- a/unit_test/swarm.cpp
+++ b/unit_test/swarm.cpp
@@ -40,7 +40,7 @@ TEST_CASE("swarm - pubkey to swarm space", "[swarm]") {
 
 TEST_CASE("service nodes - pubkey to swarm id") {
     std::vector<oxen::snode::SwarmInfo> swarms{
-        {100, {}}, {200, {}}, {300, {}}, {399, {}}, {498, {}}, {596, {}}, {694, {}}};
+            {100, {}}, {200, {}}, {300, {}}, {399, {}}, {498, {}}, {596, {}}, {694, {}}};
 
     oxen::user_pubkey_t pk;
 
@@ -75,7 +75,6 @@ TEST_CASE("service nodes - pubkey to swarm id") {
 
     REQUIRE(pk.load("05000000000000000000000000000000000000000000000000fffffffffffffffe"));
     CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
-
 
     // Midpoint tests; we prefer the lower value when exactly in the middle between two swarms.
     // 0x96 = 150
@@ -129,7 +128,6 @@ TEST_CASE("service nodes - pubkey to swarm id") {
     REQUIRE(pk.load("05000000000000000000000000000000000000000000000000800000000000018e"));
     CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 100);
 
-
     // With a swarm at -20 the midpoint is now 40 (=0x28).  When our value is the *low* value we
     // prefer the *last* swarm in the case of a tie (while consistent with the general case of
     // preferring the left edge, it means we're inconsistent with the other wraparound case, above.
@@ -142,7 +140,6 @@ TEST_CASE("service nodes - pubkey to swarm id") {
     REQUIRE(pk.load("050000000000000000000000000000000000000000000000000000000000000029"));
     CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == swarms.front().swarm_id);
 
-
     // The code used to have a broken edge case if we have a swarm at zero and a client at max-u64
     // because of an overflow in how the distance is calculated (the first swarm will be calculated
     // as max-u64 away, rather than 1 away), and so the id always maps to the highest swarm (even
@@ -153,4 +150,3 @@ TEST_CASE("service nodes - pubkey to swarm id") {
     REQUIRE(pk.load("05000000000000000000000000000000000000000000000000fffffffffffffffe"));
     CHECK(get_swarm_by_pk(swarms, pk)->swarm_id == 0);
 }
-


### PR DESCRIPTION
Nearest-swarm logic was broken in various ways when dealing with the wrapping region (i.e. between largest_swarm_id and smallest_swarm_id), and the test suite was vastly under-specified to catch these errors.  (See individual commits for details).

IP updates were broken: the code was specifically *preserving* old values when new swarm info arrives, which was exactly the wrong thing to do, and would prevent storage server from seeing IP address updates of other nodes (which would very likely lead to onion request connectivity failures).  This fixes it by only preserving values from the old swarm data if the new swarm info has a "0" value and the old data had a non-0 value.

The code around this area was also poorly optimized, with wasteful extra (hefty) allocations and data structure creations on every swarm update.

See individual commit messages for more details.