### PR TITLE
QUIC onion_req endpoint

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ endif ()
 
 add_executable(onion-request EXCLUDE_FROM_ALL contrib/onion-request.cpp)
 set_target_properties(onion-request PROPERTIES RUNTIME_OUTPUT_DIRECTORY contrib)
-target_link_libraries(onion-request common crypto cpr::cpr oxenmq::oxenmq)
+target_link_libraries(onion-request common crypto cpr::cpr oxenmq::oxenmq quic)
 target_include_directories(onion-request PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 include(cmake/archive.cmake)

--- a/oxenss/daemon/oxen-storage.cpp
+++ b/oxenss/daemon/oxen-storage.cpp
@@ -166,20 +166,20 @@ int main(int argc, char* argv[]) {
                 ssl_dh,
                 {me.pubkey_legacy, private_key}};
 
-        oxenmq_server.init(
-                &service_node,
-                &request_handler,
-                &rate_limiter,
-                oxenmq::address{options.oxend_omq_rpc});
-
         auto quic = std::make_shared<server::QUIC>(
                 service_node,
                 request_handler,
                 rate_limiter,
                 oxen::quic::Address{options.ip, options.omq_quic_port},
                 private_key_ed25519);
-
         service_node.register_mq_server(quic.get());
+
+        oxenmq_server.init(
+                &service_node,
+                &request_handler,
+                &rate_limiter,
+                oxenmq::address{options.oxend_omq_rpc});
+
         quic->startup_endpoint();
 
         https_server.start();

--- a/oxenss/rpc/onion_processing.cpp
+++ b/oxenss/rpc/onion_processing.cpp
@@ -200,4 +200,13 @@ bool operator==(const RelayToNodeInfo& a, const RelayToNodeInfo& b) {
            std::tie(b.ciphertext, b.ephemeral_key, b.enc_type, b.next_node);
 }
 
+crypto::x25519_pubkey extract_x25519_from_hex(std::string_view hex) {
+    try {
+        return crypto::x25519_pubkey::from_hex(hex);
+    } catch (const std::exception& e) {
+        log::warning(logcat, "Failed to decode ephemeral key in onion request: {}", e.what());
+        throw;
+    }
+}
+
 }  // namespace oxenss::rpc

--- a/oxenss/rpc/onion_processing.h
+++ b/oxenss/rpc/onion_processing.h
@@ -99,4 +99,7 @@ ParsedInfo process_inner_request(std::string plaintext);
 // contain a query string.
 bool is_onion_url_target_allowed(std::string_view uri);
 
+// Extracts a x25519 pubkey from a hex string. Warns and throws on invalid input.
+crypto::x25519_pubkey extract_x25519_from_hex(std::string_view hex);
+
 }  // namespace oxenss::rpc

--- a/oxenss/server/https.cpp
+++ b/oxenss/server/https.cpp
@@ -337,16 +337,6 @@ namespace {
         return result.str();
     }
 
-    // Extracts a x25519 pubkey from a hex string. Warns and throws on invalid input.
-    crypto::x25519_pubkey extract_x25519_from_hex(std::string_view hex) {
-        try {
-            return crypto::x25519_pubkey::from_hex(hex);
-        } catch (const std::exception& e) {
-            log::warning(logcat, "Failed to decode ephemeral key in onion request: {}", e.what());
-            throw;
-        }
-    }
-
     // Sets up a request handler that processes the initial incoming requests, sets up the
     // appropriate handlers for incoming data, and invokes the `ready` callback once all data
     // has been received (i.e. when the request is complete).  Can optionally call `prevalidate`
@@ -569,7 +559,7 @@ void HTTPS::process_onion_req_v2(HttpRequest& req, HttpResponse& res) {
                                 auto [ciphertext, json_req] =
                                         rpc::parse_combined_payload(data->request.body);
 
-                                onion.ephem_key = extract_x25519_from_hex(
+                                onion.ephem_key = rpc::extract_x25519_from_hex(
                                         json_req.at("ephemeral_key").get_ref<const std::string&>());
 
                                 if (auto it = json_req.find("enc_type"); it != json_req.end())

--- a/oxenss/server/quic.h
+++ b/oxenss/server/quic.h
@@ -62,6 +62,8 @@ class QUIC : public MQBase {
 
     void handle_request(quic::message m);
 
+    void handle_onion_request(quic::message m);
+
     void handle_monitor_message(quic::message m);
 
     void handle_ping(quic::message m);


### PR DESCRIPTION
The QUIC request didn't have an `onion_req` endpoint wired up and so while you could invoke most endpoints, you couldn't initiate onion requests (and so would still need HTTPS for that).  This fixes it by wiring up an `onion_req` endpoint that accepts onion requests over QUIC.