### PR TITLE
Fix get_expiries when called with a single hash

### DIFF
--- a/oxenss/storage/database.cpp
+++ b/oxenss/storage/database.cpp
@@ -986,7 +986,7 @@ std::map<std::string, int64_t> Database::get_expiries(
         auto st = impl->prepared_st(
                 "SELECT hash, expiry FROM messages WHERE hash = ?"
                 " AND owner = (SELECT id FROM owners WHERE pubkey = ? AND type = ?)");
-        return get_map<std::string, int64_t>(st);
+        return get_map<std::string, int64_t>(st, msg_hashes[0], pubkey);
     }
 
     SQLite::Statement st{


### PR DESCRIPTION
`get_expiries` was not returning any expiries when called with a single hash because of a bug in the database code's special-casing of a single-hash-lookup that didn't bind the query parameters.

This fixes it.

As a temporary workaround until this makes it into a mandatory upgrade, clients are suggested to include a second, fake hash `"fake"` when requesting just one expiry, which will not return any results (because it isn't an actual valid hash), but will avoid the bug and return the desired message expiry in the response.