### PR TITLE
Add a shared_mutex around database access

### DIFF
--- a/network-tests/test_deletes.py
+++ b/network-tests/test_deletes.py
@@ -69,25 +69,32 @@ def test_delete_all_all(omq, random_sn, sk, exclude):
     my_ss_id = '05' + sk.verify_key.encode().hex()
     ts = int(time.time() * 1000)
 
-    h42 = omq.request_future(conns[0], 'storage.store', [json.dumps({
-        "pubkey": my_ss_id,
-        "timestamp": ts,
-        "ttl": 30000,
-        "namespace": -42,
-        "data": base64.b64encode("abc 123".encode()).decode(),
-        "signature": sk.sign(f"store-42{ts}".encode(), encoder=Base64Encoder).signature.decode()}).encode()]).get()
+    h42 = omq.request_future(
+        conns[0],
+        'storage.store',
+        [
+            json.dumps(
+                {
+                    "pubkey": my_ss_id,
+                    "timestamp": ts,
+                    "ttl": 30000,
+                    "namespace": -42,
+                    "data": base64.b64encode("abc 123".encode()).decode(),
+                    "signature": sk.sign(
+                        f"store-42{ts}".encode(), encoder=Base64Encoder
+                    ).signature.decode(),
+                }
+            ).encode()
+        ],
+    ).get()
     assert len(h42) == 1
     h42 = json.loads(h42[0].decode())["hash"]
 
     to_sign = "delete_allall{}".format(ts).encode()
     sig = sk.sign(to_sign, encoder=Base64Encoder).signature.decode()
-    params = json.dumps({
-            "pubkey": my_ss_id,
-            "timestamp": ts,
-            "signature": sig,
-            "namespace": "all"
-    }).encode()
-
+    params = json.dumps(
+        {"pubkey": my_ss_id, "timestamp": ts, "signature": sig, "namespace": "all"}
+    ).encode()
 
     resp = omq.request_future(conns[1], 'storage.delete_all', [params]).get()
 
@@ -96,9 +103,7 @@ def test_delete_all_all(omq, random_sn, sk, exclude):
 
     assert set(r['swarm'].keys()) == {x['pubkey_ed25519'] for x in swarm['snodes']}
 
-    msg_hashes = {
-            '-42': [h42],
-            '0': sorted(m['hash'] for m in msgs)}
+    msg_hashes = {'-42': [h42], '0': sorted(m['hash'] for m in msgs)}
     msg_hashes_all = sorted(h for hashes in msg_hashes.values() for h in hashes)
 
     # signature of ( PUBKEY_HEX || TIMESTAMP || DELETEDHASH[0] || ... || DELETEDHASH[N] )
@@ -108,17 +113,24 @@ def test_delete_all_all(omq, random_sn, sk, exclude):
         edpk = VerifyKey(k, encoder=HexEncoder)
         edpk.verify(expected_signed, base64.b64decode(v['signature']))
 
-    r = omq.request_future(conns[0], 'storage.retrieve',
-        [json.dumps({
-            "pubkey": my_ss_id,
-            "timestamp": ts,
-            "signature": sk.sign(f"retrieve{ts}".encode(), encoder=Base64Encoder).signature.decode()
-            }).encode()]
-        ).get()
+    r = omq.request_future(
+        conns[0],
+        'storage.retrieve',
+        [
+            json.dumps(
+                {
+                    "pubkey": my_ss_id,
+                    "timestamp": ts,
+                    "signature": sk.sign(
+                        f"retrieve{ts}".encode(), encoder=Base64Encoder
+                    ).signature.decode(),
+                }
+            ).encode()
+        ],
+    ).get()
     assert len(r) == 1
     r = json.loads(r[0])
     assert not r['messages']
-
 
 
 def test_stale_delete_all(omq, random_sn, sk, exclude):

--- a/network-tests/util.py
+++ b/network-tests/util.py
@@ -7,4 +7,4 @@ def sn_address(sn):
 
 
 def random_time_delta_ms(upper: int) -> int:
-    return random.randint(1, upper*1000)
+    return random.randint(1, upper * 1000)

--- a/oxenss/server/omq_logger.cpp
+++ b/oxenss/server/omq_logger.cpp
@@ -1,19 +1,37 @@
 #include <oxenmq/oxenmq.h>
 #include <oxenss/logging/oxen_logger.h>
+#include <oxenss/utils/string_utils.hpp>
 
 namespace oxenss {
 
 static auto logcat = log::Cat("omq");
 
+static constexpr std::string_view omq_log_format = "[{}:{}]: {}";
+static constexpr std::string_view access_denied_ping = "Access denied to sn.ping";
+
 void omq_logger(oxenmq::LogLevel level, const char* file, int line, std::string message) {
-    constexpr std::string_view format = "[{}:{}]: {}";
+    // Downgrade warnings about sn.ping because there are broken nodes out there that don't know
+    // they are broken and try to ping the network, filling up logs pointlessly.
+    if (util::starts_with(message, access_denied_ping))
+        level = oxenmq::LogLevel::debug;
+
     switch (level) {
-        case oxenmq::LogLevel::fatal: log::critical(logcat, format, file, line, message); break;
-        case oxenmq::LogLevel::error: log::error(logcat, format, file, line, message); break;
-        case oxenmq::LogLevel::warn: log::warning(logcat, format, file, line, message); break;
-        case oxenmq::LogLevel::info: log::info(logcat, format, file, line, message); break;
-        case oxenmq::LogLevel::debug: log::debug(logcat, format, file, line, message); break;
-        case oxenmq::LogLevel::trace: log::trace(logcat, format, file, line, message); break;
+        case oxenmq::LogLevel::fatal:
+            log::critical(logcat, omq_log_format, file, line, message);
+            break;
+        case oxenmq::LogLevel::error:
+            log::error(logcat, omq_log_format, file, line, message);
+            break;
+        case oxenmq::LogLevel::warn:
+            log::warning(logcat, omq_log_format, file, line, message);
+            break;
+        case oxenmq::LogLevel::info: log::info(logcat, omq_log_format, file, line, message); break;
+        case oxenmq::LogLevel::debug:
+            log::debug(logcat, omq_log_format, file, line, message);
+            break;
+        case oxenmq::LogLevel::trace:
+            log::trace(logcat, omq_log_format, file, line, message);
+            break;
     }
 }
 

--- a/oxenss/storage/database.hpp
+++ b/oxenss/storage/database.hpp
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <stack>
 #include <string>
 #include <vector>
@@ -37,7 +38,8 @@ class Database {
     friend class DatabaseImpl;
     friend class LockedDBImpl;
     std::mutex impl_lock_;
-    LockedDBImpl get_impl();
+    std::shared_mutex access_lock_;
+    LockedDBImpl get_impl(bool write);
 
     const std::filesystem::path db_path_;
 


### PR DESCRIPTION
This lets us have *some* parallelism by letting reads happen in parallel, but ensures writes have exclusive access.  Without this we get spurious "database is locked" errors because sqlite does not handle multi-connection combined read/write access well (basically any write will cause any read in progress to fail with such an error, even if the write wouldn't have affected the read).