### PR TITLE
Enhance account/message counts admin stats

### DIFF
--- a/oxenss/storage/database.cpp
+++ b/oxenss/storage/database.cpp
@@ -580,9 +580,27 @@ int64_t Database::get_owner_count() {
     return get_impl()->prepared_get<int64_t>("SELECT COUNT(*) FROM owners");
 }
 
-int64_t Database::get_used_bytes() {
+std::vector<int> Database::get_message_counts() {
+    auto impl = get_impl();
+    auto st = impl->prepared_st("SELECT COUNT(*) FROM messages GROUP BY owner");
+    return get_all<int>(st);
+}
+
+std::vector<std::pair<namespace_id, int64_t>> Database::get_namespace_counts() {
+    auto impl = get_impl();
+    auto st = impl->prepared_st("SELECT namespace, COUNT(*) FROM messages GROUP BY namespace");
+    return get_all<namespace_id, int64_t>(st);
+}
+
+int64_t Database::get_total_bytes() {
     auto impl = get_impl();
     return impl->prepared_get<int64_t>("PRAGMA page_count") * impl->page_size;
+}
+
+int64_t Database::get_used_bytes() {
+    auto impl = get_impl();
+    return get_total_bytes() -
+           impl->prepared_get<int64_t>("PRAGMA freelist_count") * impl->page_size;
 }
 
 static std::optional<message> get_message(DatabaseImpl& impl, SQLite::Statement& st) {

--- a/oxenss/storage/database.hpp
+++ b/oxenss/storage/database.hpp
@@ -101,10 +101,23 @@ class Database {
     // Return the total number of messages stored
     int64_t get_message_count();
 
+    // Returns the per-owner counts of stored messages, for storage statistics purposes.
+    std::vector<int> get_message_counts();
+
     // Returns the number of distinct owner pubkeys with stored messages
     int64_t get_owner_count();
 
-    // Returns the number of used bytes (i.e. used pages * page size) of the database
+    // Returns the number of messages grouped by namespace id
+    std::vector<std::pair<namespace_id, int64_t>> get_namespace_counts();
+
+    // Returns the number of allocated bytes used on disk (i.e. used pages * page size).  This
+    // includes both used and unused storage (i.e. allocated on disk, currently currently unused
+    // that will likely be reused by sqlite when needed).
+    int64_t get_total_bytes();
+
+    // Returns the number of used bytes on disk; that is, total pages (as returned by
+    // `get_total_bytes`) minus unused pages in the database file.  Note that this is still an upper
+    // bound on actual stored size as there may be partially filled pages.
     int64_t get_used_bytes();
 
     // Get random message. Returns nullopt if there are no messages.


### PR DESCRIPTION
Adds various statistics to the admin.get_stats oxenmq endpoint:

- Add number of accounts (this was already in the systemd Status line but wasn't exposed in the get_stats endpoint).
- Per-account message count stats:
    - min, 5th, 25th, median, 75th, 9th, max values
    - mean
- Aggregate per-namespace counts