### PR TITLE
Fix active nodes via onionreq

### DIFF
--- a/contrib/onion-request.cpp
+++ b/contrib/onion-request.cpp
@@ -17,6 +17,7 @@
 #include <oxenmq/oxenmq.h>
 #include <nlohmann/json.hpp>
 #include <oxen/quic.hpp>
+#include <oxen/quic/gnutls_crypto.hpp>
 
 extern "C" {
 #include <sys/param.h>
@@ -53,7 +54,7 @@ PAYLOAD/CONTROL are values to pass to the request and should be:
 
 Onion requests for SS and oxend:
 
-    Pass '{"headers":[]}' for CONTROL
+    Pass '{"headers":[],"json":true,"base64":false}' for CONTROL
 
     PAYLOAD should be the JSON data; for example for an oxend request:
 
@@ -265,17 +266,15 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     // any onion encryption at all all the way back to the client.
 
     // Ephemeral keypair:
-    x25519_pubkey A;
-    x25519_seckey a;
-    x25519_pubkey final_pubkey;
-    x25519_seckey final_seckey;
+    x25519_keypair eph;
+    x25519_keypair final_keys;
     EncryptType last_etype;
     EncryptType final_etype;
 
     auto it = keys.rbegin();
     {
-        crypto_box_keypair(A.data(), a.data());
-        ChannelEncryption e{a, A, false};
+        crypto_box_keypair(eph.pub.data(), eph.sec.data());
+        ChannelEncryption e{eph, false};
 
         auto data = encode_size(payload.size());
         data += payload;
@@ -287,23 +286,22 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
 #endif
         blob = e.encrypt(last_etype, data, keys.back().second);
         // Save these because we need them again to decrypt the final response:
-        final_seckey = a;
-        final_pubkey = A;
+        final_keys = eph;
     }
 
     for (it++; it != keys.rend(); it++) {
         // Routing data for this hop:
         nlohmann::json routing{
             {"destination", std::prev(it)->first.hex()}, // Next hop's ed25519 key
-            {"ephemeral_key", A.hex()}, // The x25519 ephemeral_key here is the key for the *next* hop to use
+            {"ephemeral_key", eph.pub.hex()}, // The x25519 ephemeral_key here is the key for the *next* hop to use
             {"enc_type", to_string(last_etype)},
         };
 
         blob = encode_size(blob.size()) + blob + routing.dump();
 
         // Generate eph key for *this* request and encrypt it:
-        crypto_box_keypair(A.data(), a.data());
-        ChannelEncryption e{a, A, false};
+        crypto_box_keypair(eph.pub.data(), eph.sec.data());
+        ChannelEncryption e{eph, false};
         last_etype = enc_type.value_or(random_etype());
 
 #ifndef NDEBUG
@@ -315,7 +313,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     // The data going to the first hop needs to be wrapped in one more layer to tell the first hop
     // how to decrypt the initial payload:
     blob = encode_size(blob.size()) + blob + nlohmann::json{
-        {"ephemeral_key", A.hex()}, {"enc_type", to_string(last_etype)}}.dump();
+        {"ephemeral_key", eph.pub.hex()}, {"enc_type", to_string(last_etype)}}.dump();
 
     auto started = std::chrono::steady_clock::now();
     std::string body;
@@ -324,10 +322,9 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
         using namespace oxen::quic;
         Network net;
 
-        static constexpr auto ALPN = "oxenstorage"sv;
-        static const ustring uALPN{reinterpret_cast<const unsigned char*>(ALPN.data()), ALPN.size()};
+        static constexpr auto ALPN = "oxenstorage"s;
 
-        auto ep = net.endpoint(Address{}, opt::outbound_alpns{{uALPN}});
+        auto ep = net.endpoint(Address{}, opt::outbound_alpns{{ALPN}});
         std::string sk;
         sk.resize(64);
         std::array<unsigned char, 32> pk;
@@ -351,7 +348,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
                 auto finished = std::chrono::steady_clock::now();
                 std::cerr << "Got QUIC onion request response in "
                           << std::chrono::duration<double>(finished - started).count() << "s\n";
-                body_prom.set_value(msg.body_str());
+                body_prom.set_value(std::string{msg.body()});
             }
         });
 
