### PR TITLE
Fix potential deadlock in libquic handling (v2.6.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 cmake_minimum_required(VERSION 3.13)
 
 project(oxenss
-    VERSION 2.6.1
+    VERSION 2.6.2
     LANGUAGES CXX C)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/oxenss/server/quic.h
+++ b/oxenss/server/quic.h
@@ -60,13 +60,13 @@ class QUIC : public MQBase {
 
     std::shared_ptr<quic::Endpoint> create_endpoint();
 
-    void handle_request(quic::message m);
+    void handle_request(std::shared_ptr<quic::message> msg);
 
-    void handle_onion_request(quic::message m);
+    void handle_onion_request(std::shared_ptr<quic::message> msg);
 
-    void handle_monitor_message(quic::message m);
+    void handle_monitor_message(std::shared_ptr<quic::message> msg);
 
-    void handle_ping(quic::message m);
+    void handle_ping(std::shared_ptr<quic::message> msg);
 
     nlohmann::json wrap_response(
             [[maybe_unused]] const http::response_code& status,


### PR DESCRIPTION
`reachability_test` does a `open_stream` while also holding the sn_mutex_ (from up the call back).  Because that quic call is synchronous, this can deadlock if another request (or ping response) handler fires at just the wrong from the libquic loop: we end up with a worker thread holding sn_mutex_ and waiting for the libquic loop, while the libquic loop is invoke a callback that doesn't return until it acquires the sn_mutex_.

This commit addresses the issue by putting all request/responder handlers into OMQ workers (via inject_task) so that any handlers the libquic event loop fires do not invoke any sn_mutex_-locking code, cutting off the the deadlock potential.