### PR TITLE
Compact get service nodes endpoint

### DIFF
--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -738,6 +738,33 @@ struct oxend_request final : endpoint {
     void load_from(oxenc::bt_dict_consumer params) override;
 };
 
+/// Requests the current set of all active network nodes in compact representation.  This is the
+/// same data that can be retrieved via a oxend_request request to get_service_nodes, but in a much
+/// smaller form, including only the data needed/used by clients using the storage server network.
+///
+/// Takes no parameters.  Responses is a binary data blob (NOT json) consisting of repeated 51-byte
+/// values:
+///
+/// - 32 byte Ed25519 pubkey
+/// - 8 byte u64 swarm ID, in network order.
+/// - 4 bytes public ip, in network (big-endian) order (i.e. 1.2.3.4 is "\x01\x02\x03\x04")
+/// - 2 byte https port, in network order (i.e. port 259 is "\x01\x03")
+/// - 2 byte OMQ (TCP)/QUIC (UDP) port, in network order
+/// - 3 byte storage server version, e.g. 1.2.3 is "\x01\x02\x03"
+///
+/// e.g. if there are 2000 active storage servers then this returns a 51*2000 byte response.
+///
+/// Nodes are included as long as their Ed25519 pubkey is known, even if their IP/port/version info
+/// is not yet known by this node: IP/port/version values in such a case will all be 0.
+///
+/// Note that as of HF21, the Ed25519 pubkey is always known, and so this will return a complete set
+/// of network swarm info (but possibly with 0 IP/port values).  Prior to HF21, however, Ed pubkey
+/// and IP/port info arrives together, and so prior to HF21 the returned information will be
+/// incomplete, but also won't include 0 values.
+struct active_nodes_bin final : no_args {
+    static constexpr auto names() { return NAMES("active_nodes_bin"); }
+};
+
 // All of the RPC types that can be invoked as a regular request: either directly, or inside a
 // batch.  This excludes the meta-requests like batch/sequence/ifelse (since those nest other
 // requests within them).
@@ -755,6 +782,7 @@ using client_rpc_subrequests = type_list<
         get_expiries,
         get_swarm,
         oxend_request,