@@ -384,7 +381,7 @@ void onion_request(std::string ip, uint16_t port, std::vector<std::pair<ed25519_
     // Nothing in the response tells us how it is encoded so we have to guess; the client normally
     // *does* know because it specifies `"base64": false` if it wants binary, but I don't want to
     // parse and guess what we should do, so we'll just guess.
-    ChannelEncryption d{final_seckey, final_pubkey, false};
+    ChannelEncryption d{final_keys, false};
     bool decrypted = false;
     auto orig_size = body.size();
     try { body = d.decrypt(final_etype, body, keys.back().second); decrypted = true; }

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -67,7 +67,10 @@ system_or_submodule(OXENQUIC quic liboxenquic>=1.5.0 oxen-libquic)
 
 system_or_submodule(OXENMQ oxenmq liboxenmq>=1.2.22 oxen-mq)
 set(JSON_MultipleHeaders ON CACHE BOOL "") # Allows multi-header nlohmann use
-system_or_submodule(NLOHMANN nlohmann_json nlohmann_json>=3.7.0 nlohmann_json)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    set(JSON_Diagnostics ON CACHE BOOL "")
+endif()
+system_or_submodule(NLOHMANN nlohmann_json nlohmann_json>=3.11.0 nlohmann_json)
 system_or_submodule(CLI11 CLI11 CLI11>=2.2.0 CLI11)
 
 

--- a/oxenss/rpc/CMakeLists.txt
+++ b/oxenss/rpc/CMakeLists.txt
@@ -23,3 +23,6 @@ target_link_libraries(rpc
     oxenc::oxenc
     sodium)
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(rpc PUBLIC JSON_DIAGNOSTICS=1)
+endif()

--- a/oxenss/rpc/client_rpc_endpoints.h
+++ b/oxenss/rpc/client_rpc_endpoints.h
@@ -742,8 +742,7 @@ struct oxend_request final : endpoint {
 /// same data that can be retrieved via a oxend_request request to get_service_nodes, but in a much
 /// smaller form, including only the data needed/used by clients using the storage server network.
 ///
-/// Takes no parameters.  Responses is a binary data blob (NOT json) consisting of repeated 51-byte
-/// values:
+/// Takes no parameters.  Response is a binary data blob consisting of repeated 51-byte values:
 ///
 /// - 32 byte Ed25519 pubkey
 /// - 8 byte u64 swarm ID, in network order.
@@ -754,13 +753,14 @@ struct oxend_request final : endpoint {
 ///
 /// e.g. if there are 2000 active storage servers then this returns a 51*2000 byte response.
 ///
-/// Nodes are included as long as their Ed25519 pubkey is known, even if their IP/port/version info
-/// is not yet known by this node: IP/port/version values in such a case will all be 0.
+/// If this request is made through an onion request, the value will be wastefully base64 encoded as
+/// the onion request protocol has no provisions for binary data, but if made as a direct request
+/// (e.g. over lokinet or through direct HTTPS) it will be binary.
 ///
-/// Note that as of HF21, the Ed25519 pubkey is always known, and so this will return a complete set
-/// of network swarm info (but possibly with 0 IP/port values).  Prior to HF21, however, Ed pubkey
-/// and IP/port info arrives together, and so prior to HF21 the returned information will be
-/// incomplete, but also won't include 0 values.
+/// Active nodes are always included even if their IP/port/version info is not yet known by this
+/// node (i.e. because a valid uptime proof has not yet been received): IP/port/version values in
+/// such a case will all be 0.
+///
 struct active_nodes_bin final : no_args {
     static constexpr auto names() { return NAMES("active_nodes_bin"); }
 };

--- a/oxenss/rpc/onion_processing.cpp
+++ b/oxenss/rpc/onion_processing.cpp
@@ -45,7 +45,7 @@ ParsedInfo process_inner_request(std::string plaintext) {
             // rather than encode the information for the last hop inside [inner] itself (so
             // that you can send it arbitrary data encoded however the last hop wants to encode
             // things), instead it would cram extra data into the *same* json object that the
-            // last hop uses, and force the remove target to re-parse the last hop's request as
+            // last hop uses, and force the remote target to re-parse the last hop's request as
             // its own request.
             //
             // That is, a clean design here would have been:

--- a/oxenss/rpc/request_handler.cpp
+++ b/oxenss/rpc/request_handler.cpp
@@ -40,13 +40,19 @@ static auto logcat = log::Cat("rpc");
 // getting back to the client before the entry node's request times out.
 inline constexpr auto ONION_URL_TIMEOUT = 25s;
 
-std::string to_string(const Response& res) {
-    const bool is_json = std::holds_alternative<json>(res.body);
+std::string debug_string(const Response& res) {
+    const auto* json = std::get_if<nlohmann::json>(&res.body);
+    const auto* binary = std::get_if<std::span<const std::byte>>(&res.body);
     return "Status: {} {}, Content-Type: {}, Body: <{}>"_format(
             res.status.first,
             res.status.second,
-            is_json ? "application/json" : "text/plain",
-            is_json ? std::get<json>(res.body).dump() : view_body(res));
+            json     ? "application/json"
+            : binary ? "application/octet-stream"
+                     : "text/plain",
+            json ? json->dump()
+            : binary
+                    ? std::string_view{reinterpret_cast<const char*>(binary->data()), binary->size()}
+                    : view_body(res));
 }
 
 namespace {
@@ -679,7 +685,7 @@ void RequestHandler::process_client_req(
 void RequestHandler::process_client_req(
         rpc::active_nodes_bin&&, std::function<void(rpc::Response)> cb) {
     auto blobptr = service_node_.network().all_nodes_blob();
-    std::string_view blob{reinterpret_cast<const char*>(blobptr->data()), blobptr->size()};
+    std::span<const std::byte> blob{*blobptr};
     cb({http::OK, blob, std::move(blobptr)});
 }
 
@@ -1467,11 +1473,15 @@ void RequestHandler::process_client_req(rpc::batch&& req, std::function<void(rpc
         subresults->emplace_back();
 
     for (size_t i = 0; i < req.subreqs.size(); i++) {
-        auto handler = [subresults, i, cb](Response r) {
+        auto handler = [b64 = req.b64, subresults, i, cb](Response r) {
             json& subres = (*subresults)[i];
             subres["code"] = r.status.first;
             if (auto* j = std::get_if<json>(&r.body))
                 subres["body"] = std::move(*j);
+            else if (auto* b = std::get_if<std::span<const std::byte>>(&r.body))
+                subres["body"] =
+                        b64 ? oxenc::to_base64(*b)
+                            : std::string{reinterpret_cast<const char*>(b->data()), b->size()};
             else
                 subres["body"] = std::string{view_body(r)};
             bool done = true;
@@ -1525,12 +1535,15 @@ void RequestHandler::process_client_req(
     //
     auto manager = std::make_shared<sequence_manager>();
     manager->subreqs = std::move(req.subreqs);
-    manager->subresult_callback = [this, manager, cb = std::move(cb)](Response r) {
+    manager->subresult_callback = [this, manager, b64 = req.b64, cb = std::move(cb)](Response r) {
         json& subres = manager->subresults.emplace_back();
         auto status = r.status.first;
         subres["code"] = status;
         if (auto* j = std::get_if<json>(&r.body))
             subres["body"] = std::move(*j);
+        else if (auto* b = std::get_if<std::span<const std::byte>>(&r.body))
+            subres["body"] = b64 ? oxenc::to_base64(*b)
+                                 : std::string{reinterpret_cast<const char*>(b->data()), b->size()};
         else
             subres["body"] = std::string{view_body(r)};
 
@@ -1567,11 +1580,15 @@ void RequestHandler::process_client_req(rpc::ifelse&& req, std::function<void(rp
     if (!subreq)  // No subrequest action for this branch
         return cb(Response{http::OK, std::move(response)});
 
-    auto wrap_response = [response = std::move(response),
-                          cb = std::move(cb)](rpc::Response r) mutable {
+    auto wrap_response = [response = std::move(response), b64 = req.b64, cb = std::move(cb)](
+                                 rpc::Response r) mutable {
         response["result"] = json{{"code", r.status.first}};
         if (auto* j = std::get_if<json>(&r.body))
             response["result"]["body"] = std::move(*j);
+        else if (auto* b = std::get_if<std::span<const std::byte>>(&r.body))
+            response["result"]["body"] =
+                    b64 ? oxenc::to_base64(*b)
+                        : std::string{reinterpret_cast<const char*>(b->data()), b->size()};
         else
             response["result"]["body"] = std::string{view_body(r)};
         cb(Response{http::OK, std::move(response)});
@@ -1660,11 +1677,14 @@ Response RequestHandler::wrap_proxy_response(
         bool base64) const {
     int status = res.status.first;
     std::string body;
-    if (std::holds_alternative<std::string>(res.body))
-        body = json{{"status", status}, {"body", std::move(std::get<std::string>(res.body))}}
-                       .dump();
-    else if (std::holds_alternative<std::string_view>(res.body))
-        body = json{{"status", status}, {"body", std::get<std::string_view>(res.body)}}.dump();
+    if (auto* s = std::get_if<std::string>(&res.body))
+        body = json{{"status", status}, {"body", std::move(*s)}}.dump();
+    else if (auto* sv = std::get_if<std::string_view>(&res.body))
+        body = json{{"status", status}, {"body", *sv}}.dump();
+    else if (auto* bin = std::get_if<std::span<const std::byte>>(&res.body))
+        // We have a deficiency in the onion request protocol that returning binary data is simply
+        // impossible, so we get to b64 encode it hurray!
+        body = json{{"status", status}, {"body", oxenc::to_base64(*bin)}}.dump();
     else if (embed_json)
         body = json{{"status", status}, {"body", std::move(std::get<json>(res.body))}}.dump();
     else  // Yuck: double-encoded json
@@ -1745,7 +1765,10 @@ void RequestHandler::process_onion_req(RelayToNodeInfo&& info, OnionRequestMetad
             log::debug(
                     logcat,
                     "Onion request relay failed with: {}",
-                    std::holds_alternative<nlohmann::json>(res.body) ? "<json>" : view_body(res));
+                    std::holds_alternative<nlohmann::json>(res.body) ? "<json>"
+                    : std::holds_alternative<std::span<const std::byte>>(res.body)
+                            ? "<binary>"
+                            : view_body(res));
 
         cb(std::move(res));
     };

--- a/oxenss/rpc/request_handler.h
+++ b/oxenss/rpc/request_handler.h
@@ -64,24 +64,31 @@ inline constexpr size_t BATCH_REQUEST_MAX = 20;
 // Simple wrapper that works for most of our responses
 struct Response {
     http::response_code status = http::OK;
-    std::variant<std::string, std::string_view, nlohmann::json> body;
+    std::variant<std::string, std::string_view, std::span<const std::byte>, nlohmann::json> body;
     std::vector<std::pair<std::string, std::string>> headers;
     std::shared_ptr<void> keepalive;
 
     Response() = default;
     Response(
             http::response_code status,
-            std::variant<std::string, std::string_view, nlohmann::json> body = ""sv,
+            std::variant<std::string, std::string_view, std::span<const std::byte>, nlohmann::json>
+                    body = ""sv,
             std::vector<std::pair<std::string, std::string>> headers = {}) :
             status{status}, body{std::move(body)}, headers{std::move(headers)} {}
     Response(http::response_code status, std::string_view body, std::shared_ptr<void> keepalive) :
             status{status}, body{body}, keepalive{keepalive} {}
+    Response(
+            http::response_code status,
+            std::span<const std::byte> binary_response,
+            std::shared_ptr<void> keepalive) :
+            status{status}, body{binary_response}, keepalive{keepalive} {}
 };
 
 // Views the string or string_view body inside a Response.  Should only be called when the body
-// has already been verified to not contain a json object.
+// has already been verified to not contain a json object or binary blob.
 inline std::string_view view_body(const Response& r) {
-    assert(!std::holds_alternative<nlohmann::json>(r.body));
+    assert(!std::holds_alternative<nlohmann::json>(r.body) &&
+           !std::holds_alternative<std::span<const std::byte>>(r.body));
     if (auto* sv = std::get_if<std::string_view>(&r.body))
         return *sv;
     if (auto* s = std::get_if<std::string>(&r.body))
@@ -89,7 +96,7 @@ inline std::string_view view_body(const Response& r) {
     return "(internal error)"sv;
 }
 
-std::string to_string(const Response& res);
+std::string debug_string(const Response& res);
 
 namespace detail {
     // detail::to_hashable takes either an integral type, system_clock::time_point, or a string

--- a/oxenss/server/https.cpp
+++ b/oxenss/server/https.cpp
@@ -207,17 +207,25 @@ void queue_response_internal(
         r.writeStatus(fmt::format("{} {}", res.status.first, res.status.second));
         https.add_generic_headers(r);
 
-        const bool is_json = std::holds_alternative<json>(res.body);
+        const auto* json = std::get_if<nlohmann::json>(&res.body);
+        const auto* binary = std::get_if<std::span<const std::byte>>(&res.body);
         if (std::none_of(begin(res.headers), end(res.headers), [](const auto& h) {
                 return util::string_iequal(h.first, "content-type");
             }))
-            r.writeHeader("Content-Type", is_json ? "application/json" : "text/plain");
+            r.writeHeader(
+                    "Content-Type",
+                    json     ? "application/json"
+                    : binary ? "application/octet-stream"
+                             : "text/plain");
         for (const auto& [h, v] : res.headers)
             r.writeHeader(h, v);
 
         // NB: if the dump() here throws then it means we messed up and put some invalid data
         // (probably binary) into a json value.
-        r.end(is_json ? std::get<json>(res.body).dump() : view_body(res),
+        r.end(json ? json->dump()
+              : binary
+                      ? std::string_view{reinterpret_cast<const char*>(binary->data()), binary->size()}
+                      : view_body(res),
               force_close || https.closing());
     });
 }

--- a/oxenss/server/mqbase.cpp
+++ b/oxenss/server/mqbase.cpp
@@ -206,9 +206,10 @@ bool MQBase::handle_client_rpc(
                         else
                             dump = resp.dump();
                         body = dump;
-                    } else {
+                    } else if (auto* b = std::get_if<std::span<const std::byte>>(&res.body))
+                        body = {reinterpret_cast<const char*>(b->data()), b->size()};
+                    else
                         body = view_body(res);
-                    }
 
                     log::debug(
                             logcat,

--- a/oxenss/server/omq.cpp
+++ b/oxenss/server/omq.cpp
@@ -90,11 +90,16 @@ void OMQ::handle_onion_request(
         oxenmq::Message::DeferredSend send) {
     data.cb = [send](rpc::Response res) {
 #ifndef NDEBUG
-        log::trace(logcat, "on response: {}...", to_string(res).substr(0, 100));
+        log::trace(logcat, "on response: {}...", debug_string(res).substr(0, 100));
 #endif
 
         if (auto* js = std::get_if<nlohmann::json>(&res.body))
             send.reply(std::to_string(res.status.first), js->dump());
+        else if (auto* binary = std::get_if<std::span<const std::byte>>(&res.body))
+            send.reply(
+                    std::to_string(res.status.first),
+                    std::string_view{
+                            reinterpret_cast<const char*>(binary->data()), binary->size()});
         else
             send.reply(std::to_string(res.status.first), view_body(res));
     };

--- a/oxenss/server/quic.cpp
+++ b/oxenss/server/quic.cpp
@@ -143,12 +143,13 @@ void QUIC::handle_onion_request(std::shared_ptr<quic::message> msg) {
                             res.status.second,
                             util::friendly_duration(std::chrono::steady_clock::now() - started));
 
-                    const bool is_json = std::holds_alternative<nlohmann::json>(res.body);
                     std::string json_body;
                     std::string_view body;
-                    if (is_json) {
-                        json_body = std::get<nlohmann::json>(res.body).dump();
+                    if (auto json = std::get_if<nlohmann::json>(&res.body)) {
+                        json_body = json->dump();
                         body = json_body;
+                    } else if (auto* binary = std::get_if<std::span<const std::byte>>(&res.body)) {
+                        body = {reinterpret_cast<const char*>(binary->data()), binary->size()};
                     } else {
                         body = rpc::view_body(res);
                     }

--- a/oxenss/server/utils.h
+++ b/oxenss/server/utils.h
@@ -15,10 +15,6 @@
 #include <oxenc/bt.h>
 
 namespace oxenss {
-using ustring = std::basic_string<uint8_t>;
-using ustring_view = std::basic_string_view<uint8_t>;
-using bstring = std::basic_string<std::byte>;
-using bstring_view = std::basic_string_view<std::byte>;
 
 // place this here so we can use it in oxenss::*
 using namespace std::literals;


### PR DESCRIPTION
Fixes the `active_nodes_bin` request if invoked via an onion request: the binary data broke the onion request response, resulting in 500 errors.  This workaround turns it into b64 for json onion requests, and keeps it as binary for direct requests.