### PR TITLE
Remove unwanted loop break in http client

### DIFF
--- a/oxenss/http/http_client.cpp
+++ b/oxenss/http/http_client.cpp
@@ -133,7 +133,6 @@ void Client::check_multi_info() {
             }
             active_reqs.erase(it);
             curl_multi_remove_handle(curl_multi, message->easy_handle);
-            break;
         } else {
             log::warning(
                     logcat,


### PR DESCRIPTION
The break here shouldn't be happening, and could end up delaying proxied http responses if two responses arrived at the same instant.  (It came from an adaptation of the curl libevent multi example code, but there it was to end a switch, not to end the loop).