+        active_nodes_bin,
         info>;
 
 using client_subrequest = type_list_variant_t<client_rpc_subrequests>;

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -671,6 +671,13 @@ void RequestHandler::process_client_req(
 }
 
 void RequestHandler::process_client_req(
+        rpc::active_nodes_bin&&, std::function<void(rpc::Response)> cb) {
+    auto blobptr = service_node_.network().all_nodes_blob();
+    std::string_view blob{reinterpret_cast<const char*>(blobptr->data()), blobptr->size()};
+    cb({http::OK, blob, std::move(blobptr)});
+}
+
+void RequestHandler::process_client_req(
         rpc::get_swarm&& req, std::function<void(rpc::Response)> cb) {
     auto swarm = network_.get_swarm_for(req.pubkey);
 

--- a/oxenss/rpc/request_handler.h
+++ b/oxenss/rpc/request_handler.h
@@ -61,11 +61,12 @@ inline constexpr int RETRIEVE_MAX_SIZE = 7'800'000;
 // Maximum subrequests that can be stuffed into a single batch request
 inline constexpr size_t BATCH_REQUEST_MAX = 20;
 
-// Simpler wrapper that works for most of our responses
+// Simple wrapper that works for most of our responses
 struct Response {
     http::response_code status = http::OK;
     std::variant<std::string, std::string_view, nlohmann::json> body;
     std::vector<std::pair<std::string, std::string>> headers;
+    std::shared_ptr<void> keepalive;
 
     Response() = default;
     Response(
@@ -73,6 +74,8 @@ struct Response {
             std::variant<std::string, std::string_view, nlohmann::json> body = ""sv,
             std::vector<std::pair<std::string, std::string>> headers = {}) :
             status{status}, body{std::move(body)}, headers{std::move(headers)} {}
+    Response(http::response_code status, std::string_view body, std::shared_ptr<void> keepalive) :
+            status{status}, body{body}, keepalive{keepalive} {}
 };
 
 // Views the string or string_view body inside a Response.  Should only be called when the body
@@ -195,6 +198,7 @@ class RequestHandler {
     void process_client_req(rpc::retrieve&& req, std::function<void(Response)> cb);
     void process_client_req(rpc::get_swarm&& req, std::function<void(Response)> cb);
     void process_client_req(rpc::oxend_request&& req, std::function<void(Response)> cb);
+    void process_client_req(rpc::active_nodes_bin&& req, std::function<void(Response)> cb);
     void process_client_req(rpc::info&&, std::function<void(Response)> cb);
     void process_client_req(rpc::delete_all&&, std::function<void(Response)> cb);
     void process_client_req(rpc::delete_msgs&&, std::function<void(Response)> cb);

--- a/oxenss/snode/network.cpp
+++ b/oxenss/snode/network.cpp
@@ -88,10 +88,69 @@ void Network::update_swarms(
             new_pks.end(),
             std::back_inserter(removed));
 
-    contacts.update_and_erase(
+    int contact_changes = contacts.update_and_erase(
             new_contacts.begin(), new_contacts.end(), removed.begin(), removed.end());
 
+    if (all_nodes_blob_ && (contact_changes || swarms_ != new_swarms))
+        all_nodes_blob_.reset();
+
     swarms_ = std::move(new_swarms);
+}
+
+static constexpr size_t PER_SNODE_BLOB_SIZE = 51;
+static_assert(
+        sizeof(crypto::ed25519_pubkey) + sizeof(uint64_t) + sizeof(oxen::quic::ipv4) +
+                sizeof(uint16_t) + sizeof(uint16_t) + 3 ==
+        PER_SNODE_BLOB_SIZE);
+
+std::shared_ptr<std::vector<std::byte>> Network::all_nodes_blob() const {
+    {
+        std::shared_lock lock{mut_};
+        if (all_nodes_blob_)
+            return all_nodes_blob_;
+    }
+
+    std::unique_lock lock{mut_, std::defer_lock};
+    std::shared_lock c_lock{contacts, std::defer_lock};
+    std::lock(lock, c_lock);
+
+    size_t snode_count = 0;
+    for (auto& [swid, members] : swarms_)
+        snode_count += members.size();
+
+    auto blob = std::make_shared<std::vector<std::byte>>();
+    blob->resize(snode_count * PER_SNODE_BLOB_SIZE);
+    auto* ptr = blob->data();
+    for (auto& [swid, members] : swarms_) {
+        const uint64_t big_swid = oxenc::host_to_big(swid);
+        for (auto& pk : members) {
+            auto* c = contacts.find_locked(pk);
+            if (!c || !c->pubkey_ed25519)
+                continue;
+#ifndef NDEBUG
+            auto* start_ptr = ptr;
+#endif
+            std::memcpy(ptr, c->pubkey_ed25519.data(), c->pubkey_ed25519.size());
+            ptr += c->pubkey_ed25519.size();
+            std::memcpy(ptr, &big_swid, sizeof(big_swid));
+            ptr += sizeof(big_swid);
+            oxenc::write_host_as_big(c->ip.addr, ptr);
+            ptr += sizeof(c->ip.addr);
+            oxenc::write_host_as_big(c->https_port, ptr);
+            ptr += sizeof(c->https_port);
+            oxenc::write_host_as_big(c->omq_quic_port, ptr);
+            ptr += sizeof(c->omq_quic_port);
+            for (auto v16 : c->version)
+                *ptr++ = static_cast<std::byte>(std::min<uint16_t>(v16, 255));
+            assert(ptr == start_ptr + PER_SNODE_BLOB_SIZE);
+        }
+    }
+
+    // If we skipped some uncontactable nodes then we might have overallocated:
+    blob->resize(ptr - blob->data());
+
+    all_nodes_blob_ = blob;
+    return blob;
 }
 
 }  // namespace oxenss::snode

--- a/oxenss/snode/network.h
+++ b/oxenss/snode/network.h
@@ -39,6 +39,10 @@ class Network {
 
     swarms_t::const_iterator _find_swarm_for(const user_pubkey& pk) const;
 
+    // Cached value of the all_nodes_blob() return value.  The cache is cleared whenever swarms or
+    // any contact info changes.
+    mutable std::shared_ptr<std::vector<std::byte>> all_nodes_blob_;
+
     // Processes a swarm update; this replaces the current swarm map with the given one, and updates
     // contacts to remove any no-longer-present nodes, add any new ones, and update any changed
     // contact info.  As part of the update, swarm.update() is called at the end to have the current
@@ -72,6 +76,27 @@ class Network {
     // Looks up a swarm by swarm_id_t.  Returns nullopt if there is no such swarm id, otherwise
     // returns the set of swarm member pubkeys.
     std::optional<std::set<crypto::legacy_pubkey>> get_swarm(swarm_id_t swid) const;
+
+    // All-active-nodes encoded compact value, as returned by the active_nodes_bin RPC endpoint.
+    // This is a binary blob of N*51 bytes, where N is the number of active service nodes, and each
+    // 51 byte increment consists of packed values, where all numeric values are encoded in big
+    // endian order:
+    //
+    // - 32 byte Ed25519 pubkey
+    // - 8 byte u64 swarm ID
+    // - 4 bytes public ip in network encoding (e.g. 1.2.3.4 is "\x01\x02\x03\x04")
+    // - 2 byte https port
+    // - 2 byte omq/quic port
+    // - 3 byte storage server version, e.g. 1.2.3 is "\x01\x02\x03".  (If we encounter a version
+    //   value > 255 we put \xff for that component).
+    //
+    // Note that, starting with HF21, IP/ports/version will be all 0 values if this node has yet not
+    // received an uptime proof with contact info from this node.  Before HF21, non-contactable
+    // nodes are omitted entirely (as their Ed25519 pubkey is not yet known).
+    //
+    // This value is cached and recomputed whenever swarms or contact info of any active node
+    // changes.
+    std::shared_ptr<std::vector<std::byte>> all_nodes_blob() const;
 };
 
 }  // namespace oxenss::snode


### PR DESCRIPTION
This add a binary endpoint, `active_nodes_bin`, that returns a binary blob containing the info session clients need to contact the network.  The intention is that this will replace the current call to `get_service_nodes` for libsession-util, offering a much more bandwidth and processing efficient method to get the needed info.