### PR TITLE
Fix incorrect parsing of failure in recursive swarm request

### DIFF
--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -399,17 +399,23 @@ struct swarm_response {
     std::function<void(rpc::Response)> cb;
 };
 
-// Replies to a recursive swarm request via its callback; sends an http::OK unless all of the
-// swarm entries returned things with "failed" in them, in which case we send back an
-// INTERNAL_SERVER_ERROR along with the response.
+// Replies to a swarm request via its callback; sends an http::OK unless all of the
+// swarm entries returned things with "failed" in them or in the case of a non-recursive request,
+// the top-level object has a "failed" in it then we send back an INTERNAL_SERVER_ERROR
+// along with the response.
 void reply_or_fail(const std::shared_ptr<swarm_response>& res) {
     auto res_code = http::INTERNAL_SERVER_ERROR;
-    for (const auto& [snode, reply] : res->result.items()) {
-        if (!reply.count("failed")) {
-            res_code = http::OK;
-            break;
+    if (auto swarm_obj = res->result.find("swarm"); swarm_obj != res->result.end()) {
+        for (const auto& [sn_pkey, obj] : swarm_obj->items()) {
+            if (!obj.count("failed")) {
+                res_code = http::OK;
+                break;
+            }
         }
+    } else if (auto failed_it = res->result.find("failed"); failed_it == res->result.end()) {
+        res_code = http::OK;
     }
+
     res->cb(Response{res_code, std::move(res->result)});
 }
 


### PR DESCRIPTION
Example response of a recursive swarm request is:
```json
{
  "hash": "9jmGtyPGT9+MjhT7KawnEfOtHrPndBj8bO2tLYVhnc0",
  "hf": [ 21, 0 ],
  "swarm": {
    "1e85349d7de658771e6473b11c71f5fb6b45686f8451fb8b6c88681dca154de4": {
      "code": "500",
      "failed": true,
      "reason": "request failed"
    },
    "3ab5eec1fdbab025991eddefa49352d43171e5e22810e95b982e0c714f6feda7": {
      "expiry": 1749176990000,
      "hash": "9jmGtyPGT9+MjhT7KawnEfOtHrPndBj8bO2tLYVhnc0",
      "signature": "r2DVq3YzIVGp0lyAEkSa1oSugpMiuh6kbiAElWzkH3ccwu977+QTnEX4Bkg1ZZPV+mdymSAVRwe2ylltPsVFCQ==",
      "t": 1749175190606
    },
  },
  "t": 1749175190606
}
```
All the recursive requests by definition propagate out to swarm members and then the results are collated into the swarm object which we weren't checking. The result of this seems fairly benign considering the current usage patterns of the various platforms on the signatures of the swarm.

For a non-recursive swarm request, I only found one request that sets the "failed" flag in the top level object which was `rpc::store`. This is handled by the `else if` branch.