### PR TITLE
Allow 30-day TTL for owned messages

### DIFF
--- a/oxenss/rpc/request_handler.h
+++ b/oxenss/rpc/request_handler.h
@@ -28,9 +28,15 @@ inline constexpr auto TEST_RETRY_INTERVAL = 50ms;
 // we give up and send an error response back to the requestor:
 inline constexpr auto TEST_RETRY_PERIOD = 55s;
 
-// Minimum and maximum TTL permitted for a message storage request
+// Minimum and maximum TTL permitted for storing a new, public message
 inline constexpr auto TTL_MINIMUM = 10s;
 inline constexpr auto TTL_MAXIMUM = 14 * 24h;
+
+// For messages in a user's control (i.e. new messages in private namespaces, or updating TTLs of
+// existing public or private namespace messages) we allow a longer TTL (starting at HF19.3).
+inline constexpr auto TTL_MAXIMUM_PRIVATE = 30*24h;
+
+
 
 // Tolerance for store requests: we don't allow stores with a timestamp more than this into the
 // future, and don't allow stores with an expiry in the past by more than this amount.

--- a/oxenss/snode/service_node.h
+++ b/oxenss/snode/service_node.h
@@ -57,6 +57,9 @@ inline constexpr hf_revision HARDFORK_NAMESPACES = {19, 0};
 // -10 is temporarily exempt for closed group backwards support).
 inline constexpr hf_revision HARDFORK_RETRIEVE_AUTH = {19, 1};
 
+// The hardfork at which we start allowing 30d TTLs in private namespaces.
+inline constexpr hf_revision HARDFORK_EXTENDED_PRIVATE_TTL = {19, 3};
+
 class Swarm;
 
 /// WRONG_REQ - request was ignored as not valid (e.g. incorrect tester)


### PR DESCRIPTION
The 30-day TTL is available for new private namespace messages, and (authenticated) expiry updates, but not for new public namespace messages.

This is to allow for libsession-util config message storage that last a little longer; this will allow stored local account config to remain stored as long as a user comes on just once every 30 days to keep the settings refreshed.

Fixes #